### PR TITLE
docs(architecture): correct the serving backend to mlx-lm

### DIFF
--- a/docs/adr/0003-galileo-ai-observability.md
+++ b/docs/adr/0003-galileo-ai-observability.md
@@ -13,6 +13,12 @@
 > **Update 2026-07-16:** Bifrost is decommissioned. The Bifrost-scoped rows in
 > Cross-Repo Dependencies are void; this ADR's remaining scope is the MLX inference
 > stack only.
+>
+> **Update 2026-08-15:** The serving backend is now `mlx-lm`, not `vllm-mlx`.
+> `modules/mlx/assertions.nix` enforces that; vllm-mlx is preserved but disabled.
+> The Consequences section below still names vllm-mlx because that was the backend
+> when this decision was recorded. The `programs.mlx.telemetry.enable` hook carries
+> over unchanged — it sets LaunchAgent env vars, so it is backend-neutral.
 
 ## Documents in This Directory
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -40,9 +40,9 @@ Per-secret runbooks live there and in the private docs repo.
 
 ### [mlx-stack.md](mlx-stack.md)
 
-The three user-facing MLX tools (parakeet-mlx, mlx-vlm, vllm-mlx) and their shared library
+The three user-facing MLX tools (parakeet-mlx, mlx-vlm, mlx-lm) and their shared library
 dependencies. Includes the dependency graph, version management strategy, and operational
-notes covering tool-call parser compatibility, idle eviction, and MoE vs dense throughput.
+notes covering tool-call parsing, idle eviction, and MoE vs dense throughput.
 
 **Read when**: Adding a new MLX tool, debugging a model loading or tool-calling issue,
 or understanding why the 35B model is preloaded vs the 122B MoE.

--- a/docs/architecture/mlx-stack.md
+++ b/docs/architecture/mlx-stack.md
@@ -9,7 +9,13 @@ plus shared libraries and operational behaviour.
 | ---- | ------- | ------- | -------------- |
 | Ears (Audio) | `parakeet-mlx` | Real-time speech-to-text | `uvx` wrapper (Nix derivation) |
 | Eyes (Vision) | `mlx-vlm` | Screen/camera image analysis | `uvx` wrapper (Nix derivation) |
-| Brain (LLM) | `vllm-mlx` | LLM inference API server | `uvx` wrapper (LaunchAgent) |
+| Brain (LLM) | `mlx-lm` (`mlx_lm.server`) | LLM inference API server | Nix store (LaunchAgent, fronted by llama-swap) |
+
+`mlx-lm` is the only backend that serves. `vllm-mlx` is preserved but disabled:
+the code still carries it, and `modules/mlx/assertions.nix` fails evaluation
+unless `modelServerBackend` and `enabledBackends` are `mlx-lm` alone. A
+vision-language model may opt into `mlx-vlm` per model through
+`programs.mlx.modelBackends`.
 
 ## Dependency Graph
 
@@ -19,12 +25,11 @@ graph TD
         subgraph "User-Facing Tools"
             EARS["Ears — parakeet-mlx<br/><i>Speech-to-text</i>"]
             EYES["Eyes — mlx-vlm<br/><i>Vision analysis</i>"]
-            BRAIN["Brain — vllm-mlx<br/><i>LLM inference API</i>"]
+            BRAIN["Brain — mlx_lm.server<br/><i>LLM inference API</i>"]
         end
 
         subgraph "Shared Libraries"
             MLX_LM["mlx-lm"]
-            MLX_EMB["mlx-embeddings"]
             TRANSFORMERS["transformers"]
             HF_HUB["huggingface-hub"]
         end
@@ -49,13 +54,11 @@ graph TD
     EYES --> OPENCV
 
     BRAIN --> MLX_LM
-    BRAIN --> MLX_EMB
     BRAIN --> TRANSFORMERS
     BRAIN --> HF_HUB
 
     MLX_LM --> MLX
     MLX_LM --> TRANSFORMERS
