### PR TITLE
fix(mlx): quiesce standalone serving before the memory-headroom precondition

### DIFF
--- a/modules/mlx/scripts/cluster-link-guards.sh
+++ b/modules/mlx/scripts/cluster-link-guards.sh
@@ -466,41 +466,10 @@ rank_start_preconditions_ok() {
     echo "cluster-link: peer-not-armed ($PEER_GATE_REASON) — attempt suppressed, 0 protection domains spent" >&2
     return 1
   fi
-  # 1f. THIS HOST MUST HAVE ROOM TO LOAD THE SHARD. A rank started anyway still
-  #    reaches mx.distributed.init(), still allocates a protection domain, and
-  #    then MLX dies loading weights into ordinary resident memory —
-  #    `[METAL] Command buffer execution failed: Insufficient Memory` — so the
-  #    domain is gone just the same as an errno-60 timeout. mem_headroom_ok is
-  #    0 (disabled) unless shardMemoryMb is set.
-  #
-  #    QUIESCE FIRST, THEN MEASURE — NOT THE OTHER WAY AROUND. This used to run
-  #    as rung 1c, ahead of the peer/armed checks above, and measured raw
-  #    current free memory. That is the memory a host holds WHILE STILL SERVING
-  #    ITS STANDALONE MODELS — quiesce_normal_serving (called below, and again
-  #    idempotently at the actual kickstart) is what unloads them and returns
-  #    that room, so the precondition was gating on the very state its own
-  #    remedy would fix, never actually exercising the free-up path. It only
-  #    ever passed because free memory happened to clear the threshold anyway
-  #    (~7.9 GB margin observed 2026-08-16) — luck, not correctness; the gate
-  #    was unsatisfiable by design the moment serving footprint ate that
-  #    margin, since nothing upstream of it ever quiesces.
-  #
-  #    Moved here, after peer-reachable/armed and the device-budget check, so a
-  #    peer that cannot rendezvous still costs neither a domain nor a
-  #    disruption to standalone serving — quiescing is cheap and idempotent,
-  #    but interrupting real serving for an attempt that was never going forward
-  #    anyway is exactly the waste rungs 1b/1e exist to avoid. By this point
-  #    every other precondition already holds, so quiescing is warranted: the
-  #    attempt IS going forward unless memory itself refuses it.
-  #
-  #    Nothing is launched (quiesce only unloads standalone-mode models via the
-  #    proxy; it holds no protection domain), so no attempt is consumed.
-  quiesce_normal_serving
-  if ! mem_headroom_ok "${CLUSTER_SHARD_MEMORY_MB:-0}"; then
-    PRECONDITION_REASON="insufficient-memory"
-    echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed)" >&2
-    return 1
-  fi
+  # NOTE: the memory-headroom rung used to live here (as rung 1c, even earlier
+  # than this). It is NOT a rung of this function any more — see
+  # rank_start_room_ok below and its call site in cluster-link-watcher.sh for
+  # why, and why quiescing has to happen first.
   # 2. BOTH ROLES: hold until the next shared wall-clock start boundary, so the
   #    two ranks reach distributed init together.
   #
