### PR TITLE
fix(mlx): make RDMA protection-domain settle billing errno-aware

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -288,6 +288,7 @@ in
 // (import ./checks/mlx-cluster-mem-headroom.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-health-gate.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-scripts.nix { inherit pkgs hmConfigCluster src; })
+// (import ./checks/mlx-cluster-pd-settle-billing.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-peer-armed.nix { inherit pkgs hmConfigCluster src; })
 // (import ./checks/mlx-cluster-soak.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-selfheal.nix { inherit pkgs src; })

--- a/lib/checks/mlx-cluster-pd-settle-billing.nix
+++ b/lib/checks/mlx-cluster-pd-settle-billing.nix
@@ -1,0 +1,46 @@
+# Counter-settle billing check, split out of ./mlx-cluster-scripts.nix at the
+# 12KB file cap in .file-size.yml — same split-rather-than-exempt pattern as
+# ./mlx-cluster-halt-boot-scope's own split, and ./mlx-cluster-recovery.nix's.
+#
+# Duplicates the handful of guard-layer script paths this one check needs
+# rather than importing mlx-cluster-scripts.nix's `guardLayers`: that binding
+# is local to its own file, and reaching across for seven short strings would
+# cost more than repeating them — the same call ./mlx-cluster-recovery.nix and
+# ./mlx-cluster-peer-armed.nix already made.
+{
+  pkgs,
+  src,
+}:
+{
+  # THE CHECK THAT FAILS IF A COUNTER RESET CAN DISCARD LEAKED DOMAINS, OR CAN
+  # BILL DOMAINS THAT WERE NEVER SPENT. mlx-cluster-pd-debt covers the ledger
+  # at the CAP; this covers the hole underneath: the kickstart counter is
+  # session-scoped and five paths reset it (a link cycle, a settled rank,
+  # cluster-join, cluster-detach, an accepted manual clear), but the ledger
+  # was only written at the cap, so a counter at 1 or 2 reset elsewhere left
+  # no trace of the domains those attempts leaked. Asserts the transfer
+  # arithmetic (including the fail-closed direction, where an unguarded
+  # subtraction would compute a NEGATIVE debt and record nothing), that the
+  # transfer is errno-aware (a run whose every outstanding attempt is provably
+  # jaccl Stage-A-only bills nothing — it could not have allocated a
+  # protection domain — while Stage-B or unclassifiable evidence still bills
+  # in full), and pins the call sites as source.
+  mlx-cluster-pd-counter-settle = pkgs.runCommand "check-mlx-cluster-pd-counter-settle" {
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.gawk
+    ];
+    BOOT_SCOPE = "${src}/modules/mlx/scripts/cluster-boot-scope.sh";
+    LEDGER = "${src}/modules/mlx/scripts/cluster-pd-ledger.sh";
+    RECORD = "${src}/modules/mlx/scripts/cluster-pd-record.sh";
+    # jaccl Stage-A/Stage-B classifier — see cluster-pd-stage.sh. A settle
+    # window that never reached Stage B (ibv_alloc_pd) bills nothing.
+    STAGE = "${src}/modules/mlx/scripts/cluster-pd-stage.sh";
+    SETTLE = "${src}/modules/mlx/scripts/cluster-pd-settle.sh";
+    WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
+    JOIN = "${src}/modules/mlx/scripts/cluster-join.sh";
+    DETACH = "${src}/modules/mlx/scripts/cluster-detach.sh";
+  } "bash ${src}/tests/test-pd-counter-settle.sh && touch $out";
+}

--- a/lib/checks/mlx-cluster-pd-settle-billing.nix
+++ b/lib/checks/mlx-cluster-pd-settle-billing.nix
@@ -4,9 +4,9 @@
 #
 # Duplicates the handful of guard-layer script paths this one check needs
 # rather than importing mlx-cluster-scripts.nix's `guardLayers`: that binding
-# is local to its own file, and reaching across for seven short strings would
-# cost more than repeating them — the same call ./mlx-cluster-recovery.nix and
-# ./mlx-cluster-peer-armed.nix already made.
+# is local to its own file, and reaching across for these ten short strings
+# would cost more than repeating them — the same call ./mlx-cluster-recovery.nix
+# and ./mlx-cluster-peer-armed.nix already made.
 {
   pkgs,
   src,
@@ -42,5 +42,7 @@
     WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
     JOIN = "${src}/modules/mlx/scripts/cluster-join.sh";
     DETACH = "${src}/modules/mlx/scripts/cluster-detach.sh";
+    HELPERS = "${src}/modules/mlx/scripts/cluster-link-helpers.sh";
+    GUARDS = "${src}/modules/mlx/scripts/cluster-link-guards.sh";
   } "bash ${src}/tests/test-pd-counter-settle.sh && touch $out";
 }

--- a/lib/checks/mlx-cluster-peer-armed.nix
+++ b/lib/checks/mlx-cluster-peer-armed.nix
@@ -35,6 +35,7 @@ in
     CAUSE = "${src}/modules/mlx/scripts/cluster-pd-cause.sh";
     RECORD = "${src}/modules/mlx/scripts/cluster-pd-record.sh";
     PEER_STATE = "${src}/modules/mlx/scripts/cluster-peer-state.sh";
+    STAGE = "${src}/modules/mlx/scripts/cluster-pd-stage.sh";
     SETTLE = "${src}/modules/mlx/scripts/cluster-pd-settle.sh";
     HELPERS = "${src}/modules/mlx/scripts/cluster-link-helpers.sh";
   } "bash ${src}/tests/test-peer-armed-gate.sh && touch $out";

--- a/lib/checks/mlx-cluster-recovery.nix
+++ b/lib/checks/mlx-cluster-recovery.nix
@@ -37,6 +37,7 @@
     BOOT_SCOPE = "${src}/modules/mlx/scripts/cluster-boot-scope.sh";
     LEDGER = "${src}/modules/mlx/scripts/cluster-pd-ledger.sh";
     RECORD = "${src}/modules/mlx/scripts/cluster-pd-record.sh";
+    STAGE = "${src}/modules/mlx/scripts/cluster-pd-stage.sh";
     SETTLE = "${src}/modules/mlx/scripts/cluster-pd-settle.sh";
     STATUS = "${src}/modules/mlx/scripts/cluster-rank-status.sh";
     RESTORE = "${src}/modules/mlx/scripts/cluster-serving-restore.sh";

--- a/lib/checks/mlx-cluster-scripts.nix
+++ b/lib/checks/mlx-cluster-scripts.nix
@@ -113,36 +113,6 @@ in
     // guardLayers
   ) "bash ${src}/tests/test-fast-fail-standdown.sh && touch $out";
 
