### PR TITLE
fix(mlx): check real generation progress before the soak probe

### DIFF
--- a/lib/checks/mlx-cluster-recovery.nix
+++ b/lib/checks/mlx-cluster-recovery.nix
@@ -78,4 +78,19 @@
     WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
   } "bash ${src}/tests/test-quiesce-restore.sh && touch $out";
 
+  # THE CHECK THAT FAILS IF A BUSY-BUT-HEALTHY RANK GETS DECLARED WEDGED.
+  # The soak probe used to trust only endpoint_busy (a held TCP connection) as
+  # proof the pipeline was busy rather than dead — which misses a client that
+  # disconnected on its own timeout while the backend was still occupied. Pins
+  # that real generation progress (new_progress_lines) is checked first and
+  # short-circuits the probe.
+  mlx-cluster-soak-busy-vs-wedged = pkgs.runCommand "check-mlx-cluster-soak-busy-vs-wedged" {
+    nativeBuildInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.gawk
+    ];
+    WATCHER = "${src}/modules/mlx/scripts/cluster-link-watcher.sh";
+  } "bash ${src}/tests/test-soak-busy-vs-wedged.sh && touch $out";
+
 }

--- a/modules/mlx/cluster-script-layers.nix
+++ b/modules/mlx/cluster-script-layers.nix
@@ -69,6 +69,9 @@
     # layer that calls it. Watcher-only for the same SC2329 reason as
     # cluster-pd-cause.sh above: nothing else publishes or reads peer state.
     ./scripts/cluster-peer-state.sh
+    # new_progress_lines, for the soak probe's proof-of-life check ahead of
+    # endpoint_busy — the same file cluster-peer-liveness.sh already pulls in.
+    ./scripts/cluster-peer-observe.sh
     ./scripts/cluster-link-watcher.sh
   ];
 

--- a/modules/mlx/cluster-watcher-env.nix
+++ b/modules/mlx/cluster-watcher-env.nix
@@ -168,6 +168,11 @@ in
   # its connections open the same way, so the deferral is bounded here.
   CLUSTER_SOAK_BUSY_SKIP_MAX = toString ncfg.soakBusySkipMax;
   CLUSTER_WARM_RECHECK_SECS = toString ncfg.warmRecheckSecs;
+  # Real generation progress, checked ahead of endpoint_busy in the soak probe —
+  # same log and pattern cluster-peer-liveness.sh's coordinator_tick already
+  # reads, reused rather than re-derived (see cluster-peer-observe.sh).
+  CLUSTER_RANK_PROGRESS_LOG = rankErrorLog;
+  CLUSTER_PEER_PROGRESS_PATTERN = ncfg.peerLiveness.progressPattern;
   # vk1188 automated health gate + soak.
   CLUSTER_HEALTH_GATE_TIMEOUT_SECS = toString ncfg.healthGateTimeoutSecs;
   CLUSTER_HEALTH_GATE_CONCURRENCY = toString ncfg.healthGateConcurrency;

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -68,6 +68,9 @@
 #                         progress (new_progress_lines, cluster-peer-observe.sh)
 #                         before the soak probe fires; empty skips the check
 #   CLUSTER_PEER_PROGRESS_PATTERN  ERE marking token progress in that log
+#   CLUSTER_STAT_BIN         stat path/seam for the soak marker's mtime read
+#                         (BSD `-f %m` syntax); production absolute path,
+#                         since the Linux Nix sandbox has no /usr/bin/stat
 #   CLUSTER_SHARD_MEMORY_MB  expected per-rank working set in MB; 0 disables
 #                         the memory-headroom rung with no vm_stat read at all
 #                         (see mem_headroom_ok in cluster-link-guards.sh)
@@ -509,7 +512,7 @@ if [ "$cur" = "up" ]; then
     # Keep these marker comments exactly as written; the test greps for them.
     if [ "$CLUSTER_ROLE" = "coordinator" ] && [ -f "$warm_file" ] &&
       [ ! -f "$halt_file" ] && [ "${CLUSTER_WARM_RECHECK_SECS:-600}" -gt 0 ]; then