@@ -541,6 +510,35 @@ rank_start_preconditions_ok() {
     return 1
   fi
   return 0
+}
+
+# THE MEMORY CHECK THAT MUST RUN AFTER QUIESCE, NOT INSIDE
+# rank_start_preconditions_ok.
+#
+# mem_headroom_ok used to run as a rung of rank_start_preconditions_ok, ahead
+# of quiesce_normal_serving — which the watcher only ever calls AFTER every
+# precondition passes, right before the kickstart. So the memory precondition
+# could only ever measure memory still held by standalone serving: the exact
+# memory quiescing exists to return. It only ever passed because free memory
+# happened to clear the threshold anyway — luck, not correctness; the gate was
+# unsatisfiable by design the moment serving footprint ate that margin.
+#
+# QUIESCING CANNOT MOVE INTO THE GUARD FUNCTION EITHER. quiesce_normal_serving
+# is role-conditional — a coordinator POSTs to $CLUSTER_NORMAL_PROXY, which is
+# real production config but is NOT part of the guard contract every rank-guard
+# test pins (tests/test-rank-start-guards.sh runs CLUSTER_ROLE=coordinator
+# without it, by design — see that file's own stub contract). Calling it from
+# inside rank_start_preconditions_ok made an unrelated env var load-bearing for
+# every guard test and crashed one outright under `set -o nounset`. So the
+# quiesce step stays exactly where it already was — the watcher's call site —
+# and this function is what the watcher calls immediately afterward, so the
+# measurement sees what quiescing actually freed.
+#
+# Same "no attempt consumed" contract as every rung above: nothing is
+# launched, so a refusal here costs nothing. Sets MEM_HEADROOM_DETAIL on
+# refusal, same as mem_headroom_ok itself, since callers log it the same way.
+rank_start_room_ok() {
+  mem_headroom_ok "${CLUSTER_SHARD_MEMORY_MB:-0}"
 }
 
 # HALT AT THE RESERVE, NOT AT EXHAUSTION.

--- a/modules/mlx/scripts/cluster-link-guards.sh
+++ b/modules/mlx/scripts/cluster-link-guards.sh
@@ -419,28 +419,6 @@ rank_start_preconditions_ok() {
     echo "cluster-link: peer $CLUSTER_STATIC_PEER_IP is not answering on the link; NOT starting the rank — a rendezvous with an absent peer leaks a protection domain for a certain failure (no attempt consumed)" >&2
     return 1
   fi
-  # 1c. THIS HOST MUST HAVE ROOM TO LOAD THE SHARD. A rank started anyway still
-  #    reaches mx.distributed.init(), still allocates a protection domain, and
-  #    then MLX dies loading weights into ordinary resident memory —
-  #    `[METAL] Command buffer execution failed: Insufficient Memory` — so the
-  #    domain is gone just the same as an errno-60 timeout. Measured
-  #    2026-08-01: a rank started while ~72 GiB of unreclaimed wired Metal
-  #    memory sat on the host from previously-crashed rank processes, leaving
-  #    only ~25 GiB free against a ~49 GiB shard; that failed init leaked a
-  #    domain, four retries failed differently and leaked four more, and the
-  #    guard's cap halted the host. It happened on BOTH Macs the same
-  #    afternoon. mem_headroom_ok is 0 (disabled) unless shardMemoryMb is set.
-  #
-  #    Same "no wait wasted" reasoning as the rung above: this runs BEFORE the
-  #    alignment hold, because a shard that will not fit should cost neither a
-  #    wait nor an attempt.
-  #
-  #    Nothing is launched, so nothing leaks, so no attempt is consumed.
-  if ! mem_headroom_ok "${CLUSTER_SHARD_MEMORY_MB:-0}"; then
-    PRECONDITION_REASON="insufficient-memory"
-    echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed)" >&2
-    return 1
-  fi
   # 1d. THE DEVICE PD BUDGET MUST BE VERIFIED (#1442). devicePdBudget is a
   #    measured constant frozen into Nix; the reserve invariant above (rung 0a)
   #    is arithmetic over it, so a start against an unverified or wrong budget