-  # THE CHECK THAT FAILS IF A COUNTER RESET CAN DISCARD LEAKED DOMAINS, OR CAN
-  # BILL DOMAINS THAT WERE NEVER SPENT. mlx-cluster-pd-debt covers the ledger
-  # at the CAP; this covers the hole underneath: the kickstart counter is
-  # session-scoped and five paths reset it (a link cycle, a settled rank,
-  # cluster-join, cluster-detach, an accepted manual clear), but the ledger
-  # was only written at the cap, so a counter at 1 or 2 reset elsewhere left
-  # no trace of the domains those attempts leaked. Asserts the transfer
-  # arithmetic (including the fail-closed direction, where an unguarded
-  # subtraction would compute a NEGATIVE debt and record nothing), that the
-  # transfer is errno-aware (a run whose every outstanding attempt is provably
-  # jaccl Stage-A-only bills nothing — it could not have allocated a
-  # protection domain — while Stage-B or unclassifiable evidence still bills
-  # in full), and pins the call sites as source.
-  mlx-cluster-pd-counter-settle = pkgs.runCommand "check-mlx-cluster-pd-counter-settle" (
-    {
-      nativeBuildInputs = [
-        pkgs.coreutils
-        pkgs.gnugrep
-        pkgs.gnused
-        pkgs.gawk
-      ];
-      RECORD = "${src}/modules/mlx/scripts/cluster-pd-record.sh";
-      SETTLE = "${src}/modules/mlx/scripts/cluster-pd-settle.sh";
-      WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
-      JOIN = "${src}/modules/mlx/scripts/cluster-join.sh";
-      DETACH = "${src}/modules/mlx/scripts/cluster-detach.sh";
-    }
-    // guardLayers
-  ) "bash ${src}/tests/test-pd-counter-settle.sh && touch $out";
-
   # THE CHECK THAT FAILS IF A PD-EXHAUSTION HALT CAN SIT WAITING FOR A HUMAN
   # AGAIN. On 2026-08-01 a host halted and paged correctly, then sat for hours
   # with nothing issuing the reboot its own alert says is required. Asserts:

--- a/lib/checks/mlx-cluster-scripts.nix
+++ b/lib/checks/mlx-cluster-scripts.nix
@@ -25,6 +25,10 @@ let
     BOOT_SCOPE = "${src}/modules/mlx/scripts/cluster-boot-scope.sh";
     LEDGER = "${src}/modules/mlx/scripts/cluster-pd-ledger.sh";
     CAUSE = "${src}/modules/mlx/scripts/cluster-pd-cause.sh";
+    # jaccl Stage-A/Stage-B classifier. fast_fail_standdown (cluster-link-guards.sh
+    # below) calls it; a GUARDS-sourcing test that never sourced this too would
+    # fail with "command not found" the moment it actually calls that function.
+    STAGE = "${src}/modules/mlx/scripts/cluster-pd-stage.sh";
     HELPERS = "${src}/modules/mlx/scripts/cluster-link-helpers.sh";
     GUARDS = "${src}/modules/mlx/scripts/cluster-link-guards.sh";
     PEER_STATE = "${src}/modules/mlx/scripts/cluster-peer-state.sh";
@@ -109,14 +113,19 @@ in
     // guardLayers
   ) "bash ${src}/tests/test-fast-fail-standdown.sh && touch $out";
 
-  # THE CHECK THAT FAILS IF A COUNTER RESET CAN DISCARD LEAKED DOMAINS.
-  # mlx-cluster-pd-debt covers the ledger at the CAP; this covers the hole
-  # underneath: the kickstart counter is session-scoped and four paths reset
-  # it, but the ledger was only written at the cap, so a counter at 1 or 2
-  # reset by a link cycle, a settled rank or cluster-join left no trace of the
-  # domains those attempts leaked. Asserts the transfer arithmetic (including
-  # the fail-closed direction, where an unguarded subtraction would compute a
-  # NEGATIVE debt and record nothing) and pins the call sites as source.
+  # THE CHECK THAT FAILS IF A COUNTER RESET CAN DISCARD LEAKED DOMAINS, OR CAN
+  # BILL DOMAINS THAT WERE NEVER SPENT. mlx-cluster-pd-debt covers the ledger
+  # at the CAP; this covers the hole underneath: the kickstart counter is
+  # session-scoped and five paths reset it (a link cycle, a settled rank,
+  # cluster-join, cluster-detach, an accepted manual clear), but the ledger
+  # was only written at the cap, so a counter at 1 or 2 reset elsewhere left
+  # no trace of the domains those attempts leaked. Asserts the transfer
+  # arithmetic (including the fail-closed direction, where an unguarded
+  # subtraction would compute a NEGATIVE debt and record nothing), that the
+  # transfer is errno-aware (a run whose every outstanding attempt is provably
+  # jaccl Stage-A-only bills nothing — it could not have allocated a
+  # protection domain — while Stage-B or unclassifiable evidence still bills
+  # in full), and pins the call sites as source.
   mlx-cluster-pd-counter-settle = pkgs.runCommand "check-mlx-cluster-pd-counter-settle" (
     {
       nativeBuildInputs = [
@@ -129,6 +138,7 @@ in
       SETTLE = "${src}/modules/mlx/scripts/cluster-pd-settle.sh";
       WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
       JOIN = "${src}/modules/mlx/scripts/cluster-join.sh";
+      DETACH = "${src}/modules/mlx/scripts/cluster-detach.sh";
     }
     // guardLayers
   ) "bash ${src}/tests/test-pd-counter-settle.sh && touch $out";

--- a/modules/mlx/cluster-cli-env.nix
+++ b/modules/mlx/cluster-cli-env.nix
@@ -21,6 +21,7 @@
   pdDebtFile,
   apiUrl,
   modelServerProcessPattern,
+  rankErrorLog,
 }:
 let
   # The CLUSTER RANK process pattern — a different fact from
@@ -46,6 +47,12 @@ let
     # different files.
     CLUSTER_PD_DEBT_FILE = pdDebtFile;
     CLUSTER_PD_DEBT_MAX = toString ncfg.maxKickstarts;
+    # The rank's own StandardErrorPath — same file the watcher carries (see
+    # cluster-watcher-env.nix). pd_debt_settle_counter (cluster-pd-settle.sh)
+    # reads it via rank_failure_stage to tell a Stage-A TCP-bootstrap death,
+    # which cannot have leaked a protection domain, from a Stage-B one, which
+    # already has, before billing either command's counter-reset to the ledger.
+    CLUSTER_RANK_ERROR_LOG = rankErrorLog;
     # Measured device max_pd (11 here). Both commands report debt as a fraction
     # of it — "2 of 11 device protection domains consumed until reboot" — since
     # a bare count hides how small the pool actually is.

--- a/modules/mlx/cluster-mode.nix
+++ b/modules/mlx/cluster-mode.nix
@@ -55,11 +55,9 @@ let
   stateFile = "${config.home.homeDirectory}/Library/Application Support/mlx-cluster/link-state";
   # Ledger of RDMA protection domains leaked during the current boot: written by
   # cluster-detach when it must SIGKILL, read by the watcher's start guard and by
-  # cluster-join. Defined ONCE, here, because a writer and a reader that each
-  # derive the path are a writer and a reader on different files. Not a "marker":
-  # a link cycle, a manual clear and cluster-join all reset the halt state, and
-  # none of them returns a protection domain — only a reboot does, and the ledger
-  # is boot-scoped so a reboot is exactly what clears it.
+  # cluster-join. Defined ONCE, here — a writer and a reader that each derive the
+  # path are a writer and a reader on different files. Boot-scoped: only a
+  # reboot clears it (see cluster-pd-ledger.sh for why).
   pdDebtFile = "${config.home.homeDirectory}/Library/Application Support/mlx-cluster/pd-debt";
   # Written by the rank launcher at start (not a nix-managed file — its content
   # depends on which physical Thunderbolt port has the cable).