-      warmed_at="$(/usr/bin/stat -f %m "$warm_file" 2> /dev/null || echo 0)"
+      warmed_at="$("${CLUSTER_STAT_BIN:-/usr/bin/stat}" -f %m "$warm_file" 2> /dev/null || echo 0)"
       if [ "$warmed_at" -gt 0 ] &&
         [ "$(($(date +%s) - warmed_at))" -ge "${CLUSTER_WARM_RECHECK_SECS:-600}" ]; then
         echo "cluster-link: soak re-check (warm marker older than ${CLUSTER_WARM_RECHECK_SECS:-600}s)"

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -64,6 +64,10 @@
 #                         probe (c) (default 2)
 #   CLUSTER_HEALTH_GATE_CONCURRENT_TIMEOUT_SECS  bound on EACH of those N
 #                         (default 180)
+#   CLUSTER_RANK_PROGRESS_LOG  the rank's own log, tailed for real generation
+#                         progress (new_progress_lines, cluster-peer-observe.sh)
+#                         before the soak probe fires; empty skips the check
+#   CLUSTER_PEER_PROGRESS_PATTERN  ERE marking token progress in that log
 #   CLUSTER_SHARD_MEMORY_MB  expected per-rank working set in MB; 0 disables
 #                         the memory-headroom rung with no vm_stat read at all
 #                         (see mem_headroom_ok in cluster-link-guards.sh)
@@ -501,61 +505,87 @@ if [ "$cur" = "up" ]; then
     # the rank wedged on a real 8-token request — 0 bytes after 900s, both
     # ranks spinning at ~100% CPU. Readiness stayed latched and nothing
     # escalated for over an hour. This soak is what would have caught it.
+    # SOAK BLOCK — extracted and run verbatim by tests/test-soak-busy-vs-wedged.sh.
+    # Keep these marker comments exactly as written; the test greps for them.
     if [ "$CLUSTER_ROLE" = "coordinator" ] && [ -f "$warm_file" ] &&
       [ ! -f "$halt_file" ] && [ "${CLUSTER_WARM_RECHECK_SECS:-600}" -gt 0 ]; then
       warmed_at="$(/usr/bin/stat -f %m "$warm_file" 2> /dev/null || echo 0)"
       if [ "$warmed_at" -gt 0 ] &&
         [ "$(($(date +%s) - warmed_at))" -ge "${CLUSTER_WARM_RECHECK_SECS:-600}" ]; then
         echo "cluster-link: soak re-check (warm marker older than ${CLUSTER_WARM_RECHECK_SECS:-600}s)"
-        # NEVER PROBE A BUSY PIPELINE. mlx_lm.server serializes generation and
-        # blocks HTTP for its duration, so a 1-token probe fired while a real
-        # request is in flight queues behind it and expires on the probe's own
-        # timeout — through no fault of the mesh. On 2026-08-08 that killed a
-        # healthy pipeline mid-answer: a 22k-token generation had streamed
-        # nothing for 181s, the probe expired, the gate declared the rank
-        # wedged, and the SIGTERM teardown leaked the wired shard on both hosts.
-        # In-flight work IS proof of life; the probe exists to find out whether
-        # there is any, and here there demonstrably is.
-        #
-        # BOUNDED, because a wedged rank holds connections open exactly as a
-        # busy one does. After CLUSTER_SOAK_BUSY_SKIP_MAX consecutive deferrals
-        # the probe fires anyway — with a timeout that already exceeds the read
-        # timeout real clients use, so a genuine long generation still completes
-        # inside it and only a true wedge fails.
-        #
-        # The warm marker is deliberately NOT refreshed on a deferral. Touching
-        # it would push the next re-check a full interval into the future on
-        # every skip, so a rank that holds a connection forever would never be
-        # probed again — the deferral would become the wedge's hiding place.
-        # Left stale, the block re-evaluates next tick and the counter advances
-        # toward the bound.
-        soak_skips=0
-        [ -f "$soak_busy_skips_file" ] && soak_skips="$(cat "$soak_busy_skips_file")"
-        case "$soak_skips" in
-          '' | *[!0-9]*) soak_skips=0 ;;
+        # REAL GENERATION PROGRESS BEATS EVERY OTHER SIGNAL. new_progress_lines
+        # (cluster-peer-observe.sh, the same predicate cluster-peer-liveness.sh's
+        # coordinator_tick checks first) counts token/prompt lines the rank's own
+        # log emitted since the last read. endpoint_busy only sees an ESTABLISHED
+        # connection — which vanishes the moment a client disconnects on its own
+        # timeout, even while the backend is still doing real work. A soak probe
+        # fired into that gap queues behind the work and times out, misreading a
+        # busy-but-healthy pipeline as wedged (2026-08-16: a burst of requests
+        # against unloaded models did exactly this). Checked first because it is
+        # strictly stronger evidence than a held connection.
+        progressed=0
+        if [ -n "${CLUSTER_RANK_PROGRESS_LOG:-}" ]; then
+          progressed="$(new_progress_lines)"
+        fi
+        case "$progressed" in
+          '' | *[!0-9]*) progressed=0 ;;
         esac
