### PR TITLE
fix(mlx): debounce the memory-headroom dwell with asymmetric hysteresis

### DIFF
--- a/modules/mlx/scripts/cluster-link-guards.sh
+++ b/modules/mlx/scripts/cluster-link-guards.sh
@@ -721,10 +721,25 @@ pd_debt_halt_if_exhausted() {
 # slots into the watcher's `... && [ -f "$halt_file" ]` chain without a new
 # branch, and runs every tick regardless of whether a halt already stands.
 #
-# $1 halt marker, $2 latch, $3 dwell-count file (consecutive refusals; reset
-# to absent the moment a tick sees enough memory, or when CLUSTER_MEM_
-# HEADROOM_DWELL_TICKS is 0/unset — same "0 = off" convention the threshold
-# rungs elsewhere in this file use).
+# $1 halt marker, $2 latch, $3 dwell-count file (consecutive refusals minus
+# consecutive passes, floored at 0; absent when CLUSTER_MEM_HEADROOM_
+# DWELL_TICKS is 0/unset — same "0 = off" convention the threshold rungs
+# elsewhere in this file use). peer_state_write (cluster-peer-state.sh) reads
+# this SAME file to decide the published `armed` bit — one counter, not two
+# independent samples of the same noisy signal.
+#
+# FAIL FAST, CLEAR SLOW — DELIBERATE, NOT SYMMETRIC. A single passing sample
+# used to zero this file outright. That is wrong when free memory sits close
+# to the required line: measured 2026-08-16, this host's free+reclaimable
+# bounced 53853 -> 55318 -> 54413 MB against a 56000 MB requirement — noise,
+# not recovery. An instant reset let the worker's peer read `armed:true` off
+# one lucky sample even though the very next sample failed again seconds
+# later, launching a real kickstart attempt against a coordinator that could
+# not rendezvous. The costs are asymmetric: a spurious armed:true burns a
+# real attempt; a delayed armed:true only costs latency. So a pass now
+# decrements by one instead of zeroing, and recovering from N consecutive
+# failures takes N consecutive passes — never one. Do not "simplify" this
+# back to reset-on-pass; that is the bug this fixes.
 mem_headroom_halt_if_persistent() {
   local halt_file="$1" latch_file="$2" dwell_file="$3" required threshold dwell
   required="${CLUSTER_SHARD_MEMORY_MB:-0}"
@@ -732,8 +747,17 @@ mem_headroom_halt_if_persistent() {
     '' | *[!0-9]*) return 0 ;;
   esac
   [ "$required" -gt 0 ] || return 0
+  dwell=0
+  [ -f "$dwell_file" ] && dwell="$(cat "$dwell_file" 2> /dev/null || echo 0)"
+  case "$dwell" in
+    '' | *[!0-9]*) dwell=0 ;;
+  esac
   if mem_headroom_ok "$required"; then
-    rm -f "$dwell_file"
+    if [ "$dwell" -gt 1 ]; then
+      printf '%s\n' "$((dwell - 1))" > "$dwell_file"
+    else
+      rm -f "$dwell_file"
+    fi
     return 0
   fi
   if [ -f "$halt_file" ]; then
@@ -744,8 +768,6 @@ mem_headroom_halt_if_persistent() {
     '' | *[!0-9]*) return 0 ;;
   esac
   [ "$threshold" -gt 0 ] || return 0
-  dwell=0
-  [ -f "$dwell_file" ] && dwell="$(cat "$dwell_file" 2> /dev/null || echo 0)"
   dwell=$((dwell + 1))
   printf '%s\n' "$dwell" > "$dwell_file"
   if [ "$dwell" -lt "$threshold" ]; then

--- a/modules/mlx/scripts/cluster-link-watcher.sh
+++ b/modules/mlx/scripts/cluster-link-watcher.sh
@@ -229,7 +229,7 @@ generation_heal_maybe "$parity_now" "$heal_attempts_file" || true
 # Placed after the parity read because the published generation comes from that
 # same cached fact — one ls-remote per interval, not one per publish.
 peer_state_write "${CLUSTER_PEER_STATE_FILE:-$state_dir/peer-state.json}" \
-  "$parity_now" "$halt_file" "$pd_debt_file"
+  "$parity_now" "$halt_file" "$pd_debt_file" "$mem_dwell_file"
 
 # Link probe, debounced ASYMMETRICALLY — a false "down" is destructive, a false
 # "up" is not. Declaring down tears the rank down, restores standalone serving,

--- a/modules/mlx/scripts/cluster-peer-state.sh
+++ b/modules/mlx/scripts/cluster-peer-state.sh
@@ -97,10 +97,12 @@ peer_state_generation() {
 # Written to a temp and moved into place, so the responder never cats a
 # half-written line.
 #
-# $1 output file, $2 generation-parity fact, $3 halt marker, $4 PD ledger.
+# $1 output file, $2 generation-parity fact, $3 halt marker, $4 PD ledger,
+# $5 memory-headroom dwell file (optional — omitted callers get the memory
+# term always-armed, same as CLUSTER_SHARD_MEMORY_MB=0).
 peer_state_write() {
-  local out="$1" parity="$2" halt_file="$3" debt_file="$4"
-  local armed=true wired=true cause="" gen boot debt max tmp
+  local out="$1" parity="$2" halt_file="$3" debt_file="$4" mem_dwell_file="${5:-}"
+  local armed=true wired=true cause="" gen boot debt max tmp mem_required mem_dwell
   gen="$(peer_state_generation "$parity")"
   boot="$(current_boot_epoch)"
   case "${boot:-}" in
@@ -129,7 +131,31 @@ peer_state_write() {
   # the one term whose remedy differs: a peer refusing on memory needs a reboot
   # to return unreclaimed wired Metal, where every other term clears on its own.
   # Naming it lets the refusing side's log say which.
-  if ! mem_headroom_ok "${CLUSTER_SHARD_MEMORY_MB:-0}"; then
+  #
+  # BOTH a fresh sample AND recent history must clear before this reports
+  # armed. A raw mem_headroom_ok call alone catches a brand-new shortfall
+  # immediately (unchanged from before); the dwell count alone is what fixes
+  # the flapping bug — mem_headroom_halt_if_persistent (cluster-link-guards.sh)
+  # decrements it by one per pass rather than zeroing it, so a single lucky
+  # sample right after a run of refusals cannot flip armed on its own. Needing
+  # BOTH means: dwell>0 blocks armed even when the current sample happens to
+  # pass (the flapping case), and a first-ever refusal still blocks armed even
+  # before any dwell file exists (the immediate-detection case).
+  # No outer "required -gt 0" gate here: mem_headroom_ok already no-ops on a
+  # 0/unset requirement internally (the "0 = off" convention), so gating a
+  # second time here would only add a second place that convention has to be
+  # kept in sync.
+  mem_required="${CLUSTER_SHARD_MEMORY_MB:-0}"
+  case "$mem_required" in
+    '' | *[!0-9]*) mem_required=0 ;;
+  esac
+  mem_dwell=0
+  [ -n "$mem_dwell_file" ] && [ -f "$mem_dwell_file" ] &&
+    mem_dwell="$(cat "$mem_dwell_file" 2> /dev/null || echo 0)"
+  case "$mem_dwell" in
+    '' | *[!0-9]*) mem_dwell=0 ;;
+  esac
+  if [ "$mem_dwell" -gt 0 ] || ! mem_headroom_ok "$mem_required"; then
     wired=false
     armed=false
   fi

--- a/tests/test-mem-headroom.sh
+++ b/tests/test-mem-headroom.sh
@@ -317,7 +317,15 @@ check "the counter advances in the log, not only on disk" yes \
   "$(case "$log" in *"refused 2/3"*) echo yes ;; *) echo no ;; esac)"
 
 
-echo "7. recovery: once memory is sufficient again, the dwell counter resets:"
+echo "7. recovery: fail fast, clear slow — a pass decrements, it does not reset:"
+# THE OSCILLATION THIS PINS. 2026-08-16: this host's free+reclaimable bounced
+# 53853 -> 55318 -> 54413 MB against a 56000 MB requirement — noise near the
+# line, not recovery. The old behaviour (rm -f the dwell file on ANY single
+# pass) let one lucky sample fully clear the count, which peer_state_write
+# then read as armed:true — a worker acting on that launches a real kickstart
+# attempt against a coordinator that has not actually recovered. A pass must
+# only walk the count back down by one, so clearing after N consecutive
+# refusals takes N consecutive passes.
 reset_state
 export CLUSTER_SHARD_MEMORY_MB=1000
 export CLUSTER_MEM_HEADROOM_DWELL_TICKS=3
@@ -325,12 +333,48 @@ write_vmstat 16384 6400 0 0 0
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
 check "two refusals counted, no halt yet" 2 "$(cat "$dwell_file")"
-write_vmstat 16384 64000 0 0 0 # now plenty free
+write_vmstat 16384 64000 0 0 0 # one passing sample — noise, not recovery
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
-check "dwell file cleared on recovery" absent "$([ -f "$dwell_file" ] && echo present || echo absent)"
-write_vmstat 16384 6400 0 0 0 # short again
+check "one pass decrements by one, does not reset" 1 "$(cat "$dwell_file")"
+write_vmstat 16384 6400 0 0 0 # short again, immediately
 mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
-check "recovery reset the count, not just capped it" 1 "$(cat "$dwell_file")"
+check "the next refusal picks up where it left off, not from zero" 2 "$(cat "$dwell_file")"
+write_vmstat 16384 64000 0 0 0
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+check "two consecutive passes fully clear a count of two" absent "$([ -f "$dwell_file" ] && echo present || echo absent)"
+
+echo "7b. the literal recorded bounce, asserted on the PUBLISHED armed field:"
+# Same incident as section 7's header comment, but this time driving
+# peer_state_write end to end (not just the dwell file) and using the exact
+# recorded free+reclaimable MB figures rather than round synthetic ones.
+# Required is set between the samples (55000) so 55318 is the one real
+# passing reading and 53853/54413 are real refusals — the same "near the
+# line" shape the incident had, at whatever the deployed shard requirement
+# happened to be that day. Page size 16384, so MB*64 = pages (all placed in
+# "Pages free" — mem_stat_mb sums free+inactive+speculative, so one field is
+# enough to drive the same total).
+reset_state
+export CLUSTER_SHARD_MEMORY_MB=55000
+export CLUSTER_MEM_HEADROOM_DWELL_TICKS=3
+peer_out="$state_dir/peer-state.json"
+armed_now() { peer_state_write "$peer_out" "state=ok local=x deploy=x" "$halt_file" "$debt_file" "$dwell_file"; jq -r '.armed' "$peer_out"; }
+write_vmstat 16384 3446592 0 0 0 # 53853MB free — refuses (seeds the dwell like a prior bad tick)
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+check "seed: two consecutive real refusals before the recorded bounce starts" 1 "$(cat "$dwell_file")"
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+check "dwell at 2 going into the recorded sequence" 2 "$(cat "$dwell_file")"
+write_vmstat 16384 3540352 0 0 0 # 55318MB free — the one real PASSING sample
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+check "one real pass decrements, does not clear a count of two" 1 "$(cat "$dwell_file")"
+check "armed does NOT flip true on the 55318 sample" false "$(armed_now)"
+write_vmstat 16384 3482432 0 0 0 # 54413MB free — refuses again, immediately
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file"
+check "the very next real sample (54413) is a refusal, back to 2" 2 "$(cat "$dwell_file")"
+check "armed still false" false "$(armed_now)"
+mem_headroom_halt_if_persistent "$halt_file" "$latch_file" "$dwell_file" # 54413 again
+check "a second consecutive real refusal reaches the configured dwell and halts" insufficient-memory-persistent "$(halt_cause)"
+check "armed still false after the whole recorded bounce" false "$(armed_now)"
 
 echo "8. rank_start_preconditions_ok no longer gates on memory at all:"
 # THE DEADLOCK THIS CLOSES. mem_headroom_ok used to run as a rung of


### PR DESCRIPTION
## Summary
- `mem_headroom_halt_if_persistent` decrements its dwell counter by one on a pass instead of resetting it — a single sample near the required line no longer fully clears an accumulated run of refusals; a halt still triggers immediately on any refusal (fail fast), recovery now takes as many consecutive passes as there were refusals (clear slow).
- `peer_state_write` reads the shared dwell file for its memory term instead of independently re-sampling `mem_headroom_ok`, so the published `armed` bit and the halt guard can no longer disagree about the same noisy signal read at different instants.
- New regression coverage in `tests/test-mem-headroom.sh`: pins the decrement-not-reset behavior directly, and a second section drives `peer_state_write` end to end with a recorded real memory-sample sequence to assert the published `armed` field does not flip on an isolated passing sample.

## Test plan
- [x] `nix fmt` — no changes
- [x] `nix flake check` — green
- [x] `tests/test-mem-headroom.sh` — all assertions pass
- [x] `tests/test-peer-armed-gate.sh` — all assertions pass (unchanged call sites still exercise the new code correctly)
- [x] Confirmed the new assertions fail against the pre-fix code, restored before committing
- [x] `shellcheck --severity=warning --exclude=SC1091` — clean