@@ -142,6 +140,7 @@ let
       pdDebtFile
       apiUrl
       modelServerProcessPattern
+      rankErrorLog
       ;
   };
 

--- a/modules/mlx/cluster-script-layers.nix
+++ b/modules/mlx/cluster-script-layers.nix
@@ -41,6 +41,11 @@
     # failure rather than dead code.
     ./scripts/cluster-pd-cause.sh
     ./scripts/cluster-pd-record.sh
+    # jaccl Stage-A/Stage-B classifier. Ahead of cluster-pd-settle.sh, which
+    # calls it, and of cluster-link-guards.sh below, whose fast_fail_standdown
+    # also does — see that file's own header for why it is its own layer
+    # rather than living in either consumer.
+    ./scripts/cluster-pd-stage.sh
     ./scripts/cluster-pd-settle.sh
     ./scripts/cluster-link-helpers.sh
     ./scripts/cluster-serving-restore.sh
@@ -101,6 +106,8 @@
     ./scripts/cluster-boot-scope.sh
     ./scripts/cluster-pd-ledger.sh
     ./scripts/cluster-pd-record.sh
+    # See the watcher set above for why this is its own layer.
+    ./scripts/cluster-pd-stage.sh
     ./scripts/cluster-pd-settle.sh
     ./scripts/cluster-link-locate.sh
     ./scripts/cluster-link-repair.sh
@@ -133,6 +140,8 @@
     # on both its exits, so a failed detach cannot leave the next session
     # part-spent. Settling rather than deleting is what keeps that from
     # laundering attempts whose domains are not yet on the ledger.
+    # See the watcher set above for why this is its own layer.
+    ./scripts/cluster-pd-stage.sh
     ./scripts/cluster-pd-settle.sh
     ./scripts/cluster-link-locate.sh
     ./scripts/cluster-serving-restore.sh

--- a/modules/mlx/scripts/cluster-detach.sh
+++ b/modules/mlx/scripts/cluster-detach.sh
@@ -175,9 +175,12 @@ release_session() {
   local cause
   cause="$(cat "$state_dir/rank-halt-latched" 2> /dev/null || echo '')"
   cause="${cause%%[[:space:]]*}"
+  # $7/$8: same run-start byte-offset marker the watcher wrote — see
+  # cluster-join.sh's identical settle call for why this needs no writer here.
   pd_debt_settle_counter "${CLUSTER_PD_DEBT_FILE:-}" "$state_dir/rank-kickstarts" 0 \
     "cluster-detach" "attempts outstanding when cluster-detach ended the session" \
-    "${cause:-cluster-detach}"
+    "${cause:-cluster-detach}" "${CLUSTER_RANK_ERROR_LOG:-}" \
+    "$state_dir/rank-error-log-session-offset"
 
   if /bin/launchctl print "gui/$uid/${CLUSTER_RANK_LABEL}" > /dev/null 2>&1; then
     echo "cluster-detach: $CLUSTER_RANK_LABEL already loaded (idle); nothing to bootstrap"

--- a/modules/mlx/scripts/cluster-join.sh
+++ b/modules/mlx/scripts/cluster-join.sh
@@ -403,8 +403,15 @@ fi
 # pushes the ledger TO the cap, the watcher halts a tick later with cause
 # pd-debt-exhausted. That is the ledger working, not a stale marker.
 if [ -f "$halt_file" ] || [ -f "$halt_latch_file" ]; then
+  # $7/$8: the same run-start byte-offset marker the watcher wrote at the
+  # outstanding run's first kickstart (state_dir is derived identically here
+  # and there — one path, one writer, one reader per run). Lets the settle
+  # skip billing a run whose every attempt was provably Stage-A-only (jaccl
+  # TCP bootstrap, no protection domain could have been allocated) — see
+  # pd_debt_settle_counter and rank_failure_stage (./cluster-pd-stage.sh).
   pd_debt_settle_counter "${CLUSTER_PD_DEBT_FILE:-}" "$kicks_file" 0 "cluster-join" \
-    "attempts outstanding when cluster-join reset the session"
+    "attempts outstanding when cluster-join reset the session" "" \
+    "${CLUSTER_RANK_ERROR_LOG:-}" "$state_dir/rank-error-log-session-offset"
   rm -f "$halt_file" "$halt_latch_file"
   echo "cluster-join: cleared stale rank-halted latch"
 fi

--- a/modules/mlx/scripts/cluster-link-guards.sh
+++ b/modules/mlx/scripts/cluster-link-guards.sh
@@ -597,83 +597,14 @@ rank_start_preconditions_ok() {
 # to proceed. Unlike the pd/mem halt helpers this is a BRANCH, not a composed
 # always-0 rung, because its whole job is to replace the start.
 #
-# STAGE A (TCP bootstrap) vs STAGE B (RDMA queue-pair bring-up) — jaccl brings a
-# cluster up in these two distinct stages, confirmed from libjaccl.dylib's own
-# error strings. Stage A: "Connection attempt ", "Couldn't connect (error: N)",
-# "Couldn't listen", "Accept failed". Stage B, reached only once A succeeds:
-# "...RTR failed with errno N", "...RTS failed with errno N", ibv_query_gid.
-# ibv_alloc_pd — the call that actually consumes a protection domain — lives in
-# Stage B, so a Stage-A-only death structurally could not have leaked one.
+# rank_failure_stage (Stage A / Stage B classification from the rank's own
+# stderr) moved to ./cluster-pd-stage.sh: pd_debt_settle_counter needs it too
+# (cluster-pd-settle.sh), and that function is also called from cluster-join
+# and cluster-detach, neither of which carries this file. Concatenated ahead
+# of this one wherever both are used — see that file's own header.
 #
-# Classifies from the rank's own stderr, SLICED FROM AN OFFSET rather than
-# tailed by line count. launchd's StandardErrorPath appends across every rank
-# restart, so a bare tail always includes whatever the PREVIOUS attempt wrote —
-# and a bare-line-count tail can still be entirely stale prior-attempt output
-# if this attempt died leaving no stderr of its own (e.g. SIGKILLed mid-init,
-# after ibv_alloc_pd already ran). Reading that stale Stage-A tail as THIS
-# attempt's evidence would free a death that may have actually reached Stage B
-# — exactly the unclassifiable-treated-as-free hole this function exists to
-# close, just entered through staleness instead of pattern-matching. The
-# caller writes the log's byte size as $2 right before launching the attempt
-# (see cluster-link-watcher.sh); this reads only what was appended since.
-#
-# ONLY TERMINAL failure strings count as Stage A ("Couldn't connect (error:",
-# "Couldn't listen", "Accept failed") — never the bare "Connection attempt "
-# retry line. A rank that got PAST Stage A and died silently in Stage B before
-# printing an RTR/RTS line still has its own "Connection attempt" lines in the
-# appended region (from its own successful bootstrap); matching on those alone
-# would misclassify it as Stage-A-only. No terminal string from either stage
-# present classifies "unknown", not "stage-a".
-#
-# FAILS CLOSED: no path, an unreadable log, no offset marker, an offset at or
-# past the log's current size (nothing new appended — the stale-evidence case
-# above), or a slice matching neither stage's terminal strings all classify
-# "unknown" — the caller must treat that the same as a confirmed Stage-B
-# failure, because an unclassifiable failure being treated as free is exactly
-# how a domain leak goes unbounded.
-#
-# $1 rank stderr log path, $2 byte-offset marker file (baseline captured at
-# this attempt's kickstart). Prints "stage-a" | "stage-b" | "unknown".
-rank_failure_stage() {
-  local log="$1" offset_file="$2" offset size appended
-  if [ -z "$log" ] || [ ! -r "$log" ]; then
-    echo unknown
-    return
-  fi
-  # wc -c right-justifies with leading spaces on macOS (BSD) but not on Linux
-  # (GNU) — stripped here rather than relied on at every writer, so a marker
-  # written on either platform reads back the same way.
-  offset=0
-  if [ -n "$offset_file" ] && [ -r "$offset_file" ]; then
-    offset="$(cat "$offset_file" 2> /dev/null || echo 0)"
-    offset="${offset//[[:space:]]/}"
-    case "$offset" in
-      '' | *[!0-9]*) offset=0 ;;
-    esac
-  fi
-  size="$(wc -c < "$log" 2> /dev/null || echo 0)"
-  size="${size//[[:space:]]/}"
-  case "$size" in
-    '' | *[!0-9]*) size=0 ;;
-  esac
-  if [ "$offset" -ge "$size" ]; then
-    echo unknown
-    return
-  fi
-  appended="$(tail -c "+$((offset + 1))" "$log" 2> /dev/null || true)"
-  if printf '%s\n' "$appended" | grep -qE "RTR failed with errno|RTS failed with errno|ibv_query_gid"; then
-    echo stage-b
-    return
-  fi
-  if printf '%s\n' "$appended" | grep -qE "Couldn't connect \(error:|Couldn't listen|Accept failed"; then
-    echo stage-a
-    return
-  fi
-  echo unknown
-}
-
 # $1 halt marker, $2 latch, $3 strike counter, $4 attempts so far, $5 started
