### PR TITLE
feat(mlx): automated cluster rank health gate + soak (vk1188)

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -151,6 +151,7 @@ in
 // (import ./checks/mlx-cluster-pd-env.nix { inherit pkgs hmConfigCluster src; })
 // (import ./checks/mlx-cluster-pd-callsites.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-mem-headroom.nix { inherit pkgs src; })
+// (import ./checks/mlx-cluster-health-gate.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-scripts.nix { inherit pkgs hmConfigCluster src; })
 // (import ./checks/mlx-cluster-selfheal.nix { inherit pkgs src; })
 // (import ./checks/fabric.nix {

--- a/lib/checks/mlx-cluster-health-gate.nix
+++ b/lib/checks/mlx-cluster-health-gate.nix
@@ -1,0 +1,29 @@
+# vk1188: the automated rank health gate + soak. Split into its own file
+# rather than added to ./mlx-cluster-scripts.nix, which was already close to
+# the 12KB error ceiling in .file-size.yml — same split-rather-than-exempt
+# pattern as ./mlx-cluster-mem-headroom.nix.
+{
+  pkgs,
+  src,
+}:
+{
+  # THE CHECK THAT FAILS IF THE AUTOMATED GATE STOPS ACTUALLY GATING. Sources
+  # the shipped guards + gate in the module's concatenation order. curl is
+  # stubbed as a shell function (this file's own process runs the sourced
+  # probes directly, same idiom test-mem-headroom.sh uses for curl in
+  # alert()); vm_stat is a generated executable, same fixture writer as
+  # test-mem-headroom.sh. Asserts all four probes (models 200, non-empty
+  # completion under a real timeout, N-at-once, wired-vs-ceiling), that a
+  # single failed probe fails the whole gate, that every run appends evidence
+  # rather than overwriting it, and that the soak recheck exercises probe (b)
+  # alone.
+  mlx-cluster-health-gate = pkgs.runCommand "check-mlx-cluster-health-gate" {
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gawk
+    ];
+    GUARDS = "${src}/modules/mlx/scripts/cluster-link-guards.sh";
+    GATE = "${src}/modules/mlx/scripts/cluster-health-gate.sh";
+  } "bash ${src}/tests/test-health-gate.sh && touch $out";
+}

--- a/modules/mlx/cluster-script-layers.nix
+++ b/modules/mlx/cluster-script-layers.nix
@@ -50,6 +50,9 @@
     # rank-status because it refuses to touch a machine whose rank is running.
     ./scripts/cluster-generation-heal.sh
     ./scripts/cluster-link-guards.sh
+    # Automated rank health gate + soak — reads mem_stat_mb from the guards
+    # file above, so it must come after it.
+    ./scripts/cluster-health-gate.sh
     ./scripts/cluster-link-watcher.sh
   ];
 

--- a/modules/mlx/cluster-watcher-env.nix
+++ b/modules/mlx/cluster-watcher-env.nix
@@ -173,6 +173,10 @@ in
   CLUSTER_MODEL = ncfg.model;
   CLUSTER_MAX_WARM_FAILURES = toString ncfg.maxWarmFailures;
   CLUSTER_WARM_RECHECK_SECS = toString ncfg.warmRecheckSecs;
+  # vk1188 automated health gate + soak.
+  CLUSTER_HEALTH_GATE_TIMEOUT_SECS = toString ncfg.healthGateTimeoutSecs;
+  CLUSTER_HEALTH_GATE_CONCURRENCY = toString ncfg.healthGateConcurrency;
+  CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS = toString ncfg.healthGateConcurrentTimeoutSecs;
   CLUSTER_RANK_SETTLE_SECS = toString ncfg.rankSettleSecs;
   # The link-down re-warm POSTs through llama-swap, so the watcher needs to be
   # able to bootstrap that agent when cluster-join has booted it out -- otherwise

