### PR TITLE
refactor(mlx): split qwen38-27b into its own catalog file for the 12KB gate

### DIFF
--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -66,11 +66,18 @@
   # Every consumer references a capability role, never a hardcoded id — so a
   # model swap touches only the registry. Allowed: the "mlx-community/<...>"
   # placeholder in option examples and the "test-model" id in the check harness.
-  # lib/checks/* is excluded since it names the pattern itself, and
-  # modules/mlx/catalog-data.nix (plus catalog-data-80b-instruct.nix, split out
-  # for the file-size gate — see catalog-data.nix's header) is excluded because
-  # it IS the physical-id SSOT (the validated model catalog every other
-  # reference resolves through).
+  # lib/checks/* is excluded since it names the pattern itself, and the catalog
+  # data files are excluded because they ARE the physical-id SSOT (the validated
+  # model catalog every other reference resolves through).
+  #
+  # The catalog exclusion is a PATTERN, catalog-data.nix plus any
+  # catalog-data-<entry>.nix, rather than a list of filenames. Those siblings
+  # exist only because catalog-data.nix keeps crossing the per-file size gate
+  # and entries get carved out of it — so an enumerated list makes every future
+  # split fail this check for a reason that has nothing to do with the rule it
+  # enforces. That happened once already (the qwen38-27b split), and the fix is
+  # the pattern, not another line. The exclusion stays narrow: it admits catalog
+  # data files by name, nothing else in modules/mlx.
   # modules/mlx/cluster-mode.nix (and its extracted option file
   # modules/mlx/options-cluster.nix, which holds the clusterMode.model default)
   # are the same kind of SSOT for the clustered-mode model: a different engine
@@ -82,8 +89,7 @@
       --include='*.nix' --include='*.sh' --include='*.md' \
       --exclude-dir=.git --exclude-dir=result --exclude-dir=.direnv . \
       | grep -vE 'lib/checks' \