-# marker, $6 rank-stderr byte-offset marker (see rank_failure_stage above).
+# marker, $6 rank-stderr byte-offset marker (see rank_failure_stage, above).
 fast_fail_standdown() {
   local halt_file="$1" latch_file="$2" strike_file="$3" kicks="$4" started_file="$5"
   local log_offset_file="${6:-}"

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -107,13 +107,25 @@ peer_session_strikes_file="$state_dir/peer-session-strikes"
 # verdict as the counter above, for the rank that never lives long enough to
 # reach it. Session-scoped like every other strike counter here.
 fast_fail_strikes_file="$state_dir/rank-fast-fails"
-# Byte size of CLUSTER_RANK_ERROR_LOG captured right before each kickstart, so
+# Byte size of CLUSTER_RANK_ERROR_LOG captured right before EACH kickstart, so
 # fast_fail_standdown's stage classifier reads only what THIS attempt appended
 # — StandardErrorPath accumulates across every rank restart, so a bare tail
 # would otherwise still be reading the PREVIOUS attempt's evidence on a death
 # that left no stderr of its own. See rank_failure_stage in
-# cluster-link-guards.sh.
+# ./cluster-pd-stage.sh.
 rank_log_offset_file="$state_dir/rank-error-log-offset"
+# Byte size of CLUSTER_RANK_ERROR_LOG captured ONCE, at the FIRST kickstart of
+# an outstanding run — unlike rank_log_offset_file above, never overwritten by
+# a later kickstart in the same run. pd_debt_settle_counter bills the whole
+# run's outstanding attempts at once (kicks - vindicated), so classifying it
+# needs the window from the run's START, not just its latest attempt: an
+# earlier attempt in the same run could have reached Stage B and leaked a real
+# domain while a later one only hit Stage A, and reading just the latest
+# attempt's tail would misclassify the whole run as free on that later
+# attempt's evidence alone — the exact staleness bug rank_log_offset_file
+# exists to prevent, one level up. Settled (and cleared) alongside kicks_file
+# by pd_debt_settle_counter itself.
+session_log_offset_file="$state_dir/rank-error-log-session-offset"
 # Consecutive ticks the probe has failed while the link was ALREADY down. Used
 # only to make a permanently-failing probe audible on a cadence — see the
 # else-branch of the probe below.
@@ -375,7 +387,8 @@ if [ "$cur" = "up" ]; then
       # losses off, which is how a boot could reach exhaustion with the ledger
       # still reading empty.
       pd_debt_settle_counter "$pd_debt_file" "$kicks_file" 1 "rank-settled" \
-        "attempts that failed before the rank that settled"
+        "attempts that failed before the rank that settled" "" \
+        "${CLUSTER_RANK_ERROR_LOG:-}" "$session_log_offset_file"
       rm -f "$halt_file" "$halt_latch_file"
     fi
     # PAIR-WIDE STANDDOWN. A jaccl group cannot re-admit a rank, so a rank whose
@@ -648,7 +661,8 @@ if [ "$cur" = "up" ]; then
       # billed to the ledger twice. The counter now holds only what is still
       # unrecorded, which is what makes every other reset site safe to settle.
       pd_debt_settle_counter "$pd_debt_file" "$kicks_file" 0 "rank-start-failures" \
-        "$kicks consecutive failed distributed inits, one protection domain each"
+        "$kicks consecutive failed distributed inits, one protection domain each" "" \
+        "${CLUSTER_RANK_ERROR_LOG:-}" "$session_log_offset_file"
       # Every attempt was preceded by quiesce_normal_serving, which boots the
       # standalone model server out. Halting without undoing that leaves the
       # host serving NOTHING for as long as the link stays up, because the only
@@ -694,6 +708,15 @@ if [ "$cur" = "up" ]; then
       # correct — everything the attempt writes is "new".
       wc -c < "${CLUSTER_RANK_ERROR_LOG:-/dev/null}" 2> /dev/null > "$rank_log_offset_file" ||
         printf '0\n' > "$rank_log_offset_file"
+      # session_log_offset_file gets the SAME baseline, but ONLY on the run's
+      # FIRST kickstart (kicks was 0 going in) — every later kickstart in the
+      # same run leaves it alone, so it keeps describing where the run started
+      # rather than sliding forward with each attempt. See its own definition
+      # above for why pd_debt_settle_counter needs the whole run, not the
+      # latest attempt.
+      if [ "$kicks" -le 0 ]; then
+        cp -f "$rank_log_offset_file" "$session_log_offset_file"
+      fi
       # COUNT LAUNCHED ATTEMPTS, NOT ISSUED COMMANDS. The counter's stated
       # invariant (cluster-pd-settle.sh) is "launched attempts whose
       # protection-domain cost is not yet on the ledger", and every reset path
@@ -746,7 +769,7 @@ elif [ "$prev" = "up" ]; then
   link_cycle_cause="${link_cycle_cause%%[[:space:]]*}"
   pd_debt_settle_counter "$pd_debt_file" "$kicks_file" 0 "link-cycle" \
     "attempts outstanding when the link went down and reset the session" \
-    "${link_cycle_cause:-link-cycle}"
+    "${link_cycle_cause:-link-cycle}" "${CLUSTER_RANK_ERROR_LOG:-}" "$session_log_offset_file"
   rm -f "$halt_file" "$halt_latch_file" "$started_file" "$ready_file" \
     "$warm_file" "$warm_fails_file" "$mem_dwell_file" "$fast_fail_strikes_file" \
     "$rank_log_offset_file" "$soak_busy_skips_file"

--- a/modules/mlx/scripts/cluster-pd-ledger.sh
+++ b/modules/mlx/scripts/cluster-pd-ledger.sh
@@ -59,6 +59,14 @@ pd_debt_count() {
         if (!haveDom && $i ~ /^domains=/) { dom = substr($i, 9); haveDom = 1 }
       }
       if (boot != "" && rec != "" && rec != "unknown" && rec != boot) next
+      # SUM ONLY, NEVER SUBTRACT. domains= must match [0-9]+ or it counts as 1
+      # (see FAIL CLOSED above) — a NEGATIVE value fails that pattern and is
+      # charged as +1, the opposite of a credit. There is therefore no way to
+      # relieve an already-recorded charge within the same boot: an append-only
+      # correction (domains=0, same shape as a 2026-08-08 retraction) documents
+      # the finding but adds zero, it does not subtract from what is already
+      # summed. Only current_boot_epoch changing (a reboot) clears the total
+      # for a boot.
       n += (dom ~ /^[0-9]+$/) ? dom + 0 : 1
     }
     END { print n + 0 }