--- a/modules/mlx/options-cluster-rank-health.nix
+++ b/modules/mlx/options-cluster-rank-health.nix
@@ -19,21 +19,21 @@
   options.programs.mlx.clusterMode = {
     warmRecheckSecs = lib.mkOption {
       type = lib.types.int;
-      default = 1800;
+      default = 600;
       description = ''
-        Re-arm the warm marker after this long, so the post-readiness wedge
-        detector can run more than once per link session; 0 disables re-checks.
+        Soak interval (vk1188): once the automated health gate has passed,
+        re-probe liveness this often for as long as the link session is up;
+        0 disables the soak. Appends PASS/FAIL evidence to the health-gate
+        state file every time it fires.
 
-        Readiness is a one-shot latch and the wedge detector is gated on the
-        warm marker being absent, so without this a single successful warm
-        disables the detector for the rest of the session — which is how a rank
-        that wedged AFTER its first warm (2026-07-25: an 8-token completion
-        returning 0 bytes after 900s, both ranks at ~100% CPU) sat for over an
-        hour with nothing escalating.
-
-        Deliberately long: mlx_lm.server blocks HTTP during a generation, so a
-        healthy rank mid-answer fails a probe, and only maxWarmFailures
-        CONSECUTIVE failures escalate.
+        Readiness is a one-shot latch, so without a periodic recheck a rank
+        that wedges AFTER its first pass (2026-07-25: an 8-token completion
+        returning 0 bytes after 900s, both ranks at ~100% CPU) sits for over
+        an hour with nothing escalating. A single soak failure halts
+        immediately — unlike maxWarmFailures below, which tolerates
+        CONSECUTIVE failures of the initial gate, a 10-minute-interval miss
+        is already a sustained symptom, not a transient one landing mid-
+        generation.
       '';
     };
 
@@ -59,6 +59,38 @@
         budget while reporting that it is protecting it.
 
         Must exceed the jaccl back-off; the default leaves ample margin.
+      '';
+    };
+
+    healthGateTimeoutSecs = lib.mkOption {
+      type = lib.types.int;
+      default = 120;
+      description = ''
+        vk1188: bound on one 1-token completion — the automated gate's probe
+        (b), and every soak recheck thereafter. Real timeout, not the untimed
+        curl the manual gate used to run: a rank that never answers must not be
+        able to hold the watcher open indefinitely.
+      '';
+    };
+
+    healthGateConcurrency = lib.mkOption {
+      type = lib.types.int;
+      default = 2;
+      description = ''
+        vk1188: N completions fired at once for the gate's probe (c), matching
+        the ethos of programs.mlx.proxy.concurrencyLimit — a rank can answer
+        one request fine and still fall over the moment real traffic overlaps
+        it, which one-at-a-time probing can never catch.
+      '';
+    };
+
+    healthGateConcurrentTimeoutSecs = lib.mkOption {
+      type = lib.types.int;
+      default = 180;
+      description = ''
+        vk1188: bound on EACH of the healthGateConcurrency completions above.
+        Longer than healthGateTimeoutSecs because N requests genuinely compete
+        for the same rank.
       '';
     };
   };

--- a/modules/mlx/options-cluster.nix
+++ b/modules/mlx/options-cluster.nix
@@ -121,13 +121,13 @@ in
       type = lib.types.int;
       default = 3;
       description = ''
-        Consecutive post-readiness warm-generation failures before the watcher
-        declares the rank wedged, halts it, and restores standalone serving.
-        Readiness is a one-shot latch — once the endpoint answers a /v1/models
-        probe it is never re-verified, because mlx_lm.server blocks HTTP during
-        long generations and a timed probe would kill healthy ranks. A rank
-        that serves the probe but hangs on real generation (INC-17070) would
-        otherwise retry forever with nothing escalating.
+        Consecutive post-readiness automated-health-gate failures before the
+        watcher declares the rank wedged, halts it, and restores standalone
+        serving. Readiness is a one-shot latch — once the endpoint answers a
+        /v1/models probe it is never re-verified, because mlx_lm.server blocks
+        HTTP during long generations and a timed probe would kill healthy
+        ranks. A rank that serves the probe but hangs on real generation
+        (INC-17070) would otherwise retry forever with nothing escalating.
       '';
     };
 

