### PR TITLE
fix(mcp): bound the MCP Python SDK below 2.x for uvx-launched servers

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -52,6 +52,20 @@
   # renovate: datasource=npm depName=@democratize-technology/vikunja-mcp
   vikunjaMcp = "0.2.0";
 
+  # Upper bound for the MCP Python SDK, applied to every uvx-launched server
+  # below. Those servers declare `mcp>=<x>` with no ceiling, so a fresh resolve
+  # installs the 2.x SDK — which renamed the public surface (`server.fastmcp` →
+  # `server.mcpserver`, `McpError` → `MCPError`) and dropped `Server.list_tools`.
+  # The result is a server that dies at import and reports only
+  # `CONNECTION_CLOSED`, which reads as an outage rather than a dependency break.
+  # This supplies the bound upstream omitted; drop it per-server once that
+  # server ships 2.x support.
+  #
+  # Deliberately carries no `renovate:` annotation: it is a compatibility
+  # constraint, not a version pin, and there is nothing here for Renovate to
+  # bump — it is removed by hand when upstream migrates.
+  mcpSdkBound = "mcp<2";
+
   # MCP servers (pypi)
   # renovate: datasource=pypi depName=mcp-server-time
   mcpServerTime = "2026.6.4";

--- a/modules/mcp/catalog-services.nix
+++ b/modules/mcp/catalog-services.nix
@@ -109,6 +109,8 @@
       "uvx"
       "--from"
       "git+https://github.com/basher83/zammad-mcp.git@v${versions.zammadMcp}"
+      "--with"
+      versions.mcpSdkBound
       "mcp-zammad"
     ];
     env_vars = dopplerEnv;

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -52,6 +52,8 @@ in
     args = [
       "--from"
       "mcp-server-time==${versions.mcpServerTime}"
+      "--with"
+      versions.mcpSdkBound
       "mcp-server-time"
     ];
   };
@@ -108,6 +110,8 @@ in
       "huggingface-mcp-server==${versions.hfMcpServer}"
       "--with"
       "huggingface-hub==${versions.huggingfaceHub}"
+      "--with"
+      versions.mcpSdkBound
       "huggingface-mcp-server"
     ];
   };


### PR DESCRIPTION
## Summary

Three uvx-launched MCP servers — `time`, `huggingface`, and `zammad` — declare
the MCP Python SDK with a lower bound and no ceiling. A fresh resolve installs
the 2.x SDK, which renamed the public surface, so each server exits at import.
The client surfaces this only as a closed connection.

This adds the upper bound upstream omitted, as one shared constraint in
`lib/versions.nix` applied to all three call sites.

## What changed

- `lib/versions.nix` — new `mcpSdkBound` constraint, with a note on why it
  carries no Renovate annotation (it is a compatibility constraint, not a pin).
- `modules/mcp/catalog.nix` — apply it to `time` and `huggingface`.
- `modules/mcp/catalog-services.nix` — apply it to `zammad`.

## Verification

Each of the three commands was run by hand before and after. Before: all three
exit at import. After: `time` and `huggingface` start clean, and `zammad`
completes its client handshake.

Evaluating the catalog confirms the generated argument vectors match the
commands verified by hand:

```
time:       --from mcp-server-time==<pin> --with mcp<2 mcp-server-time
huggingface: --from huggingface-mcp-server==<pin> --with huggingface-hub==<pin> --with mcp<2 huggingface-mcp-server
zammad:     ... --from git+<repo>@v<pin> --with mcp<2 mcp-zammad
```

`nixfmt --check` is clean on all three files.

## Notes

The constraint is removed per-server once that server ships 2.x support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKmEBH9LdQRpsBTzQ1nZ4u