### PR TITLE
fix(mlx): serve the Qwen3.8-27B with thinking on at reasoning_effort=medium

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -88,16 +88,22 @@ in
     # regression shipped once and was caught only by reading the deployed
     # llama-swap.json, so assert the absence rather than a value: an entry with
     # no pin inherits proxy.concurrencyLimit, which is the intended contract.
-    # Thinking must also stay BOUNDED. The chat template defaults
-    # reasoning_effort to 'xhigh' when no kwarg is passed, and at xhigh this
-    # model exhausted max_tokens without emitting a single answer character on
-    # 3 of 3 measured runs. An entry carrying no chat-template kwarg therefore
-    # reads as "unconfigured" but serves as "never answers", so assert the
-    # bound is present rather than trusting its absence.
+    # The reasoning effort must be PINNED EXPLICITLY, to one of the two values
+    # measured to finish. The chat template defaults reasoning_effort to
+    # 'xhigh' when no kwarg is passed, and at xhigh this model exhausted
+    # max_tokens without emitting a single answer character on 3 of 3 measured
+    # runs. So an entry carrying no chat-template kwarg reads as
+    # "unconfigured" but serves as "never answers" — absence is the failure,
+    # which is why this asserts presence rather than trusting a default.
+    #
+    # low and medium are both accepted: both were measured to finish
+    # (finish_reason "stop"), and which one serves is a tuning decision that
+    # should not require editing a regression check. xhigh is excluded by
+    # construction, since it matches neither alternative.
     assert
       !(builtins.hasAttr judge27b c.modelConcurrencyLimits)
-      && builtins.match ".*reasoning_effort.*low.*" judgeArgs != null
-      || throw "catalog: the 27B entry must not pin concurrency (a pin of 1 serializes every request where it is resident) and must bound thinking with reasoning_effort=low (unset defaults to xhigh, which never finishes)";
+      && builtins.match ".*reasoning_effort.*(low|medium).*" judgeArgs != null
+      || throw "catalog: the 27B entry must not pin concurrency (a pin of 1 serializes every request where it is resident) and must pin reasoning_effort to low or medium (unset defaults to xhigh, which never finishes)";
     assert
       builtins.match ".*mlx-model-server --model mlx-community/Qwen3.8-27B-4bit.*" judgeCmd != null
       && builtins.match ".*--log-level INFO.*" judgeCmd != null

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -88,10 +88,16 @@ in
     # regression shipped once and was caught only by reading the deployed
     # llama-swap.json, so assert the absence rather than a value: an entry with
     # no pin inherits proxy.concurrencyLimit, which is the intended contract.
+    # Thinking must also stay BOUNDED. The chat template defaults
+    # reasoning_effort to 'xhigh' when no kwarg is passed, and at xhigh this
+    # model exhausted max_tokens without emitting a single answer character on
+    # 3 of 3 measured runs. An entry carrying no chat-template kwarg therefore
+    # reads as "unconfigured" but serves as "never answers", so assert the
+    # bound is present rather than trusting its absence.
     assert
       !(builtins.hasAttr judge27b c.modelConcurrencyLimits)
-      && builtins.match ".*enable_thinking.*false.*" judgeArgs != null
-      || throw "catalog: the 27B entry must not pin concurrency (a pin of 1 serializes every request where it is resident) and must serve text with thinking disabled";
+      && builtins.match ".*reasoning_effort.*low.*" judgeArgs != null
+      || throw "catalog: the 27B entry must not pin concurrency (a pin of 1 serializes every request where it is resident) and must bound thinking with reasoning_effort=low (unset defaults to xhigh, which never finishes)";
     assert
       builtins.match ".*mlx-model-server --model mlx-community/Qwen3.8-27B-4bit.*" judgeCmd != null
       && builtins.match ".*--log-level INFO.*" judgeCmd != null

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -83,13 +83,25 @@ in
   # incumbent runs without hybridNoPaged and this entry does the same. Do not
   # "fix" that by adding hybridNoPaged on the strength of the layer_types field
   # alone — the incumbent has served this topology in production for weeks.