--- a/modules/mlx/scripts/cluster-health-gate.sh
+++ b/modules/mlx/scripts/cluster-health-gate.sh
@@ -1,0 +1,138 @@
+# shellcheck shell=bash
+# Cluster link watcher — automated rank health gate + soak.
+#
+# Concatenated ahead of cluster-link-watcher.sh, after cluster-link-guards.sh
+# (this file calls that one's mem_stat_mb). Function definitions only, same
+# rules as every other file in this layer.
+#
+# WHY THIS FILE EXISTS. Until now "the rank is ready to serve" meant one
+# untimed 1-token warm generation succeeded once. That is the manual gate a
+# human ran by hand every night before trusting a window: /v1/models answers,
+# a real completion returns real tokens inside a real timeout, the endpoint
+# holds up under the concurrency the proxy actually offers it
+# (proxy.concurrencyLimit), and the host is not already over its wired
+# ceiling. Encoding that here removes the human from the loop entirely instead
+# of leaving one more "looked fine, run it anyway" judgment call.
+#
+# Consumed environment (coordinator only — see cluster-watcher-env.nix):
+#   CLUSTER_HEALTH_GATE_TIMEOUT_SECS  bound on one 1-token completion (probes
+#                                  b and the soak recheck)
+#   CLUSTER_HEALTH_GATE_CONCURRENCY  N concurrent completions for probe c
+#   CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS  bound on EACH of those N
+#   CLUSTER_WIRED_LIMIT_MB          probe d's ceiling; 0/unset skips it (same
+#                                  "0 = off" convention as the memory rung)
+#
+# Sets HEALTH_GATE_DETAIL on any probe failure, for the caller's log line.
+
+# Probe (a): the endpoint answers at all.
+health_gate_probe_models() {
+  local url="$1"
+  if curl -fsS -m 10 -o /dev/null "$url/v1/models" 2>/dev/null; then
+    return 0
+  fi
+  HEALTH_GATE_DETAIL="/v1/models did not return 200 within 10s"
+  return 1
+}
+
+# Probe (b): one real completion, a real timeout, and a body that is actually
+# there — `curl -f` alone accepts a 200 with an empty body, which is exactly
+# what a wedged rank behind a proxy can return. Reused verbatim by the soak
+# recheck below, so "ready" and "still alive" are judged by one definition.
+health_gate_probe_completion() {
+  local url="$1" model="$2" timeout="$3" body_file rc=1
+  body_file="$(mktemp)"
+  # No RETURN trap: it is not function-scoped — it re-fires on every LATER
+  # function return in the same shell, including callers with no body_file of
+  # their own, which is exactly the "unbound variable" this file's own test
+  # caught. Manual cleanup on every exit path instead.
+  if curl -fsS -m "$timeout" -X POST "$url/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\"warmup\"}],\"max_tokens\":1,\"stream\":false,\"temperature\":0}" \
+    -o "$body_file" 2>/dev/null && [ -s "$body_file" ]; then
+    rc=0
+  else
+    HEALTH_GATE_DETAIL="1-token completion failed or returned an empty body within ${timeout}s"
+  fi
+  rm -f "$body_file"
+  return "$rc"
+}
+
+# Probe (c): N completions in flight together, matching the proxy's own
+# concurrency ceiling (proxy.concurrencyLimit) instead of a single request at
+# a time — a rank can answer one request fine and still fall over the moment
+# real traffic overlaps it.
+health_gate_probe_concurrent() {
+  local url="$1" model="$2" n="$3" timeout="$4" i pid f passed=0
+  local pids=() ok_files=()
+  for ((i = 0; i < n; i++)); do
+    ok_files[i]="$(mktemp)"
+    (health_gate_probe_completion "$url" "$model" "$timeout" && echo pass > "${ok_files[i]}") &
+    pids[i]=$!
+  done
+  for pid in "${pids[@]}"; do wait "$pid" || true; done
+  for f in "${ok_files[@]}"; do
+    [ "$(cat "$f" 2>/dev/null)" = "pass" ] && passed=$((passed + 1))
+    rm -f "$f"
+  done
+  [ "$passed" -eq "$n" ] && return 0
+  HEALTH_GATE_DETAIL="$passed/$n concurrent completions returned non-empty 200 within ${timeout}s"
+  return 1
+}
+
+# Probe (d): reuses mem_stat_mb (cluster-link-guards.sh, concatenated ahead of
+# this file) rather than a second vm_stat read — one measurement, one page-size
+# parse, one place that can be wrong.
+health_gate_probe_wired() {
+  local ceiling="$1" stat_out wired
+  case "$ceiling" in
+    '' | *[!0-9]*) return 0 ;;
+  esac
+  [ "$ceiling" -gt 0 ] || return 0
+  if ! stat_out="$(mem_stat_mb)"; then
+    HEALTH_GATE_DETAIL="could not read vm_stat; refusing to guess whether the host is over ceiling"
+    return 1
+  fi
+  # mem_stat_mb prints "<free> <wired>"; only the second field is needed here.
+  wired="${stat_out#* }"
+  [ "$wired" -le "$ceiling" ] && return 0
+  # shellcheck disable=SC2034 # read by cluster-link-watcher.sh's log/halt/alert
+  # lines, same sourced layer (cluster-script-layers.nix's `watcher`)
+  HEALTH_GATE_DETAIL="${wired}MB wired against a ${ceiling}MB ceiling"
+  return 1
+}
+
+# The full gate, run once when the rank first reaches readiness. $1 = state
+# file (evidence log, appended forever — never truncated, same as every other
+# marker in this dir). Returns 0 only if every probe passed; always writes one
+# evidence line either way, because "the gate ran and what it saw" is the
+# audit trail a wedged window used to have none of.
+health_gate_run() {
+  local state_file="$1" url="$2" model="$3" timeout="$4" n="$5" \
+    concurrent_timeout="$6" ceiling="$7"
+  local models_ok=FAIL completion_ok=FAIL concurrent_ok=FAIL wired_ok=FAIL verdict=FAIL
+  health_gate_probe_models "$url" && models_ok=PASS
+  health_gate_probe_completion "$url" "$model" "$timeout" && completion_ok=PASS
+  health_gate_probe_concurrent "$url" "$model" "$n" "$concurrent_timeout" && concurrent_ok=PASS
+  health_gate_probe_wired "$ceiling" && wired_ok=PASS
+  if [ "$models_ok" = PASS ] && [ "$completion_ok" = PASS ] &&
+    [ "$concurrent_ok" = PASS ] && [ "$wired_ok" = PASS ]; then
+    verdict=PASS
+  fi
+  printf '%s\tGATE\tmodels=%s completion=%s concurrent=%s wired=%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$models_ok" "$completion_ok" \
+    "$concurrent_ok" "$wired_ok" "$verdict" >> "$state_file"
+  [ "$verdict" = PASS ]
+}
+
+# Soak: probe (b) alone, on the recheck interval, appended to the same log.
+# Deliberately lighter than health_gate_run — re-running the full N-way
+# concurrent probe every ~10 minutes would compete with real traffic for the
+# same proxy concurrency slot it is trying to verify is healthy.
+health_gate_soak_probe() {
+  local state_file="$1" url="$2" model="$3" timeout="$4"
+  local ok=FAIL
+  health_gate_probe_completion "$url" "$model" "$timeout" && ok=PASS
+  printf '%s\tSOAK\tcompletion=%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ok" "$ok" >> "$state_file"
+  [ "$ok" = PASS ]
+}

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -47,12 +47,18 @@
 #   CLUSTER_SERVER_LABEL    coordinator only: normal-mode server (llama-swap)
 #                         launchd label, bootstrapped before the warmup fires
 #   CLUSTER_SERVER_PLIST    coordinator only: that agent's plist, for bootstrap
-#   CLUSTER_MAX_WARM_FAILURES  consecutive post-readiness warm-generation
+#   CLUSTER_MAX_WARM_FAILURES  consecutive post-readiness health-gate
 #                         failures before the rank is declared wedged
-#   CLUSTER_WARM_RECHECK_SECS  re-arm the warm marker after this many seconds,
-#                         so the wedge detector can run more than once per link
-#                         session instead of being disabled by the first
-#                         successful warm (default 1800; 0 disables re-checks)
+#   CLUSTER_WARM_RECHECK_SECS  soak interval: re-probe liveness this often once
+#                         the gate has passed (default 600 = 10 min; 0 disables
+#                         the soak)
+#   CLUSTER_HEALTH_GATE_TIMEOUT_SECS  bound on one 1-token completion (default
+#                         120), used by the gate's probe (b) and every soak
+#                         recheck
+#   CLUSTER_HEALTH_GATE_CONCURRENCY  N concurrent completions for the gate's
+#                         probe (c) (default 2)
+#   CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS  bound on EACH of those N
+#                         (default 180)
 #   CLUSTER_SHARD_MEMORY_MB  expected per-rank working set in MB; 0 disables
 #                         the memory-headroom rung with no vm_stat read at all
 #                         (see mem_headroom_ok in cluster-link-guards.sh)
@@ -72,6 +78,10 @@ started_file="$state_dir/rank-first-running"
 ready_file="$state_dir/rank-ready"
 warm_file="$state_dir/rank-warmed"
 warm_fails_file="$state_dir/rank-warm-failures"
+# PASS/FAIL + per-probe evidence for every health-gate run and soak recheck,
+# appended forever (never truncated) — the audit trail vk1188 exists to leave
+# behind. See cluster-health-gate.sh.
+health_gate_file="$state_dir/health-gate"
 down_strikes_file="$state_dir/link-down-strikes"
 # Consecutive ticks the PEER's rendezvous session has been absent while this
 # rank is running and settled. Drives the pair-wide standdown below.
@@ -376,68 +386,83 @@ if [ "$cur" = "up" ]; then
         fi
       fi
     fi
-    # Re-arm the warm marker periodically so the wedge detector below can run
-    # more than once per link session.
+    # SOAK: while the gate has already passed once this session (warm_file
+    # present), re-probe liveness on an interval — vk1188. This is the same
+    # re-arm timer the wedge detector used to drive (CLUSTER_WARM_RECHECK_SECS),
+    # repurposed: instead of dropping the marker to make the block below redo
+    # a single curl, it now calls the health gate's own soak probe directly and
+    # appends the result to health_gate_file, so the evidence trail covers the
+    # whole session, not just the first pass.
     #
-    # The detector counts consecutive warm-generation failures and tears the
-    # rank down at CLUSTER_MAX_WARM_FAILURES — but the whole block is gated on
-    # the warm marker being ABSENT, so a single successful warm disables it for
-    # the rest of the session. It therefore catches a rank that wedges BEFORE
-    # its first warm and can never catch one that wedges AFTER.
+    # Only probe (b) (one 1-token completion) — re-running the full N-way
+    # concurrent probe every ~10 minutes would compete with real traffic for
+    # the same proxy concurrency slot it exists to verify is healthy. A single
+    # failure halts immediately (no consecutive-failure tolerance, unlike the
+    # start guards above): this runs every ~10 minutes rather than every 30s
+    # tick, so one miss here is already a sustained symptom, not a transient
+    # one landing mid-generation.
     #
-    # After is the case actually observed (2026-07-25). The one-token warm
-    # succeeded, the marker was set, and the rank then wedged on a real
-    # request: an 8-token completion returned 0 bytes after 900s while both
-    # ranks spun at ~100% CPU — the coordinator in jaccl::MeshImpl::recv, the
-    # worker in mlx::core::Fence::wait. Readiness stayed latched, the marker
-    # stayed set, and nothing escalated for over an hour.
-    #
-    # Dropping the marker on an interval re-runs the existing probe and its
-    # existing failure counting, so no new teardown path is introduced. The
-    # interval is deliberately long: mlx_lm.server blocks HTTP during a
-    # generation, so a healthy rank mid-answer will fail a probe, and only
-    # CLUSTER_MAX_WARM_FAILURES *consecutive* failures escalate.
+    # Case actually observed (2026-07-25): the one-token warm succeeded, then
+    # the rank wedged on a real 8-token request — 0 bytes after 900s, both
+    # ranks spinning at ~100% CPU. Readiness stayed latched and nothing
+    # escalated for over an hour. This soak is what would have caught it.
     if [ "$CLUSTER_ROLE" = "coordinator" ] && [ -f "$warm_file" ] &&