--- a/modules/mlx/scripts/cluster-pd-settle.sh
+++ b/modules/mlx/scripts/cluster-pd-settle.sh
@@ -38,23 +38,41 @@
 # WHY IT COUNTS ATTEMPTS AS LEAKS. The counter is incremented only after an
 # actual `launchctl kickstart` (a precondition failure consumes no attempt, by
 # design), and the watcher only kickstarts when no rank is running — so an
-# attempt that was followed by another attempt necessarily failed, and a failed
-# `mx.distributed.init()` leaks one domain. $vindicated is subtracted for the
-# one caller that has evidence a rank actually settled: there, the final attempt
-# succeeded and holds its domain live rather than having leaked it.
+# attempt that was followed by another attempt necessarily failed. $vindicated
+# is subtracted for the one caller that has evidence a rank actually settled:
+# there, the final attempt succeeded and holds its domain live rather than
+# having leaked it.
+#
+# NOT EVERY FAILED ATTEMPT ACTUALLY LEAKED, THOUGH. jaccl brings a cluster up in
+# two stages (see rank_failure_stage, ./cluster-pd-stage.sh) and ibv_alloc_pd —
+# the call that actually consumes a protection domain — lives in the second one.
+# An attempt that died in the first (TCP bootstrap: an absent or not-yet-armed
+# peer, jaccl's fixed ~15s connect budget) never reached it, and billing it
+# anyway protects a budget those attempts could not have spent — the reverse of
+# what the fail-closed rule below is for. So $7/$8, if the caller has them, are
+# used to check the OUTSTANDING RUN — from $8's baseline to the end of $7 —
+# before recording anything: if every attempt in it is provably stage-A-only,
+# nothing is billed. Any Stage-B evidence anywhere in that window, or no
+# evidence either caller could classify, still bills the full count, unchanged.
 #
 # Fail-closed on a malformed counter, matching pd_debt_count: an unreadable or
 # non-numeric count biases toward recording MORE debt, never less, because
 # under-counting is the only direction that lets a start proceed that should
-# not have.
+# not have. The stage check above is the same bias in a different shape — it
+# can only ever reduce a bill to zero on POSITIVE evidence, never partially.
 #
 # $1 ledger file, $2 kickstart counter, $3 vindicated attempts (0 or 1),
 # $4 source token, $5 free-text detail, $6 cause token (optional; defaults to