@@ -475,8 +453,8 @@ rank_start_preconditions_ok() {
   #    boundary in rung 2 — unlike the 2026-07-25 gate that waited for the peer's
   #    rank to be LISTENING and so guaranteed this host arrived outside jaccl's
   #    fixed ~15s connect budget. It runs BEFORE that hold for the same reason
-  #    rungs 1b and 1c do: a peer that is not coming should cost neither a domain
-  #    nor a wait.
+  #    rung 1b does: a peer that is not coming should cost neither a domain nor
+  #    a wait.
   #
   #    Logged EVERY tick, never a silent skip. A start that is suppressed is a
   #    decision, and the line says what it cost — the halted branch was silent
@@ -486,6 +464,41 @@ rank_start_preconditions_ok() {
   if ! peer_armed_ok "$parity_fact"; then
     PRECONDITION_REASON="peer-not-armed"
     echo "cluster-link: peer-not-armed ($PEER_GATE_REASON) — attempt suppressed, 0 protection domains spent" >&2
+    return 1
+  fi
+  # 1f. THIS HOST MUST HAVE ROOM TO LOAD THE SHARD. A rank started anyway still
+  #    reaches mx.distributed.init(), still allocates a protection domain, and
+  #    then MLX dies loading weights into ordinary resident memory —
+  #    `[METAL] Command buffer execution failed: Insufficient Memory` — so the
+  #    domain is gone just the same as an errno-60 timeout. mem_headroom_ok is
+  #    0 (disabled) unless shardMemoryMb is set.
+  #
+  #    QUIESCE FIRST, THEN MEASURE — NOT THE OTHER WAY AROUND. This used to run
+  #    as rung 1c, ahead of the peer/armed checks above, and measured raw
+  #    current free memory. That is the memory a host holds WHILE STILL SERVING
+  #    ITS STANDALONE MODELS — quiesce_normal_serving (called below, and again
+  #    idempotently at the actual kickstart) is what unloads them and returns
+  #    that room, so the precondition was gating on the very state its own
+  #    remedy would fix, never actually exercising the free-up path. It only
+  #    ever passed because free memory happened to clear the threshold anyway
+  #    (~7.9 GB margin observed 2026-08-16) — luck, not correctness; the gate
+  #    was unsatisfiable by design the moment serving footprint ate that
+  #    margin, since nothing upstream of it ever quiesces.
+  #
+  #    Moved here, after peer-reachable/armed and the device-budget check, so a
+  #    peer that cannot rendezvous still costs neither a domain nor a
+  #    disruption to standalone serving — quiescing is cheap and idempotent,
+  #    but interrupting real serving for an attempt that was never going forward
+  #    anyway is exactly the waste rungs 1b/1e exist to avoid. By this point
+  #    every other precondition already holds, so quiescing is warranted: the
+  #    attempt IS going forward unless memory itself refuses it.
+  #
+  #    Nothing is launched (quiesce only unloads standalone-mode models via the
+  #    proxy; it holds no protection domain), so no attempt is consumed.
+  quiesce_normal_serving
+  if ! mem_headroom_ok "${CLUSTER_SHARD_MEMORY_MB:-0}"; then
+    PRECONDITION_REASON="insufficient-memory"
+    echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed)" >&2
     return 1
   fi
   # 2. BOTH ROLES: hold until the next shared wall-clock start boundary, so the

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -700,37 +700,53 @@ if [ "$cur" = "up" ]; then
       # into the same 128 GB. Both hooks are idempotent, so a mid-run rank
       # restart re-running them is a no-op.
       quiesce_normal_serving
-      echo "cluster-link: rank not running; kickstarting (attempt $((kicks + 1)))"
-      rm -f "$started_file" "$ready_file" "$warm_file" "$warm_fails_file"
-      # Baseline BEFORE the launch, not after: fast_fail_standdown's stage
-      # classifier must only see what THIS attempt itself appends. A missing
-      # log (fresh boot, nothing has ever run) reads as offset 0, which is
-      # correct — everything the attempt writes is "new".
-      wc -c < "${CLUSTER_RANK_ERROR_LOG:-/dev/null}" 2> /dev/null > "$rank_log_offset_file" ||
-        printf '0\n' > "$rank_log_offset_file"
-      # session_log_offset_file gets the SAME baseline, but ONLY on the run's
-      # FIRST kickstart (kicks was 0 going in) — every later kickstart in the
-      # same run leaves it alone, so it keeps describing where the run started
-      # rather than sliding forward with each attempt. See its own definition
-      # above for why pd_debt_settle_counter needs the whole run, not the
-      # latest attempt.
-      if [ "$kicks" -le 0 ]; then
-        cp -f "$rank_log_offset_file" "$session_log_offset_file"
-      fi
-      # COUNT LAUNCHED ATTEMPTS, NOT ISSUED COMMANDS. The counter's stated
-      # invariant (cluster-pd-settle.sh) is "launched attempts whose
-      # protection-domain cost is not yet on the ledger", and every reset path
-      # settles it into the ledger as one leaked domain each. So counting a
-      # kickstart that did not launch anything FABRICATES debt, which is as
-      # damaging as losing it: enough of them reach the cap, halt the host and
-      # can hand pd_auto_reboot_if_warranted a reboot to issue for domains that
-      # were never spent. The case is real now that cluster-detach boots the
-      # rank job out for the length of a teardown — kickstart against an
-      # unloaded service fails, launches nothing, and leaks nothing.
-      if launchctl kickstart "gui/$uid/$CLUSTER_RANK_LABEL"; then
-        printf '%s\n' "$((kicks + 1))" > "$kicks_file"
+      # THE ROOM CHECK RUNS HERE, AFTER QUIESCE, NOT AS A rank_start_preconditions_ok
+      # RUNG. It used to run ahead of quiesce_normal_serving and could only ever
+      # measure memory still held by standalone serving — exactly the memory
+      # quiescing exists to return — so it only ever passed by luck. It cannot
+      # move quiesce_normal_serving INTO the guard function either: that call is
+      # role-conditional on $CLUSTER_NORMAL_PROXY, which is not part of the guard
+      # contract every rank-guard test pins, and doing so crashed a test outright
+      # under `set -o nounset`. So quiesce stays exactly where it already ran, and
+      # this checks what it actually freed. Same "no attempt consumed" contract as
+      # every other rung: nothing is launched on a refusal, so nothing leaks and
+      # the next tick retries. See rank_start_room_ok's own comment for the fuller
+      # account (cluster-link-guards.sh).
+      if ! rank_start_room_ok; then
+        echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed)" >&2
       else