-        if endpoint_busy && [ "$soak_skips" -lt "${CLUSTER_SOAK_BUSY_SKIP_MAX:-10}" ]; then
-          soak_skips=$((soak_skips + 1))
-          printf '%s\n' "$soak_skips" > "$soak_busy_skips_file"
-          echo "cluster-link: soak: request in flight — probe skipped, busy pipeline is live ($soak_skips/${CLUSTER_SOAK_BUSY_SKIP_MAX:-10} before probing regardless)"
-        elif health_gate_soak_probe "$health_gate_file" "$CLUSTER_RANK_URL" "${CLUSTER_MODEL:-}" \
-          "${CLUSTER_HEALTH_GATE_TIMEOUT_SECS:-300}"; then
+        if [ "$progressed" -gt 0 ]; then
+          echo "cluster-link: soak: $progressed new progress line(s) since last tick — real traffic is live, treating as proof of life without probing"
           touch "$warm_file"
           rm -f "$soak_busy_skips_file"
         else
-          echo "cluster-link: soak probe FAILED (${HEALTH_GATE_DETAIL:-no detail}); declaring the rank WEDGED and restoring standalone serving" >&2
-          halt_write "$halt_file" "$halt_latch_file" "health-gate-soak-fail" \
-            "${HEALTH_GATE_DETAIL:-soak completion probe failed}"
-          launchctl kill SIGTERM "gui/$uid/$CLUSTER_RANK_LABEL" 2> /dev/null || true
-          if [ -n "${CLUSTER_WIRED_LIMIT_MB:-}" ]; then
-            set_wired_limit "${CLUSTER_STANDALONE_WIRED_LIMIT_MB:-0}" || true
+          # NEVER PROBE A BUSY PIPELINE. mlx_lm.server serializes generation and
+          # blocks HTTP for its duration, so a 1-token probe fired while a real
+          # request is in flight queues behind it and expires on the probe's own
+          # timeout — through no fault of the mesh. On 2026-08-08 that killed a
+          # healthy pipeline mid-answer: a 22k-token generation had streamed
+          # nothing for 181s, the probe expired, the gate declared the rank
+          # wedged, and the SIGTERM teardown leaked the wired shard on both hosts.
+          # In-flight work IS proof of life; the probe exists to find out whether
+          # there is any, and here there demonstrably is.
+          #
+          # BOUNDED, because a wedged rank holds connections open exactly as a
+          # busy one does. After CLUSTER_SOAK_BUSY_SKIP_MAX consecutive deferrals
+          # the probe fires anyway — with a timeout that already exceeds the read
+          # timeout real clients use, so a genuine long generation still completes
+          # inside it and only a true wedge fails.
+          #
+          # The warm marker is deliberately NOT refreshed on a deferral. Touching
+          # it would push the next re-check a full interval into the future on
+          # every skip, so a rank that holds a connection forever would never be
+          # probed again — the deferral would become the wedge's hiding place.
+          # Left stale, the block re-evaluates next tick and the counter advances
+          # toward the bound.
+          soak_skips=0
+          [ -f "$soak_busy_skips_file" ] && soak_skips="$(cat "$soak_busy_skips_file")"
+          case "$soak_skips" in
+            '' | *[!0-9]*) soak_skips=0 ;;
+          esac
+          if endpoint_busy && [ "$soak_skips" -lt "${CLUSTER_SOAK_BUSY_SKIP_MAX:-10}" ]; then
+            soak_skips=$((soak_skips + 1))
+            printf '%s\n' "$soak_skips" > "$soak_busy_skips_file"
+            echo "cluster-link: soak: request in flight — probe skipped, busy pipeline is live ($soak_skips/${CLUSTER_SOAK_BUSY_SKIP_MAX:-10} before probing regardless)"
+          elif health_gate_soak_probe "$health_gate_file" "$CLUSTER_RANK_URL" "${CLUSTER_MODEL:-}" \
+            "${CLUSTER_HEALTH_GATE_TIMEOUT_SECS:-300}"; then
+            touch "$warm_file"
+            rm -f "$soak_busy_skips_file"
+          else
+            echo "cluster-link: soak probe FAILED (${HEALTH_GATE_DETAIL:-no detail}); declaring the rank WEDGED and restoring standalone serving" >&2
+            halt_write "$halt_file" "$halt_latch_file" "health-gate-soak-fail" \
+              "${HEALTH_GATE_DETAIL:-soak completion probe failed}"
+            launchctl kill SIGTERM "gui/$uid/$CLUSTER_RANK_LABEL" 2> /dev/null || true
+            if [ -n "${CLUSTER_WIRED_LIMIT_MB:-}" ]; then
+              set_wired_limit "${CLUSTER_STANDALONE_WIRED_LIMIT_MB:-0}" || true
+            fi
+            restore_normal_serving || true
+            alert "$(hostname -s): cluster rank failed its periodic soak health-check (${HEALTH_GATE_DETAIL:-no detail}); torn down to standalone serving. Replug the link to retry." \
+              "mlx-cluster rank wedged (soak)"
           fi