+  #
+  # Thinking is ON but BOUNDED. This model's reasoning is the reason it was
+  # adopted, so serving it thinking-off gives up what it was chosen for — but
+  # its chat template defaults reasoning_effort to 'xhigh' when the kwarg is
+  # unset, and at xhigh it does not finish. Measured on an isolated worker
+  # (jevans-ms, 2026-08-14, 3 runs, max_tokens 4096): 0 answer characters,
+  # 16399 reasoning characters, finish_reason "length" every run. Pinning
+  # 'low' is what makes it answer: 3/3 runs finish_reason "stop", 10079 answer
+  # against 5051 reasoning characters, 18.03 cumulative / 17.51 decode tok/s,
+  # ~220 s per response. The template accepts only xhigh | medium | low and
+  # raises a template exception on anything else; 'medium' is the model's own
+  # trained baseline and is not yet measured here.
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;
     args = [
       "--chat-template-args"
       (builtins.toJSON {
-        enable_thinking = false;
+        reasoning_effort = "low";
       })
     ];
     # NO concurrencyLimit. The entry this replaced carried concurrencyLimit = 1

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -84,37 +84,40 @@ in
   # "fix" that by adding hybridNoPaged on the strength of the layer_types field
   # alone — the incumbent has served this topology in production for weeks.
   #
-  # Thinking is ON but BOUNDED. This model's reasoning is the reason it was
-  # adopted, so serving it thinking-off gives up what it was chosen for — but
-  # its chat template defaults reasoning_effort to 'xhigh' when the kwarg is
-  # unset, and at xhigh it does not finish. Measured on an isolated worker
-  # (jevans-ms, 2026-08-14, 3 runs, max_tokens 4096): 0 answer characters,
-  # 16399 reasoning characters, finish_reason "length" every run. Pinning
-  # 'low' is what makes it answer: 3/3 runs finish_reason "stop", 10079 answer
-  # against 5051 reasoning characters, 3842 completion tokens.
+  # Thinking is ON at the model's own baseline. Its reasoning is the reason it
+  # was adopted, so serving it thinking-off gives up what it was chosen for —
+  # but the kwarg cannot simply be dropped either: the chat template defaults
+  # reasoning_effort to 'xhigh' when unset, and at xhigh it does not finish.
   #
-  # The template accepts only xhigh | medium | low. 'medium' was measured too,
-  # and it also completes at this worker's 8192-token budget: 4243 tokens,
-  # 13456 answer against 2334 reasoning characters, finish_reason "stop". It
-  # reasons LESS than low and answers more, which is not a contradiction —
-  # medium injects NO instruction at all (the prompt is 89 tokens against low's
-  # 119, the difference being low's "keep your thinking brief" string), so it
-  # is the model's unsteered baseline rather than a step up a dial.
+  # All three measured on an isolated worker (jevans-ms, 2026-08-14), weights
+  # proven from its process command line:
   #
-  # low is kept anyway, and the reason is bounding, not quality: low carries an
-  # explicit brevity instruction, so its thinking is bounded by construction,
-  # while medium is unbounded by instruction and differs from xhigh only in
-  # degree. On one 89-token prompt medium is fine; on a hard agentic prompt
-  # nothing stops it running long, and mlx-lm has no mechanism to cap it —
-  # reasoning_effort is a prompt string, not a budget. Revisit when vllm-mlx's
-  # thinking_token_budget can enforce a real ceiling.
+  #   unset -> xhigh   0 answer chars, 16399 reasoning, "length" 3/3 (at 4096)
+  #   low              10079 answer, 5051 reasoning, 3842 tokens, "stop" 3/3
+  #   medium           13456 answer, 2334 reasoning, 4243 tokens, "stop"
+  #
+  # medium is chosen: it completes inside this worker's 8192-token budget and
+  # produces the more substantial answer. It reasons LESS than low while
+  # answering more, which is not a contradiction — medium injects NO
+  # instruction at all. The prompt is 89 tokens at medium against 119 at low,
+  # and that 30-token difference IS low's "keep your thinking brief" string.
+  # medium is the model's unsteered baseline, not a step up a dial.
+  #
+  # What is NOT claimed: that either value is bounded. reasoning_effort is a
+  # prompt string the model may ignore, so neither low nor medium is a budget
+  # — only vllm-mlx's thinking_token_budget enforces a real ceiling. Do not
+  # read this pin as protection against a long think.
+  #
+  # No tok/s figure is recorded here on purpose. Decode on this host measured
+  # 17.4-27.3 across runs producing byte-identical output, so a single-run
+  # throughput number for this entry would be noise.
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;
     args = [
       "--chat-template-args"
       (builtins.toJSON {
-        reasoning_effort = "low";
+        reasoning_effort = "medium";
       })
     ];
     # NO concurrencyLimit. The entry this replaced carried concurrencyLimit = 1

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -91,10 +91,23 @@ in
   # (jevans-ms, 2026-08-14, 3 runs, max_tokens 4096): 0 answer characters,
   # 16399 reasoning characters, finish_reason "length" every run. Pinning
   # 'low' is what makes it answer: 3/3 runs finish_reason "stop", 10079 answer