-# $4 — see pd_debt_record for why the mechanism and the reason are two fields).
+# $4 — see pd_debt_record for why the mechanism and the reason are two fields),
+# $7 rank stderr log path (optional), $8 byte-offset marker for the start of
+# this outstanding run (optional; see cluster-link-watcher.sh — written once
+# per run, at its first kickstart, not overwritten by later ones in the same
+# run). $7/$8 absent classifies "unknown" (rank_failure_stage's own fail-closed
+# default), which bills exactly as if this file predated the stage check.
 pd_debt_settle_counter() {
   local debt_file="$1" kicks_file="$2" vindicated="$3" source="$4" detail="$5"
-  local cause="${6:-$4}"
-  local kicks leaked
+  local cause="${6:-$4}" rank_log="${7:-}" session_offset_file="${8:-}"
+  local kicks leaked stage
   kicks=0
   if [ -n "$kicks_file" ] && [ -f "$kicks_file" ]; then
     kicks="$(cat "$kicks_file" 2> /dev/null || echo 0)"
@@ -66,6 +84,13 @@ pd_debt_settle_counter() {
     '' | *[!0-9]*) vindicated=0 ;;
   esac
   leaked=$((kicks - vindicated))
+  if [ "$leaked" -gt 0 ]; then
+    stage="$(rank_failure_stage "$rank_log" "$session_offset_file")"
+    if [ "$stage" = "stage-a" ]; then
+      echo "cluster: $leaked attempt(s) outstanding on $source classify stage-a (TCP bootstrap only, across the whole outstanding run) — no protection domain could have been allocated; NOT billed to the ledger" >&2
+      leaked=0
+    fi
+  fi
   if [ "$leaked" -gt 0 ]; then
     pd_debt_record "$debt_file" "$leaked" "$source" "$detail" "$cause"
     # A SILENT TRANSFER WOULD DEFEAT THE POINT. This runs on the reset paths —
@@ -82,7 +107,10 @@ pd_debt_settle_counter() {
   fi
   # Cleared LAST and unconditionally: the transfer is the only thing that may
   # precede the reset, and a reset that failed to happen would re-record the
-  # same attempts on the next tick.
+  # same attempts on the next tick. session_offset_file goes with it — it
+  # describes THIS run, which just ended one way or the other; the next run's
+  # first kickstart writes a fresh one.
   [ -n "$kicks_file" ] && rm -f "$kicks_file"
+  [ -n "$session_offset_file" ] && rm -f "$session_offset_file"
   return 0
 }

--- a/modules/mlx/scripts/cluster-pd-stage.sh
+++ b/modules/mlx/scripts/cluster-pd-stage.sh
@@ -1,0 +1,104 @@
+# shellcheck shell=bash
+# jaccl failure-stage classifier — SHARED by every consumer that bills or
+# gates against the RDMA protection-domain budget.
+#
+# Split into its own file (rather than living in cluster-link-guards.sh, its
+# original home) because it has TWO consumers on TWO different privilege
+# layers: fast_fail_standdown (watcher-only, cluster-link-guards.sh) and
+# pd_debt_settle_counter (watcher AND cluster-join AND cluster-detach,
+# cluster-pd-settle.sh). cluster-join and cluster-detach never carry
+# cluster-link-guards.sh — join and detach have no business starting or
+# gating a rank, so they get none of its rank-start preconditions — but both
+# call pd_debt_settle_counter, and shellcheck's SC2329 fails a build the
+# moment a function is shipped into a script that cannot reach it. This file
+# is therefore the smallest thing all three concatenations can share, per the
+# per-consumer layering rule in ./cluster-script-layers.nix.
+#
+# Concatenated ahead of cluster-pd-settle.sh (and, in the watcher, ahead of
+# cluster-link-guards.sh too) in every layer that uses it.
+
+# STAGE A (TCP bootstrap) vs STAGE B (RDMA queue-pair bring-up) — jaccl brings a
+# cluster up in these two distinct stages, confirmed from libjaccl.dylib's own
+# error strings. Stage A: "Connection attempt ", "Couldn't connect (error: N)",
+# "Couldn't listen", "Accept failed". Stage B, reached only once A succeeds:
+# "...RTR failed with errno N", "...RTS failed with errno N", ibv_query_gid.
+# ibv_alloc_pd — the call that actually consumes a protection domain — lives in
+# Stage B, so a Stage-A-only death structurally could not have leaked one.
+#
+# Classifies from the rank's own stderr, SLICED FROM AN OFFSET rather than
+# tailed by line count. launchd's StandardErrorPath appends across every rank
+# restart, so a bare tail always includes whatever the PREVIOUS attempt wrote —
+# and a bare-line-count tail can still be entirely stale prior-attempt output
+# if this attempt died leaving no stderr of its own (e.g. SIGKILLed mid-init,
+# after ibv_alloc_pd already ran). Reading that stale Stage-A tail as THIS
+# attempt's evidence would free a death that may have actually reached Stage B
+# — exactly the unclassifiable-treated-as-free hole this function exists to
+# close, just entered through staleness instead of pattern-matching. Each
+# caller writes its own byte-size marker as $2 right before the window it
+# wants classified begins (a single kickstart for fast_fail_standdown, an
+# entire unsettled run of them for pd_debt_settle_counter); this reads only
+# what was appended since.
+#
+# ONLY TERMINAL failure strings count as Stage A ("Couldn't connect (error:",
+# "Couldn't listen", "Accept failed") — never the bare "Connection attempt "
+# retry line. A rank that got PAST Stage A and died silently in Stage B before
+# printing an RTR/RTS line still has its own "Connection attempt" lines in the
+# appended region (from its own successful bootstrap); matching on those alone
+# would misclassify it as Stage-A-only. No terminal string from either stage
+# present classifies "unknown", not "stage-a".
+#
+# FAILS CLOSED: no log path, an unreadable log, an offset marker path that was
+# GIVEN but is missing or unreadable (a caller that names a marker meant one to
+# be there — its absence is suspicious, not "read from the start"), an offset
+# at or past the log's current size (nothing new appended — the stale-evidence
+# case above), or a slice matching neither stage's terminal strings all
+# classify "unknown" — every caller must treat that the same as a confirmed
+# Stage-B failure, because an unclassifiable failure being treated as free is
+# exactly how a domain leak goes unbounded. A caller that passes NO marker
+# path at all ($2 empty) gets offset 0 — "classify the whole log" — which is a
+# deliberate, different default for a caller that never scopes the window.
+#
+# $1 rank stderr log path, $2 byte-offset marker file (baseline captured by
+# the caller at the start of the window being classified; empty = classify
+# from the start of the log). Prints "stage-a" | "stage-b" | "unknown".
+rank_failure_stage() {
+  local log="$1" offset_file="$2" offset size appended
+  if [ -z "$log" ] || [ ! -r "$log" ]; then
+    echo unknown
+    return
+  fi
+  offset=0
+  if [ -n "$offset_file" ]; then
+    if [ ! -r "$offset_file" ]; then
+      echo unknown
+      return
+    fi
+    # wc -c right-justifies with leading spaces on macOS (BSD) but not on
+    # Linux (GNU) — stripped here rather than relied on at every writer, so a
+    # marker written on either platform reads back the same way.
+    offset="$(cat "$offset_file" 2> /dev/null || echo 0)"
+    offset="${offset//[[:space:]]/}"
+    case "$offset" in
+      '' | *[!0-9]*) offset=0 ;;
+    esac
+  fi
+  size="$(wc -c < "$log" 2> /dev/null || echo 0)"
+  size="${size//[[:space:]]/}"
+  case "$size" in
+    '' | *[!0-9]*) size=0 ;;
+  esac
+  if [ "$offset" -ge "$size" ]; then
+    echo unknown
+    return
+  fi
+  appended="$(tail -c "+$((offset + 1))" "$log" 2> /dev/null || true)"
+  if printf '%s\n' "$appended" | grep -qE "RTR failed with errno|RTS failed with errno|ibv_query_gid"; then
+    echo stage-b
+    return
+  fi
+  if printf '%s\n' "$appended" | grep -qE "Couldn't connect \(error:|Couldn't listen|Accept failed"; then
+    echo stage-a
+    return
+  fi
+  echo unknown
+}

--- a/tests/test-fast-fail-standdown.sh
+++ b/tests/test-fast-fail-standdown.sh
@@ -29,8 +29,9 @@
 # output must not be read as this attempt's evidence.
 #
 # WHAT IS REAL AND WHAT IS NOT:
-#   REAL   — fast_fail_standdown, halt_write and peer_rendezvous_session, sourced
-#            from the shipped scripts in the module's own concatenation order.
+#   REAL   — fast_fail_standdown, rank_failure_stage, halt_write and
+#            peer_rendezvous_session, sourced from the shipped scripts in the
+#            module's own concatenation order.
 #   STUB   — sysctl (deterministic boot epoch for the halt marker), netstat (the
 #            seam peer_rendezvous_session already exposes), and the three
 #            side-effect calls the standdown makes on the host: set_wired_limit,
@@ -64,6 +65,11 @@ export CLUSTER_ALERT_URL_FILE="$state_dir/alert-url-absent"
 source "${BOOT_SCOPE:?set BOOT_SCOPE to cluster-boot-scope.sh}"
 # shellcheck disable=SC1090
 source "${HELPERS:?set HELPERS to cluster-link-helpers.sh}"
+# rank_failure_stage now lives in its own layer (cluster-pd-stage.sh) — shared
+# with cluster-join and cluster-detach, which never carry cluster-link-guards.sh
+# at all. See that file's own header.
+# shellcheck disable=SC1090
+source "${STAGE:?set STAGE to cluster-pd-stage.sh}"
 # shellcheck disable=SC1090
 source "${GUARDS:?set GUARDS to cluster-link-guards.sh}"
 # The two layers the shipped watcher concatenates AROUND the guards: the