-      | grep -vE 'modules/mlx/catalog-data\.nix' \
-      | grep -vE 'modules/mlx/catalog-data-80b-instruct\.nix' \
+      | grep -vE 'modules/mlx/catalog-data(-[a-z0-9-]+)?\.nix' \
       | grep -vE 'modules/mlx/cluster-mode\.nix' \
       | grep -vE 'modules/mlx/options-cluster\.nix' \
       | grep -vE 'mlx-community/test-model' || true)

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -1,0 +1,80 @@
+# qwen38-27b — split out of catalog-data.nix for the per-file 12KB gate (same
+# split-rather-than-exempt pattern as catalog-data-80b-instruct.nix). Merged
+# into the same catalog attrset by catalog-data.nix; see that file for the
+# entry schema and catalog-lib.nix for the shared serve-arg helpers.
+let
+  inherit (import ./catalog-lib.nix) block256 block512 swapFlags;
+in
+{
+  # Resident Hermes goal judge and default small/midsize model.
+  #
+  # Drop-in successor to qwen36-27b-mxfp4: both are model_type qwen3_5_text with
+  # an IDENTICAL attention topology — 64 layers split 16 full_attention /
+  # 48 linear_attention, num_key_value_heads 4, head_dim 256 (read from each
+  # model's own config.json on jevans-ms, 2026-08-14). Same geometry means the
+  # incumbent's validated serve flags transfer verbatim; nothing here is guessed.
+  #
+  # Note this family is HYBRID attention but is NOT qwen3_next: it does not hit
+  # the mlx-lm#1162 paged-block reconstruction failure, which is why the
+  # incumbent runs without hybridNoPaged and this entry does the same. Do not
+  # "fix" that by adding hybridNoPaged on the strength of the layer_types field
+  # alone — the incumbent has served this topology in production for weeks.
+  #
+  # Thinking is ON at the model's own baseline. Its reasoning is the reason it
+  # was adopted, so serving it thinking-off gives up what it was chosen for —
+  # but the kwarg cannot simply be dropped either: the chat template defaults
+  # reasoning_effort to 'xhigh' when unset, and at xhigh it does not finish.
+  #
+  # All three measured on an isolated worker (jevans-ms, 2026-08-14), weights
+  # proven from its process command line:
+  #
+  #   unset -> xhigh   0 answer chars, 16399 reasoning, "length" 3/3 (at 4096)
+  #   low              10079 answer, 5051 reasoning, 3842 tokens, "stop" 3/3
+  #   medium           13456 answer, 2334 reasoning, 4243 tokens, "stop"
+  #
+  # medium is chosen: it completes inside this worker's 8192-token budget and
+  # produces the more substantial answer. It reasons LESS than low while
+  # answering more, which is not a contradiction — medium injects NO
+  # instruction at all. The prompt is 89 tokens at medium against 119 at low,
+  # and that 30-token difference IS low's "keep your thinking brief" string.
+  # medium is the model's unsteered baseline, not a step up a dial.
+  #
+  # What is NOT claimed: that either value is bounded. reasoning_effort is a
+  # prompt string the model may ignore, so neither low nor medium is a budget
+  # — only vllm-mlx's thinking_token_budget enforces a real ceiling. Do not
+  # read this pin as protection against a long think.
+  #
+  # No tok/s figure is recorded here on purpose. Decode on this host measured
+  # 17.4-27.3 across runs producing byte-identical output, so a single-run
+  # throughput number for this entry would be noise.
+  qwen38-27b = {
+    model = "mlx-community/Qwen3.8-27B-4bit";
+    weightGb = 16.1;
+    args = [
+      "--chat-template-args"
+      (builtins.toJSON {
+        reasoning_effort = "medium";
+      })
+    ];
+    # NO concurrencyLimit. The entry this replaced carried concurrencyLimit = 1
+    # because it was a latency-sensitive judge that never needed concurrent
+    # decode. This entry is the fleet brain every role resolves to, so pinning
+    # it to 1 would make llama-swap serialize every request on the host.
+    classes = {
+      # Fleet-brain resident profile, matched to the entry it takes over from:
+      # HIGH caps for 40-58K agentic contexts. maxRequestTokens 65536 is load
+      # bearing — 32768 fed a truncation/retry death-loop.
+      resident.flags = block512 // {
+        cacheMemoryMb = 16384;
+        maxNumSeqs = 8;
+        maxRequestTokens = 65536;
+      };
+      swap.flags =
+        block256
+        // swapFlags
+        // {
+          cacheMemoryMb = 3072;
+        };
+    };
+  };
+}

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -3,8 +3,10 @@
 # (parser stacks, timeout, paged-block sizes, swap tier) are documented in
 # catalog-lib.nix; this file is split out to keep each under the 12KB gate.
 # See catalog-lib.nix for the #1334 KV-quant/MTP flag-availability note.
-# qwen3-next-80b-instruct lives in catalog-data-80b-instruct.nix, merged
-# below, for the same size-gate reason.
+# qwen3-next-80b-instruct and qwen38-27b live in their own files, merged
+# below, for the same size-gate reason. Both carry long measurement notes,
+# which is exactly what pushed this file over the gate — split the entry,
+# never trim the evidence.
 let
   inherit (import ./catalog-lib.nix)
     block256
@@ -14,6 +16,7 @@ let
     ;
 in
 (import ./catalog-data-80b-instruct.nix)
+// (import ./catalog-data-qwen38-27b.nix)
 // {
   # Small resident auxiliary model for bounded classification and judging.
   # OptiQ keeps tool/reasoning compatibility with the Qwen family while the
