### PR TITLE
fix(mlx): restore standalone serving when a post-quiesce refusal never starts a rank

### DIFF
--- a/lib/checks/mlx-cluster-recovery.nix
+++ b/lib/checks/mlx-cluster-recovery.nix
@@ -63,4 +63,19 @@
     WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
   } "bash ${src}/tests/test-watcher-heartbeat.sh && touch $out";
 
+  # THE CHECK THAT FAILS IF A REFUSAL AFTER QUIESCE LEAVES SERVING DOWN.
+  # quiesce_normal_serving kills in-flight Hermes requests outright (no drain);
+  # a room-check refusal or a launchctl kickstart failure downstream of it used
+  # to just return, leaving standalone serving down for an attempt that never
+  # started a rank. Pins that both refusal paths restore it, and that a
+  # successful kickstart does not (the rank is what serves next).
+  mlx-cluster-quiesce-restore = pkgs.runCommand "check-mlx-cluster-quiesce-restore" {
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gawk
+    ];
+    WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
+  } "bash ${src}/tests/test-quiesce-restore.sh && touch $out";
+
 }

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -693,6 +693,13 @@ if [ "$cur" = "up" ]; then
       # Retry next tick. The function logs which rung failed.
       :
     else
+      # QUIESCE-THEN-START BLOCK — extracted and run verbatim by
+      # tests/test-quiesce-restore.sh, which pins that a refusal AFTER
+      # quiesce_normal_serving (room check or kickstart failure) always calls
+      # restore_normal_serving before falling through. Keep this comment and
+      # its matching "# END QUIESCE-THEN-START BLOCK" marker in place; the
+      # test's awk range depends on both.
+      #
       # Quiesce BEFORE every (re)start, not only on the down->up edge: the
       # link-state file survives a reboot, so a host that boots with the
       # cable in arrives here as up->up with standalone serving warm — skipping the
@@ -713,7 +720,17 @@ if [ "$cur" = "up" ]; then
       # the next tick retries. See rank_start_room_ok's own comment for the fuller
       # account (cluster-link-guards.sh).
       if ! rank_start_room_ok; then
-        echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed)" >&2
+        # QUIESCE ALREADY RAN. Serving is down and no rank is going to replace
+        # it — this refusal costs no protection domain, but left here it costs
+        # Hermes every request that would have landed on standalone serving
+        # until the next tick's quiesce (a no-op, already unloaded) happens to
+        # pass. Put serving back now, not "eventually on some later tick".
+        echo "cluster-link: $MEM_HEADROOM_DETAIL; NOT starting the rank (no attempt consumed); restoring the standalone serving quiesce just took down" >&2
+        if restore_normal_serving; then
+          echo "cluster-link: standalone serving restored after the room check refused"
+        else
+          echo "cluster-link: WARN failed to restore standalone serving after the room check refused; retrying next tick" >&2
+        fi
       else
         echo "cluster-link: rank not running; kickstarting (attempt $((kicks + 1)))"
         rm -f "$started_file" "$ready_file" "$warm_file" "$warm_fails_file"
@@ -745,9 +762,18 @@ if [ "$cur" = "up" ]; then
         if launchctl kickstart "gui/$uid/$CLUSTER_RANK_LABEL"; then
           printf '%s\n' "$((kicks + 1))" > "$kicks_file"
         else
-          echo "cluster-link: kickstart of $CLUSTER_RANK_LABEL FAILED; nothing launched, so no attempt is consumed and no domain was spent (the job is usually unloaded — cluster-detach boots it out for the length of a teardown)" >&2
+          # SAME REASONING AS THE ROOM-CHECK REFUSAL ABOVE: quiesce already ran,
+          # nothing launched to replace it, so standalone serving stays down
+          # for nothing unless this restores it.
+          echo "cluster-link: kickstart of $CLUSTER_RANK_LABEL FAILED; nothing launched, so no attempt is consumed and no domain was spent (the job is usually unloaded — cluster-detach boots it out for the length of a teardown); restoring standalone serving" >&2
+          if restore_normal_serving; then
+            echo "cluster-link: standalone serving restored after the kickstart failure"
+          else
+            echo "cluster-link: WARN failed to restore standalone serving after the kickstart failure; retrying next tick" >&2
+          fi
         fi
       fi