--- a/tests/test-pd-counter-settle.sh
+++ b/tests/test-pd-counter-settle.sh
@@ -24,10 +24,19 @@
 # protection-domain cost is NOT yet in the ledger. Every reset transfers rather
 # than discards, so no path can launder debt out of the accounting.
 #
+# ALSO ASSERTED (2026-08-16): a transfer that consulted only "how many attempts"
+# and never "did any of them reach the call that actually allocates a domain"
+# billed every jaccl TCP-bootstrap-only run as if it had leaked — the mechanism
+# could not tell a Stage-A death (structurally cannot allocate a protection
+# domain) from a Stage-B one (already has). $7/$8 let it check: a run whose
+# outstanding attempts are ALL provably Stage-A-only bills nothing; any Stage-B
+# evidence, or none either caller could classify, still bills the full count.
+#
 # WHAT IS REAL AND WHAT IS NOT:
-#   REAL  — pd_debt_settle_counter, pd_debt_record and pd_debt_count are sourced
-#           from the shipped scripts in the module's own concatenation order and
-#           called exactly as the watcher, cluster-join and the guards call them.
+#   REAL  — pd_debt_settle_counter, pd_debt_record, pd_debt_count and
+#           rank_failure_stage are sourced from the shipped scripts in the
+#           module's own concatenation order and called exactly as the watcher,
+#           cluster-join, cluster-detach and the guards call them.
 #   STUB  — sysctl only, so the boot epoch is deterministic. Nothing in the
 #           decision under test is stubbed.
 #   SOURCE — part 3 reads the shipped scripts as text. Behaviour tests cannot
@@ -38,8 +47,8 @@
 #           reporting success), so the call sites are pinned as text.
 #
 # Usage:
-#   BOOT_SCOPE=… LEDGER=… RECORD=… SETTLE=… WATCHER=… JOIN=… GUARDS=… \
-#     bash test-pd-counter-settle.sh
+#   BOOT_SCOPE=… LEDGER=… RECORD=… STAGE=… SETTLE=… WATCHER=… JOIN=… DETACH=… \
+#     GUARDS=… bash test-pd-counter-settle.sh
 set -o errexit -o nounset -o pipefail
 
 state_dir="$(mktemp -d)"
@@ -71,6 +80,8 @@ export CLUSTER_SYSCTL_BIN
 . "${LEDGER:?LEDGER is required}"
 # shellcheck source=/dev/null
 . "${RECORD:?RECORD is required}"
+# shellcheck source=/dev/null
+. "${STAGE:?STAGE is required}"
 # shellcheck source=/dev/null
 . "${SETTLE:?SETTLE is required}"
 # shellcheck source=/dev/null
@@ -152,6 +163,74 @@ pd_debt_settle_counter "$debt_file" "$kicks_file" 0 link-cycle "nothing outstand
 check "it succeeds" 0 "$rc"
 check "and records nothing" 0 "$(pd_debt_count "$debt_file")"
 
+echo "1b. the transfer is ERRNO-AWARE — a provably Stage-A-only run bills nothing:"
+# ibv_alloc_pd lives in Stage B (RDMA queue-pair bring-up). A run whose every
+# outstanding attempt only ever exhausted jaccl's TCP-bootstrap connect retry
+# (Stage A) never reached it, so billing it protects a protection-domain
+# budget those attempts could not have spent — the mechanism that produced a
+# real fabricated ledger entry against a boot whose worker sat in SYN_SENT for
+# every attempt, never once established, with zero trace on the coordinator.
+rank_log="$state_dir/cluster-rank.error.log"
+offset_file="$state_dir/rank-error-log-session-offset"
+reset_state
+printf '2\n' > "$kicks_file"
+cat > "$rank_log" <<'EOF'
+[jaccl] Connection attempt 0 waiting 1000 ms
+[jaccl] Connection attempt 1 waiting 2000 ms
+[jaccl] Connection attempt 2 waiting 4000 ms
+[jaccl] Connection attempt 3 waiting 8000 ms
+RuntimeError: [jaccl] Couldn't connect (error: 60)
+EOF
+printf '0\n' > "$offset_file"
+pd_debt_settle_counter "$debt_file" "$kicks_file" 0 cluster-join \
+  "attempts outstanding when cluster-join reset the session" "" "$rank_log" "$offset_file"
+check "a stage-a-only run bills nothing" 0 "$(pd_debt_count "$debt_file")"
+check "no ledger entry written at all" missing \
+  "$([ -f "$debt_file" ] && echo present || echo missing)"
+check "the counter is still cleared" missing \
+  "$([ -f "$kicks_file" ] && echo present || echo missing)"
+check "the offset marker goes with it" missing \
+  "$([ -f "$offset_file" ] && echo present || echo missing)"
+
+echo "   ...but ANY Stage-B evidence in the run still bills the full count:"
+# One attempt in the run reaching Stage B is enough: it may have leaked, and
+# there is no per-attempt record to say which one, so the whole outstanding
+# count stays billed — the same fail-closed bias as the malformed-counter case
+# below, just triggered by content instead of a bad number.
+reset_state
+printf '2\n' > "$kicks_file"
+cat > "$rank_log" <<'EOF'
+[jaccl] Changing queue pair to RTR failed with errno 96
+EOF
+printf '0\n' > "$offset_file"
+pd_debt_settle_counter "$debt_file" "$kicks_file" 0 rank-start-failures \
+  "2 consecutive failed distributed inits" "" "$rank_log" "$offset_file"
+check "a stage-b run still bills the full count" 2 "$(pd_debt_count "$debt_file")"
+
+echo "   ...and no log at all bills exactly as before this fix (unknown, not free):"
+reset_state
+printf '2\n' > "$kicks_file"
+pd_debt_settle_counter "$debt_file" "$kicks_file" 0 link-cycle "no log configured" \
+  "" "" ""
+check "an absent log is not treated as stage-a" 2 "$(pd_debt_count "$debt_file")"
+
+echo "   ...and a run that predates this fix (no offset marker at all) bills as before:"
+# A host mid-upgrade, or a run that started before the marker existed, has a
+# log but no offset file. rank_failure_stage's own fail-closed default
+# ("unknown" on an unreadable offset) is what keeps this the SAME behaviour as
+# every call site had before this fix, not a new free pass.
+reset_state
+printf '2\n' > "$kicks_file"
+cat > "$rank_log" <<'EOF'
+[jaccl] Connection attempt 0 waiting 1000 ms
+RuntimeError: [jaccl] Couldn't connect (error: 60)
+EOF
+rm -f "$offset_file"
+pd_debt_settle_counter "$debt_file" "$kicks_file" 0 link-cycle "no offset marker" \
+  "" "$rank_log" "$offset_file"
+check "no offset marker still bills (fail closed)" 2 "$(pd_debt_count "$debt_file")"
+rm -f "$rank_log" "$offset_file"
+
 echo "2. a malformed counter is FAIL-CLOSED — never a free reset:"
 # Under-counting is the only direction that lets a start proceed that should not
 # have, so a vindicated count that is not a number must not be able to subtract.
@@ -228,6 +307,32 @@ check "and does not settle it" 0 \
 # the counter populated is how the same attempts got billed twice.
 check "the cap path no longer records bare" 0 \
   "$(grep -vE '^[[:space:]]*#' "$WATCHER" | grep -c 'pd_debt_record ' || true)"
