### PR TITLE
feat(catalog): resident paged-cache blocks 256 -> 512

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -22,8 +22,8 @@ in
       optiqFlags.cacheMemoryMb == 8192
       || throw "catalog: direct host override (8192) must beat the catalog default 16384, got ${toString optiqFlags.cacheMemoryMb}";
     assert
-      optiqFlags.pagedCacheBlockSize == 256 && optiqFlags.maxNumSeqs == 8
-      || throw "catalog: optiq resident profile (block 256 / maxNumSeqs 8) not compiled";
+      optiqFlags.pagedCacheBlockSize == 512 && optiqFlags.maxNumSeqs == 8
+      || throw "catalog: optiq resident profile (block 512 / maxNumSeqs 8) not compiled";
     assert
       builtins.match ".*--tool-call-parser hermes.*--reasoning-parser qwen3.*" optiqArgs != null
       || throw "catalog: optiq family parser args not compiled into modelExtraArgs: ${optiqArgs}";

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -31,12 +31,20 @@ let
     "--timeout"
     "3600"
   ];
-  # 256-token paged-cache blocks (default 64): long sessions shattered the KV
+  # Paged-cache block sizing (engine default 64): long sessions shatter the KV
   # into enough per-block Metal buffers to trip MLX's buffer-count limit
-  # ("Resource limit (499000) exceeded", not a byte OOM). Validated with a
-  # 113K-token request 2026-07-09 (nix-darwin#1609).
+  # ("Resource limit (499000) exceeded", not a byte OOM; nix-darwin#1609).
+  # Residents run 512: 256 (validated 113K single-stream) still tripped once
+  # under 2x ~50K-token concurrency + a 16K-token generation on 2026-07-09
+  # even with the MLX_BUFFER_CACHE_LIMIT cap — 512 halves the per-token block
+  # count again (worst case ~98K buffers at maxNumSeqs 8 x 65K window, deep
+  # under the ceiling). Swap tier stays 256: its 32K request cap keeps block
+  # counts low, and 512 is unvalidated there.
   block256 = {
     pagedCacheBlockSize = 256;
+  };
+  block512 = {
+    pagedCacheBlockSize = 512;
   };
   # Swap tier: on-demand, idle-unloaded, small caps.
   swapFlags = {
@@ -64,7 +72,7 @@ in
       # HIGH KV budget for 40-58K-token contexts; maxNumSeqs 8 = one
       # continuous batch. 65536 replaces the 32768 cap that fed the
       # truncation/retry death-loop.
-      resident.flags = block256 // {
+      resident.flags = block512 // {
         cacheMemoryMb = 16384;
         maxNumSeqs = 8;
         maxRequestTokens = 65536;
@@ -88,7 +96,7 @@ in
     ++ agentTimeout;
     classes = {
       # The global maxRequestTokens default is too low for agentic multi-turn.
-      resident.flags = block256 // {
+      resident.flags = block512 // {
         maxRequestTokens = 32768;
       };
       swap.flags = block256 // swapFlags;


### PR DESCRIPTION
## Why

Post-deploy acceptance for the buffer-count fixes (#1160): a 5-way long-context concurrency harness + live production traffic produced **one** residual `[metal::malloc] Resource limit (499000)` trip at active=54.4GB (2x ~50K-token prompts + a 16K-token generation). Enormous improvement over the pre-fix trips at 31GB under normal load — but the goal is virtually-impossible.

## What

Resident-class profiles move to `pagedCacheBlockSize = 512` (new `block512` group). Worst-case block count at maxNumSeqs 8 × 65K window ≈ 98K buffers — deep under the ceiling even with layer×K/V multipliers. Swap tier stays at 256 (32K request cap keeps counts low; 512 unvalidated there). mlx-catalog check updated to track 512.

## Verification

- `mlx-catalog` check evaluates green.
- Post-rebuild on jevans-ms: re-run the concurrency harness → target 0 resource-limit lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr