### PR TITLE
fix(mlx): update stale warm-recheck assertion for vk1188's 600s soak default

### DIFF
--- a/lib/checks/mlx-cluster.nix
+++ b/lib/checks/mlx-cluster.nix
@@ -165,8 +165,8 @@ in
     # The peer-liveness supervisor's own env contract lives in
     # ./mlx-cluster-peer-env.nix — same fixture, split for the per-file size cap.
     assert
-      watcherEnv.CLUSTER_WARM_RECHECK_SECS == "1800"
-      || throw "cluster: coordinator watcher must carry the warm-marker re-arm interval, or the wedge detector runs at most once per link session";
+      watcherEnv.CLUSTER_WARM_RECHECK_SECS == "600"
+      || throw "cluster: coordinator watcher must carry the health-gate soak recheck interval (vk1188), or liveness is verified at most once per link session";
     assert
       watcherEnv.CLUSTER_STATIC_SELF_IP == "192.168.208.1"
       && watcherEnv.CLUSTER_RENDEZVOUS_PORT == "11441"


### PR DESCRIPTION
## What

`lib/checks/mlx-cluster.nix` asserted `watcherEnv.CLUSTER_WARM_RECHECK_SECS ==
"1800"`, the pre-vk1188 warm-marker re-arm default. #1576 changed
`warmRecheckSecs`'s default to 600 (repurposed to drive the health-gate soak
recheck cadence) but this assertion's check set was not part of that PR's
verified checks, so it still expected the old value and left `develop` red.
Updated the asserted value to `"600"` and the failure message to describe the
soak recheck rather than the old wedge-detector re-arm.

## Test plan

- [x] `nix eval --impure` forcing `checks.x86_64-linux.mlx-cluster.drvPath` —
      previously threw at the assertion, now evaluates cleanly.
- [x] Confirmed no other file references the stale `"1800"` value.