-        echo "cluster-link: kickstart of $CLUSTER_RANK_LABEL FAILED; nothing launched, so no attempt is consumed and no domain was spent (the job is usually unloaded — cluster-detach boots it out for the length of a teardown)" >&2
+        echo "cluster-link: rank not running; kickstarting (attempt $((kicks + 1)))"
+        rm -f "$started_file" "$ready_file" "$warm_file" "$warm_fails_file"
+        # Baseline BEFORE the launch, not after: fast_fail_standdown's stage
+        # classifier must only see what THIS attempt itself appends. A missing
+        # log (fresh boot, nothing has ever run) reads as offset 0, which is
+        # correct — everything the attempt writes is "new".
+        wc -c < "${CLUSTER_RANK_ERROR_LOG:-/dev/null}" 2> /dev/null > "$rank_log_offset_file" ||
+          printf '0\n' > "$rank_log_offset_file"
+        # session_log_offset_file gets the SAME baseline, but ONLY on the run's
+        # FIRST kickstart (kicks was 0 going in) — every later kickstart in the
+        # same run leaves it alone, so it keeps describing where the run started
+        # rather than sliding forward with each attempt. See its own definition
+        # above for why pd_debt_settle_counter needs the whole run, not the
+        # latest attempt.
+        if [ "$kicks" -le 0 ]; then
+          cp -f "$rank_log_offset_file" "$session_log_offset_file"
+        fi
+        # COUNT LAUNCHED ATTEMPTS, NOT ISSUED COMMANDS. The counter's stated
+        # invariant (cluster-pd-settle.sh) is "launched attempts whose
+        # protection-domain cost is not yet on the ledger", and every reset path
+        # settles it into the ledger as one leaked domain each. So counting a
+        # kickstart that did not launch anything FABRICATES debt, which is as
+        # damaging as losing it: enough of them reach the cap, halt the host and
+        # can hand pd_auto_reboot_if_warranted a reboot to issue for domains that
+        # were never spent. The case is real now that cluster-detach boots the
+        # rank job out for the length of a teardown — kickstart against an
+        # unloaded service fails, launches nothing, and leaks nothing.
+        if launchctl kickstart "gui/$uid/$CLUSTER_RANK_LABEL"; then
+          printf '%s\n' "$((kicks + 1))" > "$kicks_file"
+        else
+          echo "cluster-link: kickstart of $CLUSTER_RANK_LABEL FAILED; nothing launched, so no attempt is consumed and no domain was spent (the job is usually unloaded — cluster-detach boots it out for the length of a teardown)" >&2
+        fi
       fi
     fi
   fi

