### PR TITLE
feat(mlx): derive concurrencyLimit ceiling from residency budget

### DIFF
--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -6,34 +6,10 @@
 }:
 let
   inherit (mlxShared) cfg llamaSwapConfigAttrs allModels;
-  # Documented host wired-memory ceiling (nix-darwin appleSiliconTunables,
-  # iogpu.wired_limit_mb = 102400 on the 128 GiB Macs this module targets;
-  # see modules/mlx/options-residency.nix). Not readable from this module —
-  # nix-darwin owns the sysctl — so it is named here rather than re-derived.
-  wiredCeilingGiB = 100;
 in
 {
   # Fail evaluation when coupled options or generated proxy contracts drift.
   assertions = lib.optionals cfg.enable [
-    {
-      # The residency invariant documented in options-residency.nix (lines
-      # 9, 40) and options-runtime.nix (lines 11, 72-74) but never enforced:
-      # maxResidentWorkers * memoryHardLimitGb must not exceed the host wired
-      # ceiling, or the module can represent a config the hardware cannot
-      # honor (host-wide swap/thrash under memory pressure).
-      assertion = cfg.maxResidentWorkers * cfg.memoryHardLimitGb <= wiredCeilingGiB;
-      message =
-        let
-          product = cfg.maxResidentWorkers * cfg.memoryHardLimitGb;
-        in
-        ''
-          programs.mlx: maxResidentWorkers (${toString cfg.maxResidentWorkers}) *
-          memoryHardLimitGb (${toString cfg.memoryHardLimitGb}) = ${toString product} GiB,
-          exceeding the documented wired ceiling of ${toString wiredCeilingGiB} GiB.
-          Lower memoryHardLimitGb to fit the raised worker count, or lower
-          maxResidentWorkers back down.
-        '';
-    }
     {
       assertion = cfg.modelServerBackend == "mlx-lm" && cfg.enabledBackends == [ "mlx-lm" ];
       message = "programs.mlx must use only the enabled mlx-lm backend; vllm-mlx remains preserved but disabled.";

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -6,10 +6,34 @@
 }:
 let
   inherit (mlxShared) cfg llamaSwapConfigAttrs allModels;
+  # Documented host wired-memory ceiling (nix-darwin appleSiliconTunables,
+  # iogpu.wired_limit_mb = 102400 on the 128 GiB Macs this module targets;
+  # see modules/mlx/options-residency.nix). Not readable from this module —
+  # nix-darwin owns the sysctl — so it is named here rather than re-derived.
+  wiredCeilingGiB = 100;
 in
 {
   # Fail evaluation when coupled options or generated proxy contracts drift.
   assertions = lib.optionals cfg.enable [
+    {
+      # The residency invariant documented in options-residency.nix (lines
+      # 9, 40) and options-runtime.nix (lines 11, 72-74) but never enforced:
+      # maxResidentWorkers * memoryHardLimitGb must not exceed the host wired
+      # ceiling, or the module can represent a config the hardware cannot
+      # honor (host-wide swap/thrash under memory pressure).
+      assertion = cfg.maxResidentWorkers * cfg.memoryHardLimitGb <= wiredCeilingGiB;
+      message =
+        let
+          product = cfg.maxResidentWorkers * cfg.memoryHardLimitGb;
+        in
+        ''
+          programs.mlx: maxResidentWorkers (${toString cfg.maxResidentWorkers}) *
+          memoryHardLimitGb (${toString cfg.memoryHardLimitGb}) = ${toString product} GiB,
+          exceeding the documented wired ceiling of ${toString wiredCeilingGiB} GiB.
+          Lower memoryHardLimitGb to fit the raised worker count, or lower
+          maxResidentWorkers back down.
+        '';
+    }
     {
       assertion = cfg.modelServerBackend == "mlx-lm" && cfg.enabledBackends == [ "mlx-lm" ];
       message = "programs.mlx must use only the enabled mlx-lm backend; vllm-mlx remains preserved but disabled.";

--- a/modules/mlx/options-proxy.nix
+++ b/modules/mlx/options-proxy.nix
@@ -29,13 +29,17 @@ let
   # ceiling sets the largest single-request KV reservation to budget for.
   maxGrantedRequestTokens = 65536;
   kvPerSeqGiB = (kvPerTokenDenseKiB * maxGrantedRequestTokens) / (1024 * 1024);
-  # Headroom after the peak weight, sliced into pessimistic-KV portions:
-  # the count of concurrent max-length requests the budget supports. Clamped
-  # to at least 1 — a memoryHardLimitGb set below peakWeightGiB is already a
-  # broken host (it can't hold the heaviest catalog model at all), and the
-  # unclamped division would otherwise crash `ints.between` at eval with an
-  # opaque "lowest must be smaller than highest" instead of surfacing here.
-  concurrencyLimitCeiling = lib.max 1 ((perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB);
+  # Memory-only headroom after the peak weight, sliced into pessimistic-KV
+  # portions: how many concurrent max-length requests the budget FITS.
+  # Fitting in memory is necessary but not sufficient — concurrencyLimit also
+  # sets --decode-concurrency/--prompt-concurrency on Apple Silicon's single
+  # GPU, where throughput collapses well before memory runs out. 4 is that
+  # separate operator judgment about practical decode concurrency, not a
+  # memory bound, so it caps the memory-derived value rather than replacing
+  # it: tighten on memory, never loosen past operator judgment.
+  operatorConcurrencyCap = 4;
+  memoryFitCeiling = lib.max 1 ((perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB);
+  concurrencyLimitCeiling = lib.min operatorConcurrencyCap memoryFitCeiling;
 in
 {
   options.programs.mlx = {
@@ -93,10 +97,10 @@ in
         '';
       };
       concurrencyLimit = lib.mkOption {
-        # The ceiling is derived above from the residency budget, not chosen:
-        # (perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB, expressed in the
-        # type so a value the hardware cannot honor cannot be represented
-        # rather than merely being remembered.
+        # The ceiling is derived above from the residency budget, then capped
+        # at operatorConcurrencyCap (throughput, not memory, is the limit
+        # past that point) — expressed in the type so a value the hardware
+        # cannot honor cannot be represented rather than merely remembered.
         type = lib.types.ints.between 1 concurrencyLimitCeiling;
         default = 1;
         description = ''
@@ -112,12 +116,15 @@ in
           cron kills: the proxy admitted 4 while the server served 1, and the
           excess came back as 429.
 
-          Default 1, ceiling ${toString concurrencyLimitCeiling} on this host
-          (derives from programs.mlx.memoryHardLimitGb, currently
-          ${toString perWorkerBudgetGiB} GiB): the largest number of
-          concurrent maxGrantedRequestTokens-length requests the worker's
-          memory budget can hold at once, after the peak resident model's
-          own weight footprint. 1 serializes and
+          Default 1, ceiling ${toString concurrencyLimitCeiling} on this host:
+          min(operatorConcurrencyCap = ${toString operatorConcurrencyCap}, memory fit
+          = ${toString memoryFitCeiling}). Memory fit derives from
+          programs.mlx.memoryHardLimitGb (currently ${toString perWorkerBudgetGiB} GiB)
+          — the largest number of concurrent maxGrantedRequestTokens-length
+          requests the worker's memory budget can hold after the peak
+          resident model's own weight footprint. The operator cap holds
+          regardless: more requests would fit in memory long before Apple
+          Silicon's single GPU could actually decode them concurrently. 1 serializes and
           defeats continuous batching; that is the accepted trade while the
           simplest non-crashing configuration is the goal. Raising it means
           raising the server's real capacity at the same time, which now

--- a/modules/mlx/options-proxy.nix
+++ b/modules/mlx/options-proxy.nix
@@ -8,14 +8,14 @@
 # processes. Model switching is transparent: send a request with model: "X"
 # and the proxy handles it.
 #
-{ lib, ... }:
+{ lib, config, ... }:
 let
   # concurrencyLimit ceiling — derived from the residency budget, not chosen.
   #
-  # A worker's memory budget at maxResidentWorkers = 2 (modules/mlx/
-  # options-residency.nix) is 48 GiB, per the invariant
-  # k * memoryHardLimitGb <= wired ceiling (100 GiB) documented there.
-  perWorkerBudgetGiB = 48;
+  # A worker's memory budget is programs.mlx.memoryHardLimitGb itself (see
+  # modules/mlx/options-residency.nix) — read live so this adapts per host
+  # instead of assuming the Studio's k=2/100 GiB shape.
+  perWorkerBudgetGiB = config.programs.mlx.memoryHardLimitGb;
   # Peak 4-bit weight footprint in this registry (the 35B-class model,
   # modules/mlx/catalog-data.nix), rounded up to the next whole GiB —
   # the conservative direction, so this stays a ceiling.
@@ -30,8 +30,12 @@ let
   maxGrantedRequestTokens = 65536;
   kvPerSeqGiB = (kvPerTokenDenseKiB * maxGrantedRequestTokens) / (1024 * 1024);
   # Headroom after the peak weight, sliced into pessimistic-KV portions:
-  # the count of concurrent max-length requests the budget supports.
-  concurrencyLimitCeiling = (perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB;
+  # the count of concurrent max-length requests the budget supports. Clamped
+  # to at least 1 — a memoryHardLimitGb set below peakWeightGiB is already a
+  # broken host (it can't hold the heaviest catalog model at all), and the
+  # unclamped division would otherwise crash `ints.between` at eval with an
+  # opaque "lowest must be smaller than highest" instead of surfacing here.
+  concurrencyLimitCeiling = lib.max 1 ((perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB);
 in
 {
   options.programs.mlx = {
@@ -108,10 +112,12 @@ in
           cron kills: the proxy admitted 4 while the server served 1, and the
           excess came back as 429.
 
-          Default 1, ceiling ${toString concurrencyLimitCeiling}: the largest
-          number of concurrent maxGrantedRequestTokens-length requests the
-          k=2 per-worker residency budget can hold at once, after the peak
-          resident model's own weight footprint. 1 serializes and
+          Default 1, ceiling ${toString concurrencyLimitCeiling} on this host
+          (derives from programs.mlx.memoryHardLimitGb, currently
+          ${toString perWorkerBudgetGiB} GiB): the largest number of
+          concurrent maxGrantedRequestTokens-length requests the worker's
+          memory budget can hold at once, after the peak resident model's
+          own weight footprint. 1 serializes and
           defeats continuous batching; that is the accepted trade while the
           simplest non-crashing configuration is the goal. Raising it means
           raising the server's real capacity at the same time, which now

--- a/modules/mlx/options-proxy.nix
+++ b/modules/mlx/options-proxy.nix
@@ -9,6 +9,30 @@
 # and the proxy handles it.
 #
 { lib, ... }:
+let
+  # concurrencyLimit ceiling — derived from the residency budget, not chosen.
+  #
+  # A worker's memory budget at maxResidentWorkers = 2 (modules/mlx/
+  # options-residency.nix) is 48 GiB, per the invariant
+  # k * memoryHardLimitGb <= wired ceiling (100 GiB) documented there.
+  perWorkerBudgetGiB = 48;
+  # Peak 4-bit weight footprint in this registry (the 35B-class model,
+  # modules/mlx/catalog-data.nix), rounded up to the next whole GiB —
+  # the conservative direction, so this stays a ceiling.
+  peakWeightGiB = 31;
+  # Dense-attention KV cache cost per token, the pessimistic bound (MoE
+  # families cost less, at 20 KiB/token). See docs/architecture/mlx-stack.md.
+  kvPerTokenDenseKiB = 64;
+  # Largest maxRequestTokens actually granted by a catalog entry (the HIGH
+  # agentic-context profile; modules/mlx/catalog-data.nix,
+  # modules/mlx/catalog-data-qwen38-27b.nix). One in-flight request at this
+  # ceiling sets the largest single-request KV reservation to budget for.
+  maxGrantedRequestTokens = 65536;
+  kvPerSeqGiB = (kvPerTokenDenseKiB * maxGrantedRequestTokens) / (1024 * 1024);
+  # Headroom after the peak weight, sliced into pessimistic-KV portions:
+  # the count of concurrent max-length requests the budget supports.
+  concurrencyLimitCeiling = (perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB;
+in
 {
   options.programs.mlx = {
     proxy = {
@@ -65,9 +89,11 @@
         '';
       };
       concurrencyLimit = lib.mkOption {
-        # Ceiling 4 is an operator constraint, expressed in the type so a value
-        # above it cannot be represented rather than merely being remembered.
-        type = lib.types.ints.between 1 4;
+        # The ceiling is derived above from the residency budget, not chosen:
+        # (perWorkerBudgetGiB - peakWeightGiB) / kvPerSeqGiB, expressed in the
+        # type so a value the hardware cannot honor cannot be represented
+        # rather than merely being remembered.
+        type = lib.types.ints.between 1 concurrencyLimitCeiling;
         default = 1;
         description = ''
           Max in-flight requests llama-swap will forward to a model server per
@@ -82,11 +108,14 @@
           cron kills: the proxy admitted 4 while the server served 1, and the
           excess came back as 429.
 
-          Default 1, ceiling 4 (operator constraint, enforced by the type).
-          1 serializes and defeats continuous batching; that is the accepted
-          trade while the simplest non-crashing configuration is the goal.
-          Raising it means raising the server's real capacity at the same time,
-          which now happens automatically because both derive from here.
+          Default 1, ceiling ${toString concurrencyLimitCeiling}: the largest
+          number of concurrent maxGrantedRequestTokens-length requests the
+          k=2 per-worker residency budget can hold at once, after the peak
+          resident model's own weight footprint. 1 serializes and
+          defeats continuous batching; that is the accepted trade while the
+          simplest non-crashing configuration is the goal. Raising it means
+          raising the server's real capacity at the same time, which now
+          happens automatically because both derive from here.
 
           Above the limit callers get 429 — cap or retry with backoff; the
           llm_router tier absorbs 429s via its retry policy. Prior sweep data


### PR DESCRIPTION
## Summary

- `modules/mlx/options-proxy.nix`: derives `programs.mlx.proxy.concurrencyLimit`'s ceiling from the per-worker memory budget (`programs.mlx.memoryHardLimitGb`, minus peak registry weight, sliced by dense-attention KV cost per token at the largest catalog-granted context length), then caps it at a named operator concurrency limit (4). Ceiling by budget: 99 GiB -> 4, 48 GiB -> 4, 35 GiB -> 1.
- `peakWeightGiB` is a pinned observation (largest 4-bit weight currently in the catalog, see `modules/mlx/catalog-data.nix`), not a value computed from the catalog at eval time.

## Test plan

- [x] `nix fmt` — no changes
- [x] `nix flake check` — passes (checks scoped to `x86_64-linux`; verified separately below since this ran on `aarch64-darwin`, which cannot build x86_64-linux derivations locally)
- [x] `nix eval '.#checks.x86_64-linux.<check>.drvPath'` forced-evaluated for the six relevant mlx check derivations — all evaluate cleanly
- [x] Manually evaluated `memoryHardLimitGb = 99`: `concurrencyLimit = 1` accepted, `= 5` rejected (cap holds at 4)
- [x] Manually evaluated `memoryHardLimitGb = 48`: `concurrencyLimit = 4` accepted, `= 5` rejected
- [x] Manually evaluated `memoryHardLimitGb = 35`: `concurrencyLimit = 1` accepted, `= 2` rejected (proves the budget-derived tightening below the cap)