### PR TITLE
fix(mlx): deliberate llama-swap unloadTimeout, log quiesce in-flight requests

### DIFF
--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -225,6 +225,12 @@ let
     # Tap live I/O with: curl http://127.0.0.1:11434/logs/stream
     # Configurable via programs.mlx.proxy.logLevel / logToStdout.
     startPort = 11436;
+    # Deliberately llama-swap's own default (10s), not left unset by accident.
+    # Bounds how long /api/models/unload blocks per process during cluster
+    # quiesce (cluster-link-helpers.sh: quiesce_normal_serving) before
+    # escalating SIGTERM to SIGKILL. In-flight requests are killed, not
+    # drained, regardless of this value — see cluster-quiesce-log.sh.
+    unloadTimeout = 10;
   }
   // llamaSwapTopology
   // {

--- a/modules/mlx/scripts/cluster-link-helpers.sh
+++ b/modules/mlx/scripts/cluster-link-helpers.sh
@@ -232,9 +232,27 @@ set_wired_limit() {
 
 quiesce_normal_serving() {
   if [ "$CLUSTER_ROLE" = "coordinator" ]; then
+    # llama-swap's /api/models/unload kills in-flight requests outright — it
+    # does not wait for them (upstream doc comment on router.Unload: "Stop
+    # kills the upstream, those callers see whatever error the reverse proxy
+    # surfaces"). No admission-stop exists anywhere in the chain to prevent
+    # that (checked llama-swap's own API surface and LiteLLM's model-update
+    # API, which is DB-gated and this fabric deliberately runs without a DB).
+    # So a guard that can disrupt production must at least SAY what it
+    # disrupted: snapshot in-flight requests from llama-swap's own SSE event
+    # stream (GET /api/events, first message is a full snapshot) before
+    # killing them.
+    local snapshot
+    snapshot="$(curl -fsS -m 3 --no-buffer "$CLUSTER_NORMAL_PROXY/api/events" 2> /dev/null | grep -m1 '^data:')"
+    if [ -n "$snapshot" ]; then
+      echo "cluster-link: quiesce in-flight snapshot: $(printf '%s' "${snapshot#data: }" | jq -c '.requests // [] | map(.id)' 2> /dev/null || printf '%s' "$snapshot")"
+    else
+      echo "cluster-link: quiesce in-flight snapshot: none (or /api/events unreachable)"
+    fi
     # Unload every normal-mode model; the proxy itself stays up so the
     # restore only needs a re-warm, not a proxy restart. Idempotent.
     curl -fsS -m 60 -X POST "$CLUSTER_NORMAL_PROXY/api/models/unload" || true
+    echo "cluster-link: quiesce unload request completed"
   elif [ -n "${CLUSTER_QUIESCE_CMD:-}" ]; then
     sh -c "$CLUSTER_QUIESCE_CMD" || true
   fi


### PR DESCRIPTION
## Summary
- Sets llama-swap's `unloadTimeout` to `10` explicitly in the generated config, with a comment explaining what it bounds, instead of inheriting the vendor default implicitly.
- `quiesce_normal_serving` (`cluster-link-helpers.sh`) now reads a snapshot of in-flight requests from llama-swap's `GET /api/events` SSE stream before calling `/api/models/unload`, and logs both the snapshot and unload completion.

## Test plan
- [x] `nix fmt` — 0 changed
- [x] `shellcheck --shell=bash --severity=style modules/mlx/scripts/cluster-link-helpers.sh` — clean
- [x] `bash -n modules/mlx/scripts/cluster-link-helpers.sh` — clean
- [x] `nix eval .#homeManagerModules.default` — evaluates
- [ ] `nix flake check` x86_64-linux derivations (shellcheck/mlx-cluster/mlx-defaults-regression checks) could not run locally — no remote Linux builder configured on this machine; CI covers these