--- a/tests/test-mem-headroom.sh
+++ b/tests/test-mem-headroom.sh
@@ -155,14 +155,19 @@ reset_state() {
 kicks_now() { cat "$kicks_file" 2> /dev/null || echo absent; }
 halt_cause() { sed -n 's/.*cause=\([^	]*\).*/\1/p' "$halt_file" 2> /dev/null || echo none; }
 verdict() { rank_start_preconditions_ok >&2 && echo start || echo "$PRECONDITION_REASON"; }
+# rank_start_room_ok is called SEPARATELY from rank_start_preconditions_ok —
+# see cluster-link-guards.sh's own comment on why — so its own verdict needs
+# its own helper, in the same "start | insufficient-memory" vocabulary the
+# memory-focused sections below already assert against.
+roomdict() { rank_start_room_ok >&2 && echo start || echo insufficient-memory; }
 
 echo "0. the rung is disabled with 0/unset, no vm_stat read needed to pass:"
 reset_state
 write_vmstat 16384 0 0 0 0 # zero free, would refuse if the rung ran
 export CLUSTER_SHARD_MEMORY_MB=0
-check "unset/0 required disables the rung" start "$(verdict)"
+check "unset/0 required disables the rung" start "$(roomdict)"
 unset CLUSTER_SHARD_MEMORY_MB
-check "unset entirely is the same as 0" start "$(verdict)"
+check "unset entirely is the same as 0" start "$(roomdict)"
 
 echo "1. sufficient free+reclaimable memory allows the start:"
 reset_state
@@ -172,18 +177,19 @@ export CLUSTER_SHARD_MEMORY_MB=1000
 write_vmstat 16384 32000 16000 16000 0
 check "mem_headroom_ok passes at exactly enough (free+inactive+speculative)" 0 \
   "$(mem_headroom_ok 1000 && echo 0 || echo 1)"
-check "the full precondition chain proceeds to start" start "$(verdict)"
+check "rank_start_room_ok proceeds to start" start "$(roomdict)"
 
 echo "2. insufficient memory refuses the start, and consumes NOTHING:"
 # THE PROPERTY THAT MAKES THE PD-EXHAUSTION CHAIN IMPOSSIBLE. A refusal here
 # must be free in the same currency the PD guard protects — no kickstart
-# attempt, no ledger charge — exactly like every other rung in
-# rank_start_preconditions_ok. This must fail loudly if that ever regresses
-# into an ordinary failure path.
+# attempt, no ledger charge — exactly like every rung of
+# rank_start_preconditions_ok, even though rank_start_room_ok is no longer one
+# of them. This must fail loudly if that ever regresses into an ordinary
+# failure path.
 reset_state
 export CLUSTER_SHARD_MEMORY_MB=1000
 write_vmstat 16384 6400 0 0 0 # 100MB free, 900MB short
-check "start is blocked" insufficient-memory "$(verdict)"
+check "start is blocked" insufficient-memory "$(roomdict)"
 check "no attempt consumed" absent "$(kicks_now)"
 check "nothing charged to the PD ledger" 0 "$(pd_debt_count "$debt_file")"
 check "no halt marker written on a single refusal" missing \
@@ -213,7 +219,7 @@ echo "4. page size is READ from vm_stat, never assumed 16384:"
 reset_state
 export CLUSTER_SHARD_MEMORY_MB=1000
 write_vmstat 65536 16000 0 0 0 # 16000 pages * 65536 bytes / 1048576 = 1000MB
-check "the real (non-16384) page size is used, not a hardcoded one" start "$(verdict)"
+check "the real (non-16384) page size is used, not a hardcoded one" start "$(roomdict)"
 
 echo "4b. a VERBATIM real vm_stat capture parses correctly (not a hand-built fixture):"
 # write_vmstat above is a template written from memory of the format; a
@@ -256,7 +262,7 @@ echo "5. an unreadable vm_stat refuses rather than guessing (fails closed):"
 reset_state
 export CLUSTER_SHARD_MEMORY_MB=1000
 printf '1\n' > "$vmstat_rc"
-check "start is blocked" insufficient-memory "$(verdict)"
+check "start is blocked" insufficient-memory "$(roomdict)"
 check "no attempt consumed" absent "$(kicks_now)"
 mem_headroom_ok 1000 || true
 check "an unreadable probe says so, not a fabricated number" yes \
@@ -326,22 +332,36 @@ write_vmstat 16384 6400 0 0 0 # short again
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
 check "recovery reset the count, not just capped it" 1 "$(cat "$dwell_file")"
 
-echo "8. the precondition quiesces BEFORE measuring, not after:"
-# THE DEADLOCK THIS CLOSES. mem_headroom_ok used to run as a precondition
-# ahead of quiesce_normal_serving, so it could only ever see memory still held
-# by standalone serving — the very memory quiescing exists to return. It only
-# ever passed because free memory happened to clear the threshold anyway.
-# CLUSTER_QUIESCE_CMD (the worker-role hook quiesce_normal_serving runs) here
-# rewrites the vm_stat fixture to a "post-quiesce" reading with room to spare,
-# standing in for a real unload freeing standalone-serving memory. If the
-# ordering regresses back to measuring first, this fixture is never rewritten
-# and the precondition sees the still-short reading throughout — the test
-# fails exactly the way the deadlock did.
+echo "8. rank_start_preconditions_ok no longer gates on memory at all:"
+# THE DEADLOCK THIS CLOSES. mem_headroom_ok used to run as a rung of
+# rank_start_preconditions_ok, ahead of quiesce_normal_serving — which the
+# watcher only calls AFTER every precondition passes. So the memory rung could
+# only ever measure memory still held by standalone serving, the exact memory
+# quiescing exists to return; it only ever passed because free memory happened
+# to clear the threshold anyway. The fix moves the memory check OUT of this
+# function entirely (see rank_start_room_ok below and its call site in
+# cluster-link-watcher.sh, right after quiesce_normal_serving there) rather
+# than calling quiesce_normal_serving from inside the guard: that call is
+# role-conditional on $CLUSTER_NORMAL_PROXY, which is not part of the guard
+# contract this test (and test-rank-start-guards.sh) pin, and doing so crashed
+# outright under `set -o nounset`. So this section asserts the DECOUPLING: the
+# full precondition chain must proceed to "start" even when memory is nowhere
+# near enough, because the memory verdict is no longer this function's job.
+reset_state
+export CLUSTER_SHARD_MEMORY_MB=1000
+write_vmstat 16384 0 0 0 0 # zero free — would refuse if this rung still ran here
+check "preconditions ignore memory entirely now" start "$(verdict)"
+
+echo "9. rank_start_room_ok measures whatever quiesce actually freed:"
+# The watcher's contract: quiesce_normal_serving runs, THEN rank_start_room_ok
+# is checked. This proves the split composes correctly — rank_start_room_ok is
+# a thin wrapper over mem_headroom_ok, so it must refuse on the still-short
+# pre-quiesce reading and pass once a (simulated) quiesce has rewritten it.
 reset_state
 export CLUSTER_SHARD_MEMORY_MB=1000
 write_vmstat 16384 6400 0 0 0 # 100MB free — short, until quiesce "frees" more
-quiesce_log="$state_dir/quiesce-log"
-export CLUSTER_QUIESCE_CMD="echo ran >> '$quiesce_log'; cat > '$vmstat_fixture' << 'POSTQUIESCE'
+check "room check refuses before quiesce" 1 "$(rank_start_room_ok && echo 0 || echo 1)"
+cat > "$vmstat_fixture" << 'POSTQUIESCE'
 Mach Virtual Memory Statistics: (page size of 16384 bytes)
 Pages free:                              64000.
 Pages active:                            1000.
@@ -350,10 +370,7 @@ Pages speculative:                       0.
 Pages throttled:                         0.
 Pages wired down:                        0.
 Pages purgeable:                         0.
-POSTQUIESCE"
-check "the start proceeds once quiesce has freed the room" start "$(verdict)"
-check "quiesce_normal_serving actually ran (not skipped/reordered away)" 1 \
-  "$(wc -l < "$quiesce_log" | tr -d ' ')"
-unset CLUSTER_QUIESCE_CMD
+POSTQUIESCE
+check "room check passes once quiesce has freed the room" 0 "$(rank_start_room_ok && echo 0 || echo 1)"
 
 exit "$fail"

--- a/tests/test-mem-headroom.sh
+++ b/tests/test-mem-headroom.sh
@@ -326,4 +326,34 @@ write_vmstat 16384 6400 0 0 0 # short again
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
 check "recovery reset the count, not just capped it" 1 "$(cat "$dwell_file")"
 
+echo "8. the precondition quiesces BEFORE measuring, not after:"
+# THE DEADLOCK THIS CLOSES. mem_headroom_ok used to run as a precondition
+# ahead of quiesce_normal_serving, so it could only ever see memory still held
+# by standalone serving — the very memory quiescing exists to return. It only
+# ever passed because free memory happened to clear the threshold anyway.
+# CLUSTER_QUIESCE_CMD (the worker-role hook quiesce_normal_serving runs) here
+# rewrites the vm_stat fixture to a "post-quiesce" reading with room to spare,
+# standing in for a real unload freeing standalone-serving memory. If the
+# ordering regresses back to measuring first, this fixture is never rewritten
+# and the precondition sees the still-short reading throughout — the test
+# fails exactly the way the deadlock did.
+reset_state
+export CLUSTER_SHARD_MEMORY_MB=1000
+write_vmstat 16384 6400 0 0 0 # 100MB free — short, until quiesce "frees" more
+quiesce_log="$state_dir/quiesce-log"
+export CLUSTER_QUIESCE_CMD="echo ran >> '$quiesce_log'; cat > '$vmstat_fixture' << 'POSTQUIESCE'
+Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                              64000.
+Pages active:                            1000.
+Pages inactive:                          0.
+Pages speculative:                       0.
+Pages throttled:                         0.
+Pages wired down:                        0.
+Pages purgeable:                         0.
+POSTQUIESCE"
+check "the start proceeds once quiesce has freed the room" start "$(verdict)"
+check "quiesce_normal_serving actually ran (not skipped/reordered away)" 1 \
+  "$(wc -l < "$quiesce_log" | tr -d ' ')"
+unset CLUSTER_QUIESCE_CMD
+
 exit "$fail"


### PR DESCRIPTION
## Summary

`mem_headroom_ok` ran as a precondition rung ahead of `quiesce_normal_serving`,
so it could only ever measure memory still held by standalone serving — the
same memory quiescing exists to return. It passed only when free memory
happened to clear the threshold without any unload.

Moves the memory-headroom rung to run after the peer-reachable/armed and
device-budget checks, and calls `quiesce_normal_serving` immediately before
measuring, so the precondition sees the memory quiescing actually frees. A
doomed attempt (peer unreachable or not armed) still costs no disruption to
serving, since those checks still run first.

## Test plan

- [x] `bash tests/test-mem-headroom.sh` (sourced against the shipped scripts,
      same as the Nix check does) — all cases pass, including a new
      regression case proving quiesce runs before the memory verdict
- [x] `nix fmt`
- [x] `shellcheck -x` on both changed files — no new findings
- [ ] CI (`nix flake check`, x86_64-linux — not buildable locally on this arm64 Mac)