-    MLX_EMB --> MLX
 ```
 
 ## Version Management
@@ -71,7 +74,7 @@ Two delivery paths, split by whether a working Nix package exists:
 | Component | Delivery | Why |
 | --------- | -------- | --- |
 | `mlx`, `mlx-lm`, `transformers` | Nix store (`modules/mlx/python-overlay.nix`) | Always-running serving path; needs dedup and GC |
-| `parakeet-mlx`, `vllm-mlx` | `uvx` wrapper | Not packaged in nixpkgs |
+| `parakeet-mlx`, `vllm-mlx` (preserved, disabled) | `uvx` wrapper | Not packaged in nixpkgs |
 | `mlx-vlm` | `uvx` wrapper | nixpkgs lags the pinned version |
 
 The serving stack moved off `uv run --with` because uv's cache is append-only
@@ -120,16 +123,23 @@ overlay's wheel mlx (`modules/mlx/python-overlay.nix`), which reports
 server's `system_fingerprint` ends in the GPU id (e.g. `applegpu_g16s`) when
 Metal is live.
 
-**Tool-call parser compatibility**: vllm-mlx defaults to `--tool-call-parser hermes`. Only Qwen
-models pass tool-calling validation with this parser; GLM and Seed-OSS models fail with output
-format errors despite correct reasoning. To use non-Qwen models for tool calling, switch to
-`auto` or a model-specific parser in the llama-swap config.
+**Tool-call parsing**: the mlx-lm backend uses the patched wheel's
+`--harmony-tool-parser` (`auto` by default; `on`/`off` pinned per model in
+`modules/mlx/catalog-data.nix`). `auto` engages only on turns that open with
+harmony markup, so it is inert for every other model. The `--tool-call-parser`
+flag and its hermes/Qwen compatibility caveat belong to the disabled vllm-mlx
+path only — `programs.mlx.toolCallParser` emits nothing while mlx-lm serves.
 
 **Idle penalty**: llama-swap evicts an idle model after `proxy.idleTtl` (default 15 min;
 the worker's `autoUnloadIdleSeconds` failsafe fires at 30 min). The next request pays a
 full reload — seconds for a small MoE, ~60-120s for a 120B model.
 
-**Resident vs swap tiers**: the resident registry comes from `services.aiStack.models`
+**Resident vs swap tiers**: a server-class host is the intelligence tier — it
+optimises for answer quality, not throughput, so it keeps several models
+resident rather than swapping for speed. The live roster is the registry itself
+(`services.aiStack.models` plus the catalog entries in
+`modules/mlx/catalog-data*.nix`), never a list copied into prose. The resident
+registry comes from `services.aiStack.models`
 and the `preload` list. Server-class hosts keep several resident models warm by setting
 `groupSwap = false`, listing each resident role in `preload`, and disabling eviction
 for that tier (`proxy.idleTtl = 0`, `autoUnloadIdleSeconds = 0`). The separate

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -24,7 +24,7 @@ graph TD
 
     subgraph LocalInference["Local Inference — Apple Silicon"]
         LS["llama-swap proxy\n:11434"]
-        VLLM["vllm-mlx backends\n:11436+"]
+        WORKERS["MLX model-server workers\n(mlx-lm)\n:11436+"]
     end
 
     subgraph WebTools["Web & Pattern Tools"]
@@ -39,7 +39,7 @@ graph TD
 
     FAB -->|HTTP /v1| LS
 
-    LS -->|manages processes| VLLM
+    LS -->|manages processes| WORKERS
 ```
 
 Local nix-ai clients (qwen-code, cecli, Fabric) call llama-swap directly at
@@ -111,7 +111,7 @@ and adding any required runtime secret injection.
 | Port | Service | Protocol | Module |
 |------|---------|----------|--------|
 | 11434 | llama-swap proxy | HTTP (OpenAI-compatible) | `modules/mlx/` |
