### PR TITLE
fix(docs): split observation traps out instead of raising the token limit

### DIFF
--- a/.token-limits.yaml
+++ b/.token-limits.yaml
@@ -15,10 +15,4 @@ limits:
 
   # Module and architecture documentation.
   modules/*/README.md: 3000
-
-  # The single authoritative cluster runbook: dense by design (verbatim
-  # operator quotes plus every corrected belief, so a reader never re-derives
-  # a wrong one) — kept as one page rather than split, so it earns a wider
-  # budget than the general docs/*.md default below.
-  docs/runbooks/cluster-link-truths.md: 3300
   docs/*.md: 3000

--- a/docs/runbooks/cluster-link-truths.md
+++ b/docs/runbooks/cluster-link-truths.md
@@ -77,52 +77,11 @@ cluster capacity.
 
 ## 4. Reading the machine — the observation traps
 
-Each produced a confident wrong diagnosis at least once.
-
-- **`RUNNING` in ifconfig flags is NOT carrier.** It is set on an admin-up
-  port with nothing plugged in. Carrier is the per-port `status:` line —
-  `active`/`inactive`, read on `en1`/`en2`/`en3` individually. `bridge0`'s own
-  status is irrelevant. The facts line renders this per port.
-- **A missing link address means link prep did not run.** It says *nothing*
-  about the cable — fully compatible with a seated cable and `status: active`.
-  Only the cluster tooling aliases it, never DHCP or the bridge service.
-  Enforced: carrier present + address absent self-repairs, bounded
-  (`linkPrepMaxRepairs`).
-- **A disabled Thunderbolt Bridge with zero members is the CORRECT state.**
-  The tooling deliberately frees TB ports *from* `bridge0`; `member: enX`
-  reappearing is the classic prep loss, undone by `repair_link_direct`. Do not
-  "fix" it in System Settings.
-- **macOS Local Network Privacy has a distinct signature and never removes an
-  address**: same-subnet `EHOSTUNREACH` (**errno 65**) for a gated process
-  while `/usr/bin/curl` succeeds in the same second. Both agents launch
-  through Apple's interpreter (`programs.mlx.appleInterpreter`) for this
-  reason. **Discriminator: errno 65 = gate blocked; errno 61
-  (`ECONNREFUSED`) = reached the peer, gate clear.** The gate CAN be prompted
-  from launchd; a grant persists on disk at
-  `/Library/Preferences/com.apple.networkextension.plist` (`DenyAll = false`),
-  not the (empty, here) TCC.db table. If `nehelper` can't resolve the
-  identity's display metadata (no alert ever attempted), the resulting
-  connect failures classify as ordinary Stage-A rank-start failures and drive
-  the same kickstart-cap → `rank-start-failures` halt → §6 auto-reboot path —
-  so this failure mode already self-clears without a special case.
-- **Never read halt state by file existence.** `[ -f rank-halted ]` reports
-  the automation's own self-healing as an outage: post-reboot the marker
-  legitimately exists for a tick before `halt_drop_if_pre_boot` drops it. Test
-  the marker's `boot=` field against `sysctl -n kern.boottime`. Same family: a
-  `quiesced-agents` marker is not evidence the agents are quiesced — observe
-  the processes, never trust a marker over the machine.
-- **Read a failure burst from the FIRST error, not the last.** 2026-08-02: the
-  first rank failure was a Metal OOM
-  (`kIOGPUCommandBufferCallbackErrorOutOfMemory`); every later attempt died
-  `[jaccl] Couldn't connect (error: 60)` — a downstream symptom pointing at
-  the network. The last error names the aftermath; the first names the cause.
-- **`errno 60` never names the machine that is wrong.** It is `ETIMEDOUT`.
-  Enforced: `cluster-join` probes the peer (`peerReadyTimeoutSecs`) before the
-  long wait and refuses naming which side is unverified; the watcher's peer
-  rung refuses a start against an absent peer — no rank, no domain spent.
-- **A worker rank can die SIGSEGV (exit 139) when its peer vanishes.**
-  `launchctl list`'s second column is the last exit status; a bare
-  running/not-running check hides it.
+Each produced a confident wrong diagnosis at least once. Split into its own
+page: [cluster-observation-traps.md](cluster-observation-traps.md) — carrier
+vs. `RUNNING`, link-address vs. cable state, the Thunderbolt Bridge's correct
+empty state, the Local Network Privacy errno signature, halt-state markers,
+first-vs-last error in a burst, and `errno 60`/SIGSEGV misattribution.
 
 ## 5. Serving truths
 
@@ -180,7 +139,7 @@ boot-scope comparison; link prep self-repaired; PD debt read 0 for the new
 boot; `iogpu.wired_limit_mb` restored by activation — it needs **no**
 re-applying by hand. Post-reboot transients (a `rank-halted` file for one
 tick, "no carrier-active link address" while prep settles) are the automation
-working; see §4 before declaring an outage. **The cluster has since formed
+working; see [cluster-observation-traps.md](cluster-observation-traps.md) before declaring an outage. **The cluster has since formed
 fully unattended this way** — no belief that formation needs a manual step
 should survive that.
 
@@ -197,7 +156,7 @@ holds. Deleting `pd-debt` returns no domain.
 | `link-prep-repairs`, `port-reups` | bounded self-heal counters |
 | `standalone-lease` | the §1 lease: `<expiry-epoch> <created> <reason>` |
 | `generation-parity/-alerted/-heal-attempts` | §2 cache, once-per-drift page, heal budget |
-| `rank-halted` / `rank-halt-latched` | halt + sticky latch (read `boot=`, §4) |
+| `rank-halted` / `rank-halt-latched` | halt + sticky latch (read `boot=`, see [cluster-observation-traps.md](cluster-observation-traps.md)) |
 | `rank-kickstarts` | session-scoped failed-start counter |
 | `pd-debt` | **boot-scoped** leaked-domain ledger |
 | `quiesced-agents` | worker: what `cluster-quiesce` booted out |

--- a/docs/runbooks/cluster-observation-traps.md
+++ b/docs/runbooks/cluster-observation-traps.md
@@ -1,0 +1,53 @@
+# Cluster observation traps
+
+Split out of [cluster-link-truths.md](cluster-link-truths.md) — that page
+holds the state-machine rules the automation enforces; this page holds the
+diagnostic gotchas that produced a confident wrong reading of the machine at
+least once each. Read this before trusting any manual observation over what
+the watcher itself reports.
+
+- **`RUNNING` in ifconfig flags is NOT carrier.** It is set on an admin-up
+  port with nothing plugged in. Carrier is the per-port `status:` line —
+  `active`/`inactive`, read on `en1`/`en2`/`en3` individually. `bridge0`'s own
+  status is irrelevant. The facts line renders this per port.
+- **A missing link address means link prep did not run.** It says *nothing*
+  about the cable — fully compatible with a seated cable and `status: active`.
+  Only the cluster tooling aliases it, never DHCP or the bridge service.
+  Enforced: carrier present + address absent self-repairs, bounded
+  (`linkPrepMaxRepairs`).
+- **A disabled Thunderbolt Bridge with zero members is the CORRECT state.**
+  The tooling deliberately frees TB ports *from* `bridge0`; `member: enX`
+  reappearing is the classic prep loss, undone by `repair_link_direct`. Do not
+  "fix" it in System Settings.
+- **macOS Local Network Privacy has a distinct signature and never removes an
+  address**: same-subnet `EHOSTUNREACH` (**errno 65**) for a gated process
+  while `/usr/bin/curl` succeeds in the same second. Both agents launch
+  through Apple's interpreter (`programs.mlx.appleInterpreter`) for this
+  reason. **Discriminator: errno 65 = gate blocked; errno 61
+  (`ECONNREFUSED`) = reached the peer, gate clear.** The gate CAN be prompted
+  from launchd; a grant persists on disk at
+  `/Library/Preferences/com.apple.networkextension.plist` (`DenyAll = false`),
+  not the (empty, here) TCC.db table. If `nehelper` can't resolve the
+  identity's display metadata (no alert ever attempted), the resulting
+  connect failures classify as ordinary Stage-A rank-start failures and drive
+  the same kickstart-cap → `rank-start-failures` halt →
+  [the auto-reboot path](rdma-protection-domains.md#the-watcher-reboots-itself)
+  — so this failure mode already self-clears without a special case.
+- **Never read halt state by file existence.** `[ -f rank-halted ]` reports
+  the automation's own self-healing as an outage: post-reboot the marker
+  legitimately exists for a tick before `halt_drop_if_pre_boot` drops it. Test
+  the marker's `boot=` field against `sysctl -n kern.boottime`. Same family: a
+  `quiesced-agents` marker is not evidence the agents are quiesced — observe
+  the processes, never trust a marker over the machine.
+- **Read a failure burst from the FIRST error, not the last.** 2026-08-02: the
+  first rank failure was a Metal OOM
+  (`kIOGPUCommandBufferCallbackErrorOutOfMemory`); every later attempt died
+  `[jaccl] Couldn't connect (error: 60)` — a downstream symptom pointing at
+  the network. The last error names the aftermath; the first names the cause.
+- **`errno 60` never names the machine that is wrong.** It is `ETIMEDOUT`.
+  Enforced: `cluster-join` probes the peer (`peerReadyTimeoutSecs`) before the
+  long wait and refuses naming which side is unverified; the watcher's peer
+  rung refuses a start against an absent peer — no rank, no domain spent.
+- **A worker rank can die SIGSEGV (exit 139) when its peer vanishes.**
+  `launchctl list`'s second column is the last exit status; a bare
+  running/not-running check hides it.


### PR DESCRIPTION
## Summary
- Reverts the per-file `.token-limits.yaml` override added in #1686 — raising a check's own threshold is a bypass, not a fix.
- Splits the "reading the machine" observation-trap bullets out of `cluster-link-truths.md` into a new page, `docs/runbooks/cluster-observation-traps.md` — a real category split (diagnostic gotchas vs. state-machine rules), not a token-shedding trick.
- `cluster-link-truths.md` goes from 3270 tokens (11 over budget before this session ever touched it) to 2578, honestly under the shared `docs/*.md` 3000 limit.

## Test plan
- [x] `pre-commit run` on changed files — passed
- [x] Verified token counts with the same tiktoken counter CI uses

Assisted-by: Claude:claude-sonnet-5
Claude-Session: https://claude.ai/code/session_01R438Ytsn7PLsnDUUTbexp3