-      [ "${CLUSTER_WARM_RECHECK_SECS:-1800}" -gt 0 ]; then
+      [ ! -f "$halt_file" ] && [ "${CLUSTER_WARM_RECHECK_SECS:-600}" -gt 0 ]; then
       warmed_at="$(/usr/bin/stat -f %m "$warm_file" 2> /dev/null || echo 0)"
       if [ "$warmed_at" -gt 0 ] &&
-        [ "$(($(date +%s) - warmed_at))" -ge "${CLUSTER_WARM_RECHECK_SECS:-1800}" ]; then
-        echo "cluster-link: re-checking liveness (warm marker older than ${CLUSTER_WARM_RECHECK_SECS:-1800}s)"
-        rm -f "$warm_file"
+        [ "$(($(date +%s) - warmed_at))" -ge "${CLUSTER_WARM_RECHECK_SECS:-600}" ]; then
+        echo "cluster-link: soak re-check (warm marker older than ${CLUSTER_WARM_RECHECK_SECS:-600}s)"
+        if health_gate_soak_probe "$health_gate_file" "$CLUSTER_RANK_URL" "${CLUSTER_MODEL:-}" \
+          "${CLUSTER_HEALTH_GATE_TIMEOUT_SECS:-120}"; then
+          touch "$warm_file"
+        else
+          echo "cluster-link: soak probe FAILED (${HEALTH_GATE_DETAIL:-no detail}); declaring the rank WEDGED and restoring standalone serving" >&2
+          halt_write "$halt_file" "$halt_latch_file" "health-gate-soak-fail" \
+            "${HEALTH_GATE_DETAIL:-soak completion probe failed}"
+          launchctl kill SIGTERM "gui/$uid/$CLUSTER_RANK_LABEL" 2> /dev/null || true
+          if [ -n "${CLUSTER_WIRED_LIMIT_MB:-}" ]; then
+            set_wired_limit "${CLUSTER_STANDALONE_WIRED_LIMIT_MB:-0}" || true
+          fi
+          restore_normal_serving || true
+          alert "$(hostname -s): cluster rank failed its periodic soak health-check (${HEALTH_GATE_DETAIL:-no detail}); torn down to standalone serving. Replug the link to retry." \
+            "mlx-cluster rank wedged (soak)"
+        fi
       fi
     fi
 
-    # First-token warm-up: once the rank is ready, fire one untimed 1-token
-    # generation so weights/compile caches are hot before the router flips
-    # traffic in. Coordinator-only (only rank 0 binds the endpoint) and
-    # idempotent per link session via the rank-warmed marker, which link-down
-    # clears. A blocked or failed warm just leaves the marker absent, so the
-    # next tick retries — no regression versus not warming.
+    # THE HEALTH GATE: once the rank is ready, run the full automated check —
+    # vk1188, replacing the human who used to run this by hand every night.
+    # (a) /v1/models answers, (b) one real completion inside a real timeout
+    # with a non-empty body, (c) N of those AT ONCE (matching the proxy's own
+    # concurrencyLimit), (d) the host is not already over its wired ceiling.
+    # Coordinator-only (only rank 0 binds the endpoint) and idempotent per link
+    # session via the rank-warmed marker, which link-down clears.
     if [ "$CLUSTER_ROLE" = "coordinator" ] && [ -f "$ready_file" ] && [ ! -f "$warm_file" ] &&
       [ ! -f "$halt_file" ] && [ -n "${CLUSTER_RANK_URL:-}" ]; then
-      echo "cluster-link: rank ready; firing 1-token warm generation"
-      if curl -fsS -m 300 -X POST "$CLUSTER_RANK_URL/v1/chat/completions" \
-        -H "Content-Type: application/json" \
-        -d "{\"model\":\"${CLUSTER_MODEL:-}\",\"messages\":[{\"role\":\"user\",\"content\":\"warmup\"}],\"max_tokens\":1,\"stream\":false,\"temperature\":0}" \
-        > /dev/null 2>&1; then
+      echo "cluster-link: rank ready; running the automated health gate"
+      if health_gate_run "$health_gate_file" "$CLUSTER_RANK_URL" "${CLUSTER_MODEL:-}" \
+        "${CLUSTER_HEALTH_GATE_TIMEOUT_SECS:-120}" "${CLUSTER_HEALTH_GATE_CONCURRENCY:-2}" \
+        "${CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS:-180}" "${CLUSTER_WIRED_LIMIT_MB:-0}"; then
+        echo "cluster-link: health gate PASSED"
         touch "$warm_file"
         rm -f "$warm_fails_file"
       else
         # Readiness is a one-shot latch: /v1/models answering once is never
         # re-verified, so a rank that serves the probe but wedges on real
         # generation (INC-17070) would sit here retrying forever with nothing
-        # escalating. Count consecutive post-readiness failures and tear down
-        # to standalone at the cap instead of running wedged.
+        # escalating. Count consecutive post-readiness gate failures and tear
+        # down to standalone at the cap instead of running wedged.
         warm_fails=0
         [ -f "$warm_fails_file" ] && warm_fails="$(cat "$warm_fails_file")"
         warm_fails=$((warm_fails + 1))
         printf '%s\n' "$warm_fails" > "$warm_fails_file"