-          restore_normal_serving || true
-          alert "$(hostname -s): cluster rank failed its periodic soak health-check (${HEALTH_GATE_DETAIL:-no detail}); torn down to standalone serving. Replug the link to retry." \
-            "mlx-cluster rank wedged (soak)"
         fi
       fi
     fi
+    # END SOAK BLOCK
 
     # THE HEALTH GATE: once the rank is ready, run the full automated check —
     # vk1188, replacing the human who used to run this by hand every night.

--- a/tests/test-soak-busy-vs-wedged.sh
+++ b/tests/test-soak-busy-vs-wedged.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# THE CHECK THAT FAILS IF A BUSY-BUT-HEALTHY RANK GETS DECLARED WEDGED.
+#
+# The soak probe (health_gate_soak_probe) used to trust only endpoint_busy — an
+# ESTABLISHED TCP connection on the endpoint port — as evidence the pipeline was
+# busy rather than dead. That misses the case where the client that triggered
+# real work (a generation, a model load) disconnects on its own timeout: the
+# connection vanishes while the backend is still occupied, the soak probe's own
+# request queues behind it, times out, and a healthy-but-busy rank is torn down
+# as "wedged" (2026-08-16: a burst of requests against unloaded models did
+# exactly this and halted a rank that was never broken).
+#
+# This pins that real generation progress (new_progress_lines — the SAME
+# predicate cluster-peer-liveness.sh's coordinator_tick already checks first)
+# is consulted BEFORE endpoint_busy, and that any progress since the last tick
+# short-circuits the probe entirely rather than risking it against a still-busy
+# backend.
+#
+# WHAT IS REAL AND WHAT IS NOT:
+#   REAL  — the SOAK BLOCK is EXTRACTED FROM THE SHIPPED cluster-link-watcher.sh
+#           between its own comment markers and executed, so a drift in the
+#           shipped sequence fails here.
+#   STUB  — new_progress_lines, endpoint_busy, health_gate_soak_probe,
+#           halt_write, restore_normal_serving, launchctl and alert are stubbed
+#           to drive each branch deterministically; each one's own behaviour is
+#           pinned by its own test file (test-mem-headroom.sh,
+#           test-quiesce-restore.sh).
+#
+# Usage:
+#   WATCHER=… bash test-soak-busy-vs-wedged.sh
+set -o errexit -o nounset -o pipefail
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+watcher="${WATCHER:?set WATCHER to cluster-link-watcher.sh}"
+
+# The shipped block itself, between its own markers. Empty extraction = the
+# markers moved, which must fail loudly rather than test nothing.
+block="$(awk '/^    # SOAK BLOCK/,/^    # END SOAK BLOCK/' "$watcher")"
+case "$block" in
+  *new_progress_lines* | *endpoint_busy* | *health_gate_soak_probe*) ;;
+  *)
+    echo "FAIL could not extract the soak block from $watcher" >&2
+    exit 1
+    ;;
+esac
+
+fail=0
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  ok   $label -> $got"
+  else
+    echo "  FAIL $label -> got '$got', want '$want'"
+    fail=1
+  fi
+}
+contains() {
+  local label="$1" needle="$2" hay="$3"
+  case "$hay" in
+    *"$needle"*) echo "  ok   $label" ;;
+    *)
+      echo "  FAIL $label -> '$needle' not in: $hay"
+      fail=1
+      ;;
+  esac
+}
+
+probe_log="$tmp/probe-log"
+restore_log="$tmp/restore-log"
+halt_log="$tmp/halt-log"
+new_progress_lines() { printf '%s' "${FAKE_PROGRESS:-0}"; }
+endpoint_busy() { [ "${FAKE_BUSY:-0}" = 1 ]; }
+health_gate_soak_probe() {
+  echo ran >> "$probe_log"
+  [ "${FAKE_PROBE_OK:-1}" = 1 ]
+}
+restore_normal_serving() { echo ran >> "$restore_log"; }
+halt_write() {
+  echo "$3" >> "$halt_log"
+  printf '%s\n' "$3" > "$1"
+}
+launchctl() { :; }
+set_wired_limit() { :; }
+alert() { :; }
+
+# Watcher-scope variables the block reads/writes at this point in a real tick.
+# shellcheck disable=SC2034  # read by the extracted block, not by name here
+uid=501
+# shellcheck disable=SC2034  # read by the extracted block, not by name here
+CLUSTER_ROLE=coordinator
+# shellcheck disable=SC2034
+CLUSTER_RANK_LABEL="dev.mlx-cluster.rank"
+# shellcheck disable=SC2034
+CLUSTER_RANK_URL="http://127.0.0.1:11440"
+# shellcheck disable=SC2034
+CLUSTER_MODEL="test-model"
+# shellcheck disable=SC2034
+CLUSTER_RANK_PROGRESS_LOG="$tmp/rank.log"
+warm_file="$tmp/warm"
+# shellcheck disable=SC2034
+health_gate_file="$tmp/health-gate"
+halt_file="$tmp/halted"
+# shellcheck disable=SC2034
+halt_latch_file="$tmp/halt-latch"
+soak_busy_skips_file="$tmp/soak-skips"
+touch "$warm_file"
+# Old enough to trip the recheck unconditionally, regardless of wall-clock skew.
+touch -t 202001010000 "$warm_file"
+
+reset() {
+  rm -f "$probe_log" "$restore_log" "$halt_log" "$halt_file" "$soak_busy_skips_file"
+  touch "$warm_file"
+  touch -t 202001010000 "$warm_file"
+  export FAKE_PROGRESS=0 FAKE_BUSY=0 FAKE_PROBE_OK=1
+}
+tick() { out="$(eval "$block" 2>&1)"; }
+probe_count() { [ -f "$probe_log" ] && wc -l < "$probe_log" | tr -d ' ' || echo 0; }
+
+echo "real generation progress: no probe fired, not declared wedged:"
+reset
+export FAKE_PROGRESS=3 FAKE_BUSY=0
+tick
+check "probe NOT called" 0 "$(probe_count)"
+check "not halted" absent "$([ -f "$halt_file" ] && echo present || echo absent)"
+contains "logs proof of life" "real traffic is live, treating as proof of life" "$out"
+
+echo "progress AND endpoint_busy both true: progress still wins, no probe:"
+reset
+export FAKE_PROGRESS=1 FAKE_BUSY=1
+tick
+check "probe NOT called" 0 "$(probe_count)"
+
+echo "no progress, endpoint busy: deferred exactly as before (unchanged behaviour):"
+reset
+export FAKE_PROGRESS=0 FAKE_BUSY=1
+tick
+check "probe NOT called" 0 "$(probe_count)"
+contains "logs the defer" "busy pipeline is live" "$out"
+
+echo "no progress, not busy, probe fails: still declared wedged (unchanged behaviour):"
+reset
+export FAKE_PROGRESS=0 FAKE_BUSY=0 FAKE_PROBE_OK=0
+tick
+check "probe called" 1 "$(probe_count)"
+check "halted" health-gate-soak-fail "$(cat "$halt_file" 2> /dev/null || echo absent)"
+check "restore ran" 1 "$([ -f "$restore_log" ] && wc -l < "$restore_log" | tr -d ' ' || echo 0)"
+
+exit "$fail"