-  # against 5051 reasoning characters, 18.03 cumulative / 17.51 decode tok/s,
-  # ~220 s per response. The template accepts only xhigh | medium | low and
-  # raises a template exception on anything else; 'medium' is the model's own
-  # trained baseline and is not yet measured here.
+  # against 5051 reasoning characters, 3842 completion tokens.
+  #
+  # The template accepts only xhigh | medium | low. 'medium' was measured too,
+  # and it also completes at this worker's 8192-token budget: 4243 tokens,
+  # 13456 answer against 2334 reasoning characters, finish_reason "stop". It
+  # reasons LESS than low and answers more, which is not a contradiction —
+  # medium injects NO instruction at all (the prompt is 89 tokens against low's
+  # 119, the difference being low's "keep your thinking brief" string), so it
+  # is the model's unsteered baseline rather than a step up a dial.
+  #
+  # low is kept anyway, and the reason is bounding, not quality: low carries an
+  # explicit brevity instruction, so its thinking is bounded by construction,
+  # while medium is unbounded by instruction and differs from xhigh only in
+  # degree. On one 89-token prompt medium is fine; on a hard agentic prompt
+  # nothing stops it running long, and mlx-lm has no mechanism to cap it —
+  # reasoning_effort is a prompt string, not a budget. Revisit when vllm-mlx's
+  # thinking_token_budget can enforce a real ceiling.
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;


### PR DESCRIPTION
Serves the 27B with thinking on at `reasoning_effort=medium` instead of `enable_thinking=false`, and moves the catalog check with it.

The template accepts only `xhigh | medium | low` and defaults to `xhigh` when the kwarg is unset. All three measured on an isolated worker outside llama-swap, weights proven from its process command line:

| Setting | finish_reason | tokens | answer chars | reasoning chars | prompt tokens |
| --- | --- | --- | --- | --- | --- |
| unset (template default `xhigh`) | `length` 3/3 | 4096 (cap) | **0** | 16399 | — |
| `low` | `stop` 3/3 | 3842 | 10079 | 5051 | **119** |
| **`medium`** | `stop` | 4243 | **13456** | 2334 | **89** |

`medium` completes inside the worker's 8192-token budget and produces the more substantial answer, so it is the default.

It reasons *less* than `low` while answering more, which reads as a contradiction only if `medium` is assumed to be a step up a dial. It isn't — the 30-token prompt difference **is** `low`'s "keep your thinking brief" string. `medium` injects nothing; it's the model's unsteered baseline.

**The check now accepts `low` OR `medium`.** The invariant worth protecting is that an effort is pinned *explicitly at all* — unset means `xhigh` means zero answers. Which finishing value serves is tuning, and shouldn't require editing a regression check. `xhigh` is excluded by construction. Negative-tested: setting `xhigh` throws.

**Not claimed:** that either value bounds thinking. `reasoning_effort` is a prompt string the model may ignore, not a budget — only vllm-mlx's `thinking_token_budget` enforces a ceiling.

`lib/checks/mlx-catalog.nix` asserted `enable_thinking=false` on this entry, so the catalog change alone would have taken develop red — the same coupled-check break as #1626, which darwin `nix flake check` passes vacuously.

Verified with `nix eval '.#checks.x86_64-linux.mlx-catalog.drvPath'` from inside the worktree.

No tok/s figure is recorded: decode measured 17.4–27.3 across runs producing byte-identical output, so a single-run throughput number would be noise.