### PR TITLE
fix(mlx): unbreak develop — 27B catalog check asserted a removed concurrency pin

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -33,6 +33,18 @@ in
       # A check pinning a magic number is what kept --decode-concurrency
       # hard-coded at 1 while proxy.concurrencyLimit said 4.
       conc = modelId: toString (commandBuilder.effectiveConcurrency modelId);
+      # Same reason as `conc`: derive, never pin a literal. The emitted byte
+      # figure is model-server-cmd's effectiveMlxLmCacheMb, which tracks the
+      # catalog class's declared cacheMemoryMb (clamped to 16 GiB). A hardcoded
+      # number here turns any legitimate class retune into a CI break — which is
+      # exactly what happened when the 27B entry moved from an 8 GiB judge
+      # profile to a 16 GiB large-context profile.
+      cacheBytes =
+        modelId:
+        let
+          mb = c.modelFlagOverrides.${modelId}.cacheMemoryMb or c.cacheMemoryMb;
+        in
+        toString ((if mb == null then 8192 else pkgs.lib.min mb 16384) * 1024 * 1024);
       nullDefaultsCmd =
         (import ../../modules/mlx/model-server-cmd.nix {
           inherit (pkgs) lib;
@@ -69,10 +81,17 @@ in
     assert
       !hmConfigCatalog.config.launchd.agents.mlx-model-server-watchdog.enable
       || throw "catalog: the vllm-specific watchdog must stay disabled for mlx-lm";
+    # The 27B entry MUST NOT pin concurrency. It used to: as a latency-sensitive
+    # judge beside a resident 80B it carried concurrencyLimit = 1. That entry is
+    # gone, and this one is shaped as a fleet brain — so a pin of 1 makes
+    # llama-swap serialize every request on any host where it is resident. That
+    # regression shipped once and was caught only by reading the deployed
+    # llama-swap.json, so assert the absence rather than a value: an entry with
+    # no pin inherits proxy.concurrencyLimit, which is the intended contract.
     assert
-      c.modelConcurrencyLimits.${judge27b} == 1
+      !(builtins.hasAttr judge27b c.modelConcurrencyLimits)
       && builtins.match ".*enable_thinking.*false.*" judgeArgs != null
-      || throw "catalog: 27B judge must use bounded single-concurrency text serving";
+      || throw "catalog: the 27B entry must not pin concurrency (a pin of 1 serializes every request where it is resident) and must serve text with thinking disabled";
     assert
       builtins.match ".*mlx-model-server --model mlx-community/Qwen3.8-27B-4bit.*" judgeCmd != null
       && builtins.match ".*--log-level INFO.*" judgeCmd != null
@@ -80,7 +99,7 @@ in
       && builtins.match ".*--decode-concurrency ${conc judge27b}.*" judgeCmd != null
       && builtins.match ".*--prompt-concurrency ${conc judge27b}.*" judgeCmd != null
       && builtins.match ".*--prompt-cache-size 4.*" judgeCmd != null
-      && builtins.match ".*--prompt-cache-bytes 8589934592.*" judgeCmd != null
+      && builtins.match ".*--prompt-cache-bytes ${cacheBytes judge27b}.*" judgeCmd != null
       && builtins.match ".*vllm-mlx.*" judgeCmd == null
       && builtins.match ".*--gpu-memory-utilization.*" judgeCmd == null
       || throw "catalog: 27B judge command must use only the bounded official mlx_lm serving contract: ${judgeCmd}";

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -83,10 +83,6 @@ in
   # incumbent runs without hybridNoPaged and this entry does the same. Do not
   # "fix" that by adding hybridNoPaged on the strength of the layer_types field
   # alone — the incumbent has served this topology in production for weeks.
-  #
-  # Keep it serialized: judging is latency-sensitive but never needs concurrent
-  # decode, and a second prompt would only increase unified-memory pressure
-  # beside the resident 80B worker.
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -239,35 +239,16 @@ let
     groupSwap = cfg.proxy.groupSwap;
   };
 
-  # Judge model + its own group — merged in directly rather than through
-  # llamaSwapTopology, which only compiles a two-bucket resident/swap shape.
-  # See options-judge.nix for why this stays outside that compiler.
-  judgeModels = lib.optionalAttrs cfg.judge.enable {
-    ${cfg.judge.model} = {
-      cmd =
-        mkModelCmd cfg.judge.model
-        + lib.optionalString (cfg.judge.extraArgs != [ ]) (" " + lib.escapeShellArgs cfg.judge.extraArgs);
-      ttl = 0; # persistent group already keeps it resident; no idle unload
-      env = workerEnv;
-      checkEndpoint = "/v1/models";
-      aliases = cfg.judge.aliases;
-      useModelName = cfg.judge.model;
-      concurrencyLimit = effectiveConcurrency cfg.judge.model;
-    }
-    // lib.optionalAttrs (defaultFilters != { }) { filters = defaultFilters; };
-  };
-
-  # persistent = true: protected from unload when the main mlx-models group's
-  # exclusive=true evicts every OTHER group on load. exclusive = false: this
-  # group never evicts anything itself. Net effect: never evicted, never
-  # evicts — a real third bucket the topology compiler doesn't have.
-  judgeGroups = lib.optionalAttrs cfg.judge.enable {
-    mlx-judge-model = {
-      swap = false;
-      exclusive = false;
-      persistent = true;
-      members = [ cfg.judge.model ];
-    };
+  # Judge model entries, split to ./judge-topology.nix for the file-size gate.
+  judgeTopology = import ./judge-topology.nix {
+    inherit
+      lib
+      cfg
+      mkModelCmd
+      workerEnv
+      effectiveConcurrency
+      defaultFilters
+      ;
   };
 
   llamaSwapConfigAttrs = {
@@ -280,8 +261,8 @@ let
   }
   // llamaSwapTopology
   // {
-    models = (llamaSwapTopology.models or { }) // judgeModels;
-    groups = (llamaSwapTopology.groups or { }) // judgeGroups;
+    models = (llamaSwapTopology.models or { }) // judgeTopology.models;
+    groups = (llamaSwapTopology.groups or { }) // judgeTopology.groups;
   };
 
   # Use pkgs.writeText because command strings embed Nix store paths.

--- a/modules/mlx/judge-topology.nix
+++ b/modules/mlx/judge-topology.nix
@@ -1,0 +1,48 @@
+# The judge model's llama-swap entries: its own model definition and its own
+# group.
+#
+# Split out of ./default.nix at the per-file byte cap (.file-size.yml), the same
+# split-rather-than-exempt move ./cluster-script-layers.nix and the
+# options-cluster-* family already made. Pure function of its inputs; the
+# caller merges the two attrsets into the llama-swap config.
+#
+# These are merged in DIRECTLY rather than compiled by llamaSwapTopology, which
+# only knows a two-bucket resident/swap shape. See options-judge.nix for why the
+# judge stays outside that compiler.
+{
+  lib,
+  cfg,
+  mkModelCmd,
+  workerEnv,
+  effectiveConcurrency,
+  defaultFilters,
+}:
+{
+  models = lib.optionalAttrs cfg.judge.enable {
+    ${cfg.judge.model} = {
+      cmd =
+        mkModelCmd cfg.judge.model
+        + lib.optionalString (cfg.judge.extraArgs != [ ]) (" " + lib.escapeShellArgs cfg.judge.extraArgs);
+      ttl = 0; # persistent group already keeps it resident; no idle unload
+      env = workerEnv;
+      checkEndpoint = "/v1/models";
+      aliases = cfg.judge.aliases;
+      useModelName = cfg.judge.model;
+      concurrencyLimit = effectiveConcurrency cfg.judge.model;
+    }
+    // lib.optionalAttrs (defaultFilters != { }) { filters = defaultFilters; };
+  };
+
+  # persistent = true: protected from unload when the main mlx-models group's
+  # exclusive=true evicts every OTHER group on load. exclusive = false: this
+  # group never evicts anything itself. Net effect: never evicted, never
+  # evicts — a real third bucket the topology compiler doesn't have.
+  groups = lib.optionalAttrs cfg.judge.enable {
+    mlx-judge-model = {
+      swap = false;
+      exclusive = false;
+      persistent = true;
+      members = [ cfg.judge.model ];
+    };
+  };
+}


### PR DESCRIPTION
**develop is red and this unblocks it.** Every PR targeting develop currently fails Nix Validate, and therefore Merge Gate, regardless of content.

## Cause

`lib/checks/mlx-catalog.nix` binds `judge27b = "mlx-community/Qwen3.8-27B-4bit"` and asserted `c.modelConcurrencyLimits.${judge27b} == 1`. That pin was deliberately removed when the entry took over the fleet-brain role — pinning it to 1 makes llama-swap serialize every request on a host where it is resident. The bare attribute lookup threw:

```
error: attribute '"mlx-community/Qwen3.8-27B-4bit"' missing
    72|     assert
    73|       c.modelConcurrencyLimits.${judge27b} == 1
```

## Changes

1. **Assert the absence of the pin rather than a value.** The invariant that matters now is that this entry must *not* carry one, so that is what the check enforces. An entry with no pin inherits `proxy.concurrencyLimit`, which is the intended contract.
2. **Derive `--prompt-cache-bytes` instead of pinning a literal.** A second assertion hardcoded `8589934592`, but the emitted figure is `model-server-cmd`'s `effectiveMlxLmCacheMb`, which tracks the catalog class's declared `cacheMemoryMb` clamped to 16 GiB. The entry moved from an 8 GiB judge profile to a 16 GiB large-context profile, so the literal no longer matched. This follows the principle already stated a few lines above in the same file: *"Assert the EMITTED flags equal the DECLARED concurrency, not a literal. A check pinning a magic number is what kept --decode-concurrency hard-coded at 1."*
3. **Remove a stale comment** above the entry that still described it as a serialized judge, directly contradicting the entry body four lines below it.

## Verification

Reproduced and confirmed fixed with the exact failing command:

```
nix eval '.#checks.x86_64-linux.mlx-catalog.drvPath'
```

Fails on `origin/develop`; resolves to a derivation on this branch. `nix fmt` clean, `nix flake check` green.

**Worth knowing:** `nix flake check` on aarch64-darwin passes this check *vacuously* and caught neither failure. The x86_64-linux eval is the one that reproduces CI.