+      # END QUIESCE-THEN-START BLOCK
     fi
   fi
 elif [ "$prev" = "up" ]; then

--- a/tests/test-quiesce-restore.sh
+++ b/tests/test-quiesce-restore.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# THE CHECK THAT FAILS IF A REFUSAL AFTER QUIESCE LEAVES SERVING DOWN.
+#
+# quiesce_normal_serving runs (kills in-flight Hermes requests, see its own
+# header) BEFORE rank_start_room_ok is checked and before the kickstart is
+# issued. Either can still refuse — insufficient memory even after quiescing,
+# or `launchctl kickstart` itself failing — and both used to return there,
+# leaving standalone serving down for an attempt that never even started a
+# rank. This pins that both refusal paths call restore_normal_serving before
+# falling through, and that a successful room-check + kickstart does NOT
+# restore (the rank is what serves next, not standalone).
+#
+# WHAT IS REAL AND WHAT IS NOT:
+#   REAL  — the QUIESCE-THEN-START BLOCK is EXTRACTED FROM THE SHIPPED
+#           cluster-link-watcher.sh between its own comment markers and
+#           executed, so a drift in the shipped sequence fails here.
+#   STUB  — quiesce_normal_serving, rank_start_room_ok, restore_normal_serving
+#           and launchctl are stubbed to drive each branch deterministically;
+#           each one's own behaviour is pinned by its own test file
+#           (test-mem-headroom.sh, test-serving-restore.sh).
+#
+# Usage:
+#   WATCHER=… bash test-quiesce-restore.sh
+set -o errexit -o nounset -o pipefail
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+watcher="${WATCHER:?set WATCHER to cluster-link-watcher.sh}"
+
+# The shipped block itself, between its own markers. Empty extraction = the
+# markers moved, which must fail loudly rather than test nothing.
+block="$(awk '/^      # QUIESCE-THEN-START BLOCK/,/^      # END QUIESCE-THEN-START BLOCK/' "$watcher")"
+case "$block" in
+  *rank_start_room_ok* | *restore_normal_serving*) ;;
+  *)
+    echo "FAIL could not extract the quiesce-then-start block from $watcher" >&2
+    exit 1
+    ;;
+esac
+
+fail=0
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  ok   $label -> $got"
+  else
+    echo "  FAIL $label -> got '$got', want '$want'"
+    fail=1
+  fi
+}
+contains() {
+  local label="$1" needle="$2" hay="$3"
+  case "$hay" in
+    *"$needle"*) echo "  ok   $label" ;;
+    *)
+      echo "  FAIL $label -> '$needle' not in: $hay"
+      fail=1
+      ;;
+  esac
+}
+
+quiesce_log="$tmp/quiesce-log"
+restore_log="$tmp/restore-log"
+quiesce_normal_serving() { echo ran >> "$quiesce_log"; }
+restore_normal_serving() {
+  echo ran >> "$restore_log"
+  [ "${FAKE_RESTORE_OK:-1}" = 1 ]
+}
+launchctl() {
+  [ "$1" = kickstart ] || return 0
+  [ "${FAKE_KICKSTART_OK:-1}" = 1 ]
+}
+
+# Watcher-scope variables the block reads/writes at this point in a real tick.
+# shellcheck disable=SC2034  # read by the extracted block, not by name here
+uid=501
+kicks=0
+started_file="$tmp/started"
+# shellcheck disable=SC2034
+ready_file="$tmp/ready"
+# shellcheck disable=SC2034
+warm_file="$tmp/warm"
+# shellcheck disable=SC2034
+warm_fails_file="$tmp/warm-fails"
+# shellcheck disable=SC2034
+rank_log_offset_file="$tmp/rank-log-offset"
+# shellcheck disable=SC2034
+session_log_offset_file="$tmp/session-log-offset"
+kicks_file="$tmp/kicks"
+# shellcheck disable=SC2034
+CLUSTER_RANK_LABEL="dev.mlx-cluster.rank"
+
+reset() {
+  rm -f "$quiesce_log" "$restore_log" "$started_file" "$kicks_file"
+  export FAKE_ROOM_OK=1 FAKE_KICKSTART_OK=1 FAKE_RESTORE_OK=1
+  # shellcheck disable=SC2034
+  kicks=0
+}
+tick() { out="$(eval "$block" 2>&1)"; }
+restore_count() { [ -f "$restore_log" ] && wc -l < "$restore_log" | tr -d ' ' || echo 0; }
+
+# rank_start_room_ok itself is real code pinned by test-mem-headroom.sh; here
+# it is stubbed to drive both branches without a vm_stat fixture.
+rank_start_room_ok() { [ "${FAKE_ROOM_OK:-1}" = 1 ]; }
+# The real mem_headroom_ok sets this on refusal; the block only reads it for
+# its own log line, so a fixed value under the stub is enough.
+# shellcheck disable=SC2034
+MEM_HEADROOM_DETAIL="not enough memory (stub)"
+
+echo "room check refuses after quiesce: serving is restored:"
+reset
+export FAKE_ROOM_OK=0
+tick
+check "quiesce ran" 1 "$(wc -l < "$quiesce_log" | tr -d ' ')"
+check "restore ran" 1 "$(restore_count)"
+check "no attempt consumed" absent "$([ -f "$kicks_file" ] && cat "$kicks_file" || echo absent)"
+contains "logs the restore" "standalone serving restored after the room check refused" "$out"
+
+echo "   ...and a failed restore says so instead of pretending it worked:"
+reset
+export FAKE_ROOM_OK=0 FAKE_RESTORE_OK=0
+tick
+contains "logs the restore failure" "WARN failed to restore standalone serving after the room check refused" "$out"
+
+echo "kickstart itself fails after quiesce: serving is restored:"
+reset
+export FAKE_KICKSTART_OK=0
+tick
+check "quiesce ran" 1 "$(wc -l < "$quiesce_log" | tr -d ' ')"
+check "restore ran" 1 "$(restore_count)"
+check "no attempt consumed" absent "$([ -f "$kicks_file" ] && cat "$kicks_file" || echo absent)"
+contains "logs the restore" "standalone serving restored after the kickstart failure" "$out"
+
+echo "a successful room check + kickstart does NOT restore (the rank serves next):"
+reset
+tick
+check "quiesce ran" 1 "$(wc -l < "$quiesce_log" | tr -d ' ')"
+check "restore did NOT run" 0 "$(restore_count)"
+check "attempt consumed" 1 "$(cat "$kicks_file")"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

`quiesce_normal_serving` kills whatever requests are in flight when it runs
(no drain, per llama-swap's own doc comment on `Unload`). Two paths
downstream of it could return without ever starting a rank — the memory room
check failing, or `launchctl kickstart` itself failing — leaving standalone
serving down for an attempt that accomplished nothing. Neither restored it.

Both now call `restore_normal_serving` (the existing shared restore path,
already used by cluster-detach and cluster-join) and log the outcome, so a
refusal at either point never leaves serving down silently.

## Test plan

- [x] `bash tests/test-quiesce-restore.sh` (new) — extracts the shipped
      quiesce-then-start block from `cluster-link-watcher.sh` and pins that
      both refusal paths restore serving while a successful kickstart does not
- [x] `test-mem-headroom.sh`, `test-watcher-heartbeat.sh` rerun clean
- [x] `nix fmt`, `shellcheck -x` — no new findings
- [ ] CI (`nix flake check`, x86_64-linux)