+        echo "cluster-link: health gate FAILED (${HEALTH_GATE_DETAIL:-no detail}), attempt $warm_fails/${CLUSTER_MAX_WARM_FAILURES:-3}" >&2
         if [ "$warm_fails" -ge "${CLUSTER_MAX_WARM_FAILURES:-3}" ]; then
-          echo "cluster-link: warm generation failed $warm_fails times after readiness; declaring the rank WEDGED and restoring standalone serving" >&2
+          echo "cluster-link: health gate failed $warm_fails times after readiness; declaring the rank WEDGED and restoring standalone serving" >&2
           # Reuse the PD-guard halt latch: it already suppresses restarts until
           # the link cycles, so the wedged rank is not immediately restarted.
-          halt_write "$halt_file" "$halt_latch_file" "warm-wedged" \
-            "$warm_fails consecutive post-readiness warm-generation failures"
+          halt_write "$halt_file" "$halt_latch_file" "health-gate-fail" \
+            "$warm_fails consecutive post-readiness health-gate failures (${HEALTH_GATE_DETAIL:-no detail})"
           launchctl kill SIGTERM "gui/$uid/$CLUSTER_RANK_LABEL" 2> /dev/null || true
           if [ -n "${CLUSTER_WIRED_LIMIT_MB:-}" ]; then
             set_wired_limit "${CLUSTER_STANDALONE_WIRED_LIMIT_MB:-0}" || true
@@ -447,8 +472,8 @@ if [ "$cur" = "up" ]; then
           # ntfy-style body with Priority/Title HEADERS, which the Slack webhook
           # rejects as invalid_payload — and `-fsS ... || true` then swallowed
           # both the rejection and the message. Silent by construction.
-          alert "$(hostname -s): cluster rank answered /v1/models but failed $warm_fails consecutive warm generations; torn down to standalone serving. Replug the link to retry." \
-            "mlx-cluster rank wedged (warm generation)"
+          alert "$(hostname -s): cluster rank answered /v1/models but failed $warm_fails consecutive health-gate checks (${HEALTH_GATE_DETAIL:-no detail}); torn down to standalone serving. Replug the link to retry." \
+            "mlx-cluster rank wedged (health gate)"
         fi
       fi
     fi