--- a/tests/test-soak-busy-vs-wedged.sh
+++ b/tests/test-soak-busy-vs-wedged.sh
@@ -105,6 +105,16 @@ halt_file="$tmp/halted"
 # shellcheck disable=SC2034
 halt_latch_file="$tmp/halt-latch"
 soak_busy_skips_file="$tmp/soak-skips"
+
+# CLUSTER_STAT_BIN seam: the shipped block reads BSD `stat -f %m`, which does
+# not exist in the Linux Nix sandbox this test also runs in under `nix flake
+# check`. Falls back to GNU coreutils' `stat -c %Y` there.
+stat_stub() {
+  /usr/bin/stat -f %m "$3" 2> /dev/null || stat -c %Y "$3" 2> /dev/null
+}
+# shellcheck disable=SC2034
+CLUSTER_STAT_BIN=stat_stub
+
 touch "$warm_file"
 # Old enough to trip the recheck unconditionally, regardless of wall-clock skew.
 touch -t 202001010000 "$warm_file"


### PR DESCRIPTION
## Summary
- The soak probe (`cluster-link-watcher.sh`'s SOAK BLOCK) now checks `new_progress_lines` — real token-generation progress in the rank's own log since the last tick — before falling back to `endpoint_busy`. Any progress short-circuits the probe as proof of life.
- `endpoint_busy` alone only sees an ESTABLISHED TCP connection, which can vanish (client-side disconnect/timeout) while the backend is still occupied with real work, letting a busy-but-healthy rank get misread as wedged and torn down.
- Reuses `new_progress_lines` (`cluster-peer-observe.sh`), the same predicate `cluster-peer-liveness.sh`'s `coordinator_tick` already checks first — added `cluster-peer-observe.sh` to the watcher's script layer and wired `CLUSTER_RANK_PROGRESS_LOG` / `CLUSTER_PEER_PROGRESS_PATTERN` into the watcher's env (same values `peer-liveness.nix` already derives).
- Behavior when there is no progress is unchanged: `endpoint_busy` deferral, then the probe, then `health-gate-soak-fail` + `restore_normal_serving` on failure.

## Tests
- New `tests/test-soak-busy-vs-wedged.sh`, extracting the shipped `SOAK BLOCK` between its own markers (same pattern as `tests/test-quiesce-restore.sh`). Covers: progress alone skips the probe; progress wins even when also busy; no-progress-and-busy defers as before; no-progress-and-not-busy still probes and halts+restores on failure.
- Registered as `lib/checks/mlx-cluster-recovery.nix`'s `mlx-cluster-soak-busy-vs-wedged`.
- Confirmed the new test fails against the pre-fix watcher (marker extraction fails, same failure shape the existing quiesce-restore test uses).
- `nix flake check` green; sibling tests (`test-quiesce-restore.sh`, `test-watcher-heartbeat.sh`) unaffected; `shellcheck --severity=warning --exclude=SC1091` clean.