@@ -67,78 +70,6 @@ in
     classes = {
       resident.flags = { };
       swap.flags = swapFlags;
-    };
-  };
-
-  # Resident Hermes goal judge and default small/midsize model.
-  #
-  # Drop-in successor to qwen36-27b-mxfp4: both are model_type qwen3_5_text with
-  # an IDENTICAL attention topology — 64 layers split 16 full_attention /
-  # 48 linear_attention, num_key_value_heads 4, head_dim 256 (read from each
-  # model's own config.json on jevans-ms, 2026-08-14). Same geometry means the
-  # incumbent's validated serve flags transfer verbatim; nothing here is guessed.
-  #
-  # Note this family is HYBRID attention but is NOT qwen3_next: it does not hit
-  # the mlx-lm#1162 paged-block reconstruction failure, which is why the
-  # incumbent runs without hybridNoPaged and this entry does the same. Do not
-  # "fix" that by adding hybridNoPaged on the strength of the layer_types field
-  # alone — the incumbent has served this topology in production for weeks.
-  #
-  # Thinking is ON at the model's own baseline. Its reasoning is the reason it
-  # was adopted, so serving it thinking-off gives up what it was chosen for —
-  # but the kwarg cannot simply be dropped either: the chat template defaults
-  # reasoning_effort to 'xhigh' when unset, and at xhigh it does not finish.
-  #
-  # All three measured on an isolated worker (jevans-ms, 2026-08-14), weights
-  # proven from its process command line:
-  #
-  #   unset -> xhigh   0 answer chars, 16399 reasoning, "length" 3/3 (at 4096)
-  #   low              10079 answer, 5051 reasoning, 3842 tokens, "stop" 3/3
-  #   medium           13456 answer, 2334 reasoning, 4243 tokens, "stop"
-  #
-  # medium is chosen: it completes inside this worker's 8192-token budget and
-  # produces the more substantial answer. It reasons LESS than low while
-  # answering more, which is not a contradiction — medium injects NO
-  # instruction at all. The prompt is 89 tokens at medium against 119 at low,
-  # and that 30-token difference IS low's "keep your thinking brief" string.
-  # medium is the model's unsteered baseline, not a step up a dial.
-  #
-  # What is NOT claimed: that either value is bounded. reasoning_effort is a
-  # prompt string the model may ignore, so neither low nor medium is a budget
-  # — only vllm-mlx's thinking_token_budget enforces a real ceiling. Do not
-  # read this pin as protection against a long think.
-  #
-  # No tok/s figure is recorded here on purpose. Decode on this host measured
-  # 17.4-27.3 across runs producing byte-identical output, so a single-run
-  # throughput number for this entry would be noise.
-  qwen38-27b = {
-    model = "mlx-community/Qwen3.8-27B-4bit";
-    weightGb = 16.1;
-    args = [
-      "--chat-template-args"
-      (builtins.toJSON {
-        reasoning_effort = "medium";
-      })
-    ];
-    # NO concurrencyLimit. The entry this replaced carried concurrencyLimit = 1
-    # because it was a latency-sensitive judge that never needed concurrent
-    # decode. This entry is the fleet brain every role resolves to, so pinning
-    # it to 1 would make llama-swap serialize every request on the host.
-    classes = {
-      # Fleet-brain resident profile, matched to the entry it takes over from:
-      # HIGH caps for 40-58K agentic contexts. maxRequestTokens 65536 is load
-      # bearing — 32768 fed a truncation/retry death-loop.
-      resident.flags = block512 // {
-        cacheMemoryMb = 16384;
-        maxNumSeqs = 8;
-        maxRequestTokens = 65536;
-      };
-      swap.flags =
-        block256
-        // swapFlags
-        // {
-          cacheMemoryMb = 3072;
-        };
     };
   };
 


### PR DESCRIPTION
`catalog-data.nix` reached 12,896 bytes and failed `File Size / Check` on the develop→main promotion (#1628). The cause was the measurement notes added with the `reasoning_effort` work in #1627.

Splitting the entry is the fix, not trimming the notes — that evidence is *why* the entry is configured as it is, and the repo already has the pattern (`catalog-data-80b-instruct.nix` was carved out of this same file for this same gate).

Sizes after: 9,588 / 3,865 / 3,298 bytes.

Verified the entry survives the merge rather than trusting the diff: the imported catalog still resolves `qwen38-27b` with `--chat-template-args {"reasoning_effort":"medium"}` and still has 12 entries. `nix eval '.#checks.x86_64-linux.mlx-catalog.drvPath'` re-run from inside the worktree.

Unblocks #1628, which unblocks the nix-darwin pin bump and the Studio converge.