--- a/tests/test-health-gate.sh
+++ b/tests/test-health-gate.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Exercises the automated rank health gate + soak (vk1188,
+# modules/mlx/scripts/cluster-health-gate.sh) — the check that replaces the
+# human who used to run this by hand every night before trusting a window.
+#
+# WHY THIS EXISTS. The old gate was one untimed 1-token warm generation.
+# vk1188 replaces it with four probes — /v1/models answers, one real
+# completion inside a real timeout with a non-empty body, N of those AT ONCE
+# (matching the proxy's own concurrency ceiling), and the host is not already
+# over its wired ceiling — plus a periodic soak recheck once the gate has
+# passed. This is the test that fails if any probe stops actually gating, or
+# if a failure stops reaching the halt path.
+#
+# WHAT IS REAL AND WHAT IS NOT:
+#   REAL  — every health_gate_* function is sourced from the shipped script
+#           and called exactly as the watcher calls it.
+#   STUB  — curl, as a shell FUNCTION (the shipped code calls it by plain
+#           name from within this same sourced process, so a function
+#           shadows it — same idiom test-mem-headroom.sh uses for curl in
+#           alert()). vm_stat as a generated executable on CLUSTER_VMSTAT_BIN,
+#           same reason and same fixture writer as test-mem-headroom.sh.
+#
+# Usage:
+#   GUARDS=… GATE=… bash test-health-gate.sh
+set -o errexit -o nounset -o pipefail
+
+state_dir="$(mktemp -d)"
+trap 'rm -rf "$state_dir"' EXIT
+
+# shellcheck disable=SC1090
+source "${GUARDS:?set GUARDS to cluster-link-guards.sh}"
+# shellcheck disable=SC1090
+source "${GATE:?set GATE to cluster-health-gate.sh}"
+
+# --- vm_stat stub, generated executable (see test-mem-headroom.sh) ---------
+bin="$state_dir/bin"
+mkdir -p "$bin"
+vmstat_fixture="$state_dir/vmstat-output"
+vmstat_rc="$state_dir/vmstat-rc"
+cat > "$bin/vm_stat" << VMSTAT
+#!$BASH
+forced="\$(cat '$vmstat_rc' 2>/dev/null || true)"
+if [ -n "\$forced" ]; then exit "\$forced"; fi
+cat '$vmstat_fixture'
+VMSTAT
+chmod +x "$bin/vm_stat"
+export CLUSTER_VMSTAT_BIN="$bin/vm_stat"
+
+write_vmstat() {
+  local wired="$1"
+  cat > "$vmstat_fixture" << EOF
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                              256000.
+Pages active:                            1000.
+Pages inactive:                          1000.
+Pages speculative:                       1000.
+Pages throttled:                         0.
+Pages wired down:                        ${wired}.
+Pages purgeable:                         0.
+EOF
+}
+write_vmstat 0
+
+# --- curl stub, a shell FUNCTION (see header) -------------------------------
+# Controlled per request kind via three files: models_rc gates the /v1/models
+# probe, completion_rc + completion_body gate every /v1/chat/completions call
+# (probe b, every concurrent leg of probe c, and every soak recheck alike —
+# they are all the same underlying probe function).
+models_rc="$state_dir/models-rc"
+completion_rc="$state_dir/completion-rc"
+completion_body="$state_dir/completion-body"
+echo 0 > "$models_rc"
+echo 0 > "$completion_rc"
+echo '{"choices":[{"text":"ok"}]}' > "$completion_body"
+curl() {
+  local out="" is_completion=0 a
+  for a in "$@"; do
+    case "$a" in
+      */v1/chat/completions) is_completion=1 ;;
+    esac
+  done
+  # -o FILE is always the argument immediately following it in every call
+  # this file makes.
+  local prev=""
+  for a in "$@"; do
+    [ "$prev" = "-o" ] && out="$a"
+    prev="$a"
+  done
+  if [ "$is_completion" = 1 ]; then
+    [ -n "$out" ] && cat "$completion_body" > "$out"
+    return "$(cat "$completion_rc")"
+  fi
+  return "$(cat "$models_rc")"
+}
+
+fail=0
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  ok   $label -> $got"
+  else
+    echo "  FAIL $label -> got '$got', want '$want'"
+    fail=1
+  fi
+}
+reset() {
+  echo 0 > "$models_rc"
+  echo 0 > "$completion_rc"
+  echo '{"choices":[{"text":"ok"}]}' > "$completion_body"
+  write_vmstat 0
+}
+
+url="http://127.0.0.1:9"
+model="test-model"
+
+echo "--- probe (a): /v1/models ---"
+reset
+health_gate_probe_models "$url" && got=pass || got=fail
+check "models healthy" pass "$got"
+echo 1 > "$models_rc"
+health_gate_probe_models "$url" && got=pass || got=fail
+check "models non-200" fail "$got"
+
+echo "--- probe (b): 1-token completion ---"
+reset
+health_gate_probe_completion "$url" "$model" 5 && got=pass || got=fail
+check "completion healthy" pass "$got"
+echo 1 > "$completion_rc"
+health_gate_probe_completion "$url" "$model" 5 && got=pass || got=fail
+check "completion curl failure" fail "$got"
+reset
+: > "$completion_body"
+health_gate_probe_completion "$url" "$model" 5 && got=pass || got=fail
+check "completion empty body (200 but nothing to serve)" fail "$got"
+
+echo "--- probe (c): N concurrent completions ---"
+reset
+health_gate_probe_concurrent "$url" "$model" 2 5 && got=pass || got=fail
+check "concurrent all healthy" pass "$got"
+echo 1 > "$completion_rc"
+health_gate_probe_concurrent "$url" "$model" 2 5 && got=pass || got=fail
+check "concurrent all failing" fail "$got"
+
+echo "--- probe (d): wired vs ceiling ---"
+reset
+write_vmstat 1000
+health_gate_probe_wired 90000 && got=pass || got=fail
+check "wired under ceiling" pass "$got"
+write_vmstat 25600000
+health_gate_probe_wired 90000 && got=pass || got=fail
+check "wired over ceiling refuses" fail "$got"
+health_gate_probe_wired 0 && got=pass || got=fail
+check "ceiling 0 disables the rung with no refusal" pass "$got"
+
+echo "--- health_gate_run: overall verdict + evidence ---"
+reset
+gate_file="$state_dir/health-gate"
+health_gate_run "$gate_file" "$url" "$model" 5 2 5 90000 && got=pass || got=fail
+check "full gate all healthy" pass "$got"
+check "evidence line written" 1 "$(wc -l < "$gate_file" | tr -d ' ')"
+check "evidence verdict PASS" 1 "$(grep -c $'\tPASS$' "$gate_file" | tr -d ' ')"
+
+echo 1 > "$completion_rc"
+health_gate_run "$gate_file" "$url" "$model" 5 2 5 90000 && got=pass || got=fail
+check "full gate one probe failing" fail "$got"
+check "second evidence line appended, not overwritten" 2 "$(wc -l < "$gate_file" | tr -d ' ')"
+
+echo "--- health_gate_soak_probe: probe (b) only, appended ---"
+reset
+soak_file="$state_dir/soak"
+health_gate_soak_probe "$soak_file" "$url" "$model" 5 && got=pass || got=fail
+check "soak healthy" pass "$got"
+echo 1 > "$completion_rc"
+health_gate_soak_probe "$soak_file" "$url" "$model" 5 && got=pass || got=fail
+check "soak failing" fail "$got"
+check "soak evidence has one line per call" 2 "$(wc -l < "$soak_file" | tr -d ' ')"
+
+exit "$fail"

--- a/tests/test-peer-rendezvous-session.sh
+++ b/tests/test-peer-rendezvous-session.sh
@@ -140,7 +140,7 @@ check "the halt precedes its SIGTERM" yes \
 # Deliberately NOT pinned: the readiness probe also sends SIGTERM but does not
 # halt, because that path is a restart-on-hung-init that is SUPPOSED to retry.
 # A blanket "every SIGTERM halts" rule would be wrong and would break it.