+
+# ...and each settle call actually PASSES the stage-classification args, not
+# just calls the function. A call site that forgot $7/$8 bills exactly as
+# before this fix while every assertion above still passes — the same "correct
+# function nobody wires up" failure mode part 3's own opening comment names,
+# one call site at a time. -A4 covers each call's line-continuation tail.
+check "the watcher's rank-settled call passes the rank log" 1 \
+  "$(grep -A4 'pd_debt_settle_counter .* 1 "rank-settled"' "$WATCHER" |
+    grep -c 'CLUSTER_RANK_ERROR_LOG' || true)"
+check "the watcher's link-cycle call passes the rank log" 1 \
+  "$(grep -A4 'pd_debt_settle_counter .* 0 "link-cycle"' "$WATCHER" |
+    grep -c 'CLUSTER_RANK_ERROR_LOG' || true)"
+check "the watcher's cap-path call passes the rank log" 1 \
+  "$(grep -A4 'pd_debt_settle_counter .* 0 "rank-start-failures"' "$WATCHER" |
+    grep -c 'CLUSTER_RANK_ERROR_LOG' || true)"
+check "cluster-join's call passes the rank log" 1 \
+  "$(grep -A4 'pd_debt_settle_counter .* 0 "cluster-join"' "$JOIN" |
+    grep -c 'CLUSTER_RANK_ERROR_LOG' || true)"
+check "cluster-detach settles before clearing the session" 1 \
+  "$(grep -vE '^[[:space:]]*#' "${DETACH:?DETACH is required}" |
+    grep -c 'pd_debt_settle_counter ' || true)"
+detach_settle_block="$(grep -vE '^[[:space:]]*#' "$DETACH" | grep -A4 'pd_debt_settle_counter ')"
+check "...naming cluster-detach as the source" 1 \
+  "$(printf '%s\n' "$detach_settle_block" | grep -c '"cluster-detach"' || true)"
+check "...and passing the rank log" 1 \
+  "$(printf '%s\n' "$detach_settle_block" | grep -c 'CLUSTER_RANK_ERROR_LOG' || true)"
 
 echo "4. a halt marker left over from a PREVIOUS boot never suppresses THIS boot's charge:"
 # 2026-08-08 night watch: a stale halt from an earlier boot sat on disk when a

--- a/tests/test-peer-armed-gate.sh
+++ b/tests/test-peer-armed-gate.sh
@@ -22,8 +22,8 @@
 # Peer address is an RFC 5737 documentation address, never a real link address.
 #
 # Usage:
-#   BOOT_SCOPE=... LEDGER=... CAUSE=... RECORD=... PEER_STATE=... \
-#     bash test-peer-armed-gate.sh
+#   BOOT_SCOPE=... LEDGER=... CAUSE=... RECORD=... PEER_STATE=... STAGE=... \
+#     SETTLE=... HELPERS=... bash test-peer-armed-gate.sh
 set -o errexit -o nounset -o pipefail
 
 state_dir="$(mktemp -d)"
@@ -56,6 +56,8 @@ source "${CAUSE:?set CAUSE to cluster-pd-cause.sh}"
 source "${RECORD:?set RECORD to cluster-pd-record.sh}"
 # shellcheck disable=SC1090
 source "${PEER_STATE:?set PEER_STATE to cluster-peer-state.sh}"
+# shellcheck disable=SC1090
+source "${STAGE:?set STAGE to cluster-pd-stage.sh}"
 # shellcheck disable=SC1090
 source "${SETTLE:?set SETTLE to cluster-pd-settle.sh}"
 # halt_write and halt_cause_file — the cross-boot cause record the budget falls

--- a/tests/test-teardown-recovery.sh
+++ b/tests/test-teardown-recovery.sh
@@ -31,8 +31,8 @@
 #            matters here: a bootout AFTER the signal closes no window at all.
 #
 # Usage:
-#   BOOT_SCOPE=… RESTORE=… STATUS=… LEDGER=… RECORD=… SETTLE=… JOIN=… DETACH=… LAYERS=… \
-#     bash test-teardown-recovery.sh
+#   BOOT_SCOPE=… RESTORE=… STATUS=… LEDGER=… RECORD=… STAGE=… SETTLE=… JOIN=… \
+#     DETACH=… LAYERS=… bash test-teardown-recovery.sh
 set -o errexit -o nounset -o pipefail
 
 tmp="$(mktemp -d)"
@@ -85,6 +85,8 @@ source "${BOOT_SCOPE:?set BOOT_SCOPE to cluster-boot-scope.sh}"
 source "${LEDGER:?set LEDGER to cluster-pd-ledger.sh}"
 # shellcheck disable=SC1090
 source "${RECORD:?set RECORD to cluster-pd-record.sh}"
+# shellcheck disable=SC1090
+source "${STAGE:?set STAGE to cluster-pd-stage.sh}"
 # shellcheck disable=SC1090
 source "${SETTLE:?set SETTLE to cluster-pd-settle.sh}"
 # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

- `pd_debt_settle_counter` (the shared function every kickstart-counter
  reset path — watcher, cluster-join, cluster-detach — routes through
  to transfer outstanding attempts onto the boot-scoped protection-domain
  ledger) now classifies the run before billing it. A run whose every
  attempt died in jaccl's Stage A (TCP bootstrap, before `ibv_alloc_pd`
  ever runs) bills nothing; any Stage-B evidence, or nothing classifiable,
  still bills the full count, unchanged.
- Moves the Stage A/B classifier out of the rank-start guard script into
  its own shared file (`modules/mlx/scripts/cluster-pd-stage.sh`) so
  `cluster-join` and `cluster-detach` — which never carry that script —
  can call it too.
- Scopes each settle window to a single outstanding run via a byte-offset
  marker written once at that run's first kickstart, so a stale prior
  attempt's Stage-A tail cannot mask a later Stage-B death in the same run.
- Wires the classifier's dependency into every check derivation and test
  that drives the settle function with a positive kickstart count.

## Test plan

- [x] `tests/test-pd-counter-settle.sh` — new errno-aware settle
      sub-tests (Stage-A-only bills nothing and clears the marker,
      Stage-B evidence still bills in full, no log/no marker still
      fail-closed) plus source-pinning checks for every real call site
- [x] `tests/test-fast-fail-standdown.sh`, `tests/test-teardown-recovery.sh`,
      `tests/test-peer-armed-gate.sh`, `tests/test-pd-debt.sh`,
      `tests/test-rank-start-guards.sh`, `tests/test-watcher-heartbeat.sh`
      all pass unchanged
- [x] `nix fmt`, `deadnix`, `statix` clean; affected check derivations
      (`mlx-cluster-teardown-recovery`, `mlx-cluster-peer-armed`,
      `mlx-cluster-pd-counter-settle`, `mlx-cluster-fast-fail-standdown`)
      evaluate cleanly

Assisted-by: Claude:claude-sonnet-5
https://claude.ai/code/session_01R438Ytsn7PLsnDUUTbexp3