-| 11436+ | vllm-mlx backends | HTTP (managed by llama-swap) | `modules/mlx/` |
+| 11436+ | MLX model-server workers (mlx-lm) | HTTP (managed by llama-swap) | `modules/mlx/` |
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |
 | 9379 | LiteRT-LM classifier (Antigravity CLI gemma router, opt-in) | HTTP | `modules/antigravity-cli/` |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
@@ -125,7 +125,7 @@ Reserved but avoid: **11435** (macOS app conflict, see PR #230).
 ```mermaid
 graph LR
     CC["Claude Code\n(metrics + logs)"]
-    MLX["vllm-mlx\n(traces, when telemetry.enable=true)"]
+    MLX["MLX model server\n(traces, when telemetry.enable=true)"]
     OTEL["OTEL Collector\n:30317"]
     CRIBL["Cribl Stream\n:4317"]
     SPLUNK["Splunk HEC"]

--- a/docs/runbooks/cluster-lifecycle.md
+++ b/docs/runbooks/cluster-lifecycle.md
@@ -32,7 +32,7 @@ environment and behave identically on the coordinator and the worker.
 3. Coordinator only: refuse to proceed if `vm.swapusage` used exceeds
    `joinSwapThresholdMb` (default 8000 MB) — loading against stale swap spirals
    to a panic (INC-17075) — then quiesce standalone serving (bootout the server +
-   warmup agents, wait for zero `vllm-mlx serve` processes, reap orphans after a
+   warmup agents, wait for zero MLX model-server processes, reap orphans after a
    grace).
 4. Clear a stale `rank-halted` PD-guard latch and any standalone lease, ensure
    the watcher agent is loaded (bootstrap in the caller's own `gui/$uid` domain

--- a/docs/runbooks/galileo-onboarding.md
+++ b/docs/runbooks/galileo-onboarding.md
@@ -87,7 +87,7 @@ Apply to the `traces/galileo` sub-pipeline only, not the Cribl/Splunk pipeline.
 
 | Action | Effect |
 |--------|--------|
-| `programs.mlx.telemetry.enable = false` + rebuild | Removes OTel env vars from vllm-mlx LaunchAgent; MLX stops sending to collector |
+| `programs.mlx.telemetry.enable = false` + rebuild | Removes OTel env vars from the MLX model-server LaunchAgent; MLX stops sending to collector |
 | Remove `otlphttp/galileo` from collector pipeline | Stops all Galileo exports; Splunk unaffected |
 | Delete `GALILEO_API_KEY` in Doppler | Collector authentication fails; no traces accepted by Galileo |
 | Unset `GALILEO_TRACE` in shell | No `X-Trace-Sink` header sent; routing connector drops all spans before Galileo exporter |


### PR DESCRIPTION
Documentation named `vllm-mlx` as the serving LLM backend. The serving backend is `mlx-lm`, and `modules/mlx/assertions.nix` enforces that. `vllm-mlx` is described as preserved but disabled, not removed.

## What changed

- `docs/architecture/mlx-stack.md` — Brain row now `mlx-lm` (`mlx_lm.server`, Nix store, LaunchAgent fronted by llama-swap); mermaid `BRAIN` node relabelled; dropped the `mlx-embeddings` node and edges (no module references it); delivery table annotates `vllm-mlx` as preserved/disabled; tool-call parsing note rewritten to describe mlx-lm's `--harmony-tool-parser` and scope the `--tool-call-parser` hermes caveat to the disabled vllm-mlx path; resident/swap section states the intelligence-tier framing and points at the registry as the roster source.
- `docs/architecture/README.md` — tool list and the operational-notes summary.
- `docs/architecture/system-integration-map.md` — topology node, its edge, the port-allocation row for 11436+, and the telemetry-pipeline node label.
- `docs/runbooks/cluster-lifecycle.md` — quiesce step now names MLX model-server processes, matching `modules/mlx/model-server-pattern.nix`.
- `docs/runbooks/galileo-onboarding.md` — kill-switch row names the MLX model-server LaunchAgent.
- `docs/adr/0003-galileo-ai-observability.md` — dated amendment only; the recorded decision text is unchanged.

`nix flake check` and `nix fmt` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)