-for cause in peer-absent warm-wedged rank-start-failures; do
+for cause in peer-absent health-gate-fail health-gate-soak-fail rank-start-failures; do
   check "the $cause teardown halts" 1 \
     "$(code | grep -c "halt_write .* \"$cause\"" || true)"
 done


### PR DESCRIPTION
## What

Extends the watcher's post-readiness one-shot warm generation
(`cluster-link-watcher.sh`) into a full automated health gate, and adds a
periodic soak recheck for the rest of the link session — `vk1188`.

- New `modules/mlx/scripts/cluster-health-gate.sh` (watcher-layer only,
  concatenated after `cluster-link-guards.sh`): four probes —
  `health_gate_probe_models` (`/v1/models` 200), `health_gate_probe_completion`
  (one real completion, real timeout, non-empty body required),
  `health_gate_probe_concurrent` (N of those at once), `health_gate_probe_wired`
  (reuses `mem_stat_mb` from the guards file; refuses over ceiling) —
  `health_gate_run` (all four, PASS/FAIL + per-probe evidence appended to a
  state file) and `health_gate_soak_probe` (probe (b) alone, same evidence
  file).
- `cluster-link-watcher.sh`: the post-readiness block now calls
  `health_gate_run` in place of the single curl, with the same
  `CLUSTER_MAX_WARM_FAILURES`-gated retry-then-halt escalation it already had
  (cause `health-gate-fail`). The former warm-recheck re-arm block now calls
  `health_gate_soak_probe` directly instead of clearing the marker to redo a
  full warm; a single soak failure halts immediately (cause
  `health-gate-soak-fail`). Both reuse the existing halt path (`halt_write` +
  SIGTERM + `set_wired_limit` + `restore_normal_serving` + `alert`) — no new
  teardown mechanism.
- `cluster-script-layers.nix`: registers the new file in the `watcher` layer.
- New options in `options-cluster-rank-health.nix`: `healthGateTimeoutSecs`
  (120), `healthGateConcurrency` (2), `healthGateConcurrentTimeoutSecs` (180).
  `warmRecheckSecs` default changed 1800 -> 600 (10 min) and repurposed to
  drive the soak cadence; `maxWarmFailures` description updated. Wired into
  `cluster-watcher-env.nix` as `CLUSTER_HEALTH_GATE_TIMEOUT_SECS` /
  `CLUSTER_HEALTH_GATE_CONCURRENCY` / `CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS`.
  The wired ceiling reuses the existing `CLUSTER_WIRED_LIMIT_MB`.
- New `tests/test-health-gate.sh` (stub-friendly, follows
  `test-rank-start-guards.sh`'s pattern): sources the real
  `cluster-health-gate.sh` + `cluster-link-guards.sh`, stubs `curl` as a shell
  function and `vm_stat` as a generated executable, and exercises every probe
  pass/fail case plus the evidence-file append behavior of `health_gate_run`
  and `health_gate_soak_probe`. Registered as a new check,
  `lib/checks/mlx-cluster-health-gate.nix` (split out of
  `mlx-cluster-scripts.nix`, which was already close to the 12KB file-size
  ceiling).
- `tests/test-peer-rendezvous-session.sh`: updated its pinned halt-cause list
  (`peer-absent` / `warm-wedged` / `rank-start-failures`) to match the renamed
  causes (`health-gate-fail`, `health-gate-soak-fail` replacing
  `warm-wedged`).

## Test plan

- [x] `shellcheck --severity=warning --exclude=SC1091` on every touched/new
      `.sh` file individually (matches CI's standalone lint) — clean.
- [x] Whole-repo `find . -name '*.sh' | xargs shellcheck` sweep — clean.
- [x] `tests/bash32-scan.py` on every touched/new `.sh` file — clean (no bash4
      syntax; these agents run under Apple's bash 3.2).
- [x] Manually concatenated the full `watcher` layer in the module's exact
      order and ran `shellcheck` at CI's build-time default severity (stricter
      than the warning sweep, catches SC2329 unused-function) — clean, so the
      new file's functions are all reachable from the real call graph.
- [x] `nix fmt` — no changes.
- [x] `nix eval --impure` forcing `checks.x86_64-linux.mlx-cluster-health-gate.drvPath`
      and `.mlx-cluster-scripts-build.drvPath` — both evaluate cleanly (no
      local x86_64-linux builder available on this Mac to actually build).
- [x] `statix check` / `deadnix` on every touched `.nix` file — clean.
- [x] Ran `tests/test-health-gate.sh` directly — all cases pass.
- [x] Re-ran the existing watcher-adjacent tests this change touches —
      `test-rank-start-guards.sh`, `test-mem-headroom.sh`,
      `test-peer-rendezvous-session.sh`, `test-pd-counter-settle.sh` — all
      still pass (caught and fixed a real regression in
      `test-peer-rendezvous-session.sh`'s pinned cause list before this PR).
- [ ] CI (Nix Validate / File Size / Merge Gate) — pending, not yet merged.