### PR TITLE
feat(opencode): pretty-print config, trust public root, add aikey keychain shortcut

### DIFF
--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -100,6 +100,10 @@ in
       # User-facing values (model, marketplaces, hooks, settings.*) live in
       # this module — nix-claude-code only declares the option schema.
       ../modules/claude-config.nix
+      # userConfig option surface (claude-config reads it via common →
+      # permissions). Imported here so standalone consumers get the same
+      # option as homeManagerModules.default.
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -125,6 +129,7 @@ in
       ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/codex
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -140,6 +145,7 @@ in
       ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/antigravity-cli
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -155,6 +161,7 @@ in
       ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/antigravity-ide
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -180,6 +187,7 @@ in
       ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/qwen-code
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -195,6 +203,7 @@ in
       ../modules/mcp/module.nix
       ../modules/agent-skills
       ../modules/opencode
+      ../modules/maintainer-profile.nix
     ];
     _module.args = {
       inherit
@@ -205,6 +214,9 @@ in
   };
 
   maestro = {
-    imports = [ ../modules/maestro ];
+    imports = [
+      ../modules/maestro
+      ../modules/maintainer-profile.nix
+    ];
   };
 }

--- a/modules/agent-skills/components.nix
+++ b/modules/agent-skills/components.nix
@@ -15,8 +15,17 @@ let
   inactiveSkillRoot = skillRoots.${if cfg.root == "codex" then "agents" else "codex"};
 
   # Harness fan-out: one registry generates the symlinks, the cleanup sweep,
-  # and (via lib/checks/agent-skills.nix) the regression coverage.
-  harnesses = import ./harnesses.nix;
+  # and (via lib/checks/agent-skills.nix) the regression coverage. harnesses.nix
+  # stays the static default registry; the opencode entries are re-derived from
+  # `opencodeConfigDir` so a relocated opencode config dir follows automatically.
+  harnesses = (import ./harnesses.nix) // {
+    skills = (import ./harnesses.nix).skills // {
+      opencode = "${cfg.opencodeConfigDir}/skills";
+    };
+    agentsMd = (import ./harnesses.nix).agentsMd // {
+      opencode = "${cfg.opencodeConfigDir}/AGENTS.md";
+    };
+  };
   harnessSkillDirs = builtins.attrValues harnesses.skills;
   harnessSymlinks = lib.genAttrs harnessSkillDirs (_: {
     source = config.lib.file.mkOutOfStoreSymlink "${homeDir}/${skillRoot}";

--- a/modules/agent-skills/options.nix
+++ b/modules/agent-skills/options.nix
@@ -29,6 +29,18 @@ in
       '';
     };
 
+    opencodeConfigDir = lib.mkOption {
+      type = lib.types.str;
+      default = ".config/opencode";
+      description = ''
+        OpenCode config directory (relative to $HOME) that the registry
+        symlinks skills and AGENTS.md into. Kept as the harness's own option so
+        this module stays standalone (it does not import programs.opencode);
+        the full stack wires it from programs.opencode.configDir in
+        modules/default.nix.
+      '';
+    };
+
     fromFlakeInputs = lib.mkOption {
       type = lib.types.listOf componentModule;
       default = [ ];

--- a/modules/ai-aliases.zsh
+++ b/modules/ai-aliases.zsh
@@ -25,6 +25,16 @@ if [[ "$OSTYPE" == darwin* ]]; then
   unset _ai_ro_var _ai_ro_val
 fi
 
+# Router API-key shortcut (macOS keychain only): `aikey <HARNESS>` prints the
+# value of the <HARNESS>_ROUTER_API_KEY generic-password item, e.g.
+#   aikey OPENCODE  ->  security find-generic-password -s OPENCODE_ROUTER_API_KEY -w
+if [[ "$OSTYPE" == darwin* ]]; then
+  aikey() {
+    [[ -n "$1" ]] || { print -u2 "usage: aikey <harness>"; return 1; }
+    security find-generic-password -s "${1}_ROUTER_API_KEY" -w
+  }
+fi
+
 # `claude` (unaliased) resolves via PATH to ~/.local/bin/claude — the pinned
 # stable build maintained by Anthropic's claude.ai/install.sh.
 # `claude-latest` bypasses the local install and fetches the npm `latest`

--- a/modules/antigravity-cli/settings.nix
+++ b/modules/antigravity-cli/settings.nix
@@ -19,7 +19,7 @@
 let
   cfg = config.programs.antigravity-cli;
   homeDir = config.home.homeDirectory;
-  gitDir = "${homeDir}/git";
+  gitDir = config.userConfig.paths.git;
 
   aiCommon = import ../common {
     inherit lib config nix-claude-code;
@@ -38,11 +38,11 @@ let
   ];
 
   # Default paths the sandbox may write to. Merged with cfg.sandboxAllowedPaths
-  # so every bare repo under ~/git/ can create worktrees without a denial.
+  # so every bare repo under the git root can create worktrees without a denial.
   defaultSandboxAllowedPaths = [
     gitDir
-    "${homeDir}/git/public"
-    "${homeDir}/git/public/nix-darwin/.git"
+    "${gitDir}/public"
+    "${gitDir}/public/nix-darwin/.git"
   ];
 
   mergedSandboxAllowedPaths = lib.unique (defaultSandboxAllowedPaths ++ cfg.sandboxAllowedPaths);

--- a/modules/antigravity-cli/settings.nix
+++ b/modules/antigravity-cli/settings.nix
@@ -38,11 +38,13 @@ let
   ];
 
   # Default paths the sandbox may write to. Merged with cfg.sandboxAllowedPaths
-  # so every bare repo under the git root can create worktrees without a denial.
+  # so git worktree creation on any bare repo under the workspace root succeeds
+  # without a denial — gitDir is a prefix, so it covers every repo's .git dir
+  # (including the consumer's nix-darwin bare repo); paths.public is the shared
+  # public workspace root.
   defaultSandboxAllowedPaths = [
     gitDir
-    "${gitDir}/public"
-    "${gitDir}/public/nix-darwin/.git"
+    config.userConfig.paths.public
   ];
 
   mergedSandboxAllowedPaths = lib.unique (defaultSandboxAllowedPaths ++ cfg.sandboxAllowedPaths);

--- a/modules/common/formatters/opencode.nix
+++ b/modules/common/formatters/opencode.nix
@@ -12,6 +12,13 @@
     {
       edit = "allow";
       webfetch = "allow";
+      # Always-trusted workspace root (permissions.directories.public). opencode
+      # expands an absolute /** glob identically to ~/git/public/**; without this
+      # rule, cross-repo access under the public root trips external_directory's
+      # default "ask".
+      external_directory = lib.genAttrs (map (d: "${d}/**") (permissions.directories.public or [ ])) (
+        _: "allow"
+      );
       bash = {
         "*" = "ask";
       }

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -100,6 +100,12 @@ in
     ];
 
     home = [ homeDir ];
+
+    # Public workspace root. Eval-time equivalent of GIT_HOME_PUBLIC (a runtime
+    # env var in nix-home); nix-ai cannot read env vars at eval time, so it is
+    # derived here from homeDir. Consumed by the opencode formatter's
+    # external_directory rules.
+    public = [ "${homeDir}/git/public" ];
   };
 
   # Tool-specific identifiers (non-shell, built-in tools)

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -107,9 +107,9 @@ in
 
     # Public workspace root. Eval-time equivalent of GIT_HOME_PUBLIC (a runtime
     # env var in nix-home); nix-ai cannot read env vars at eval time, so it is
-    # derived here from userConfig.paths.git (which defaults to ~/git).
+    # derived here from userConfig.paths.public (which defaults to ~/git/public).
     # Consumed by the opencode formatter's external_directory rules.
-    public = [ "${gitHome}/public" ];
+    public = [ config.userConfig.paths.public ];
   };
 
   # Tool-specific identifiers (non-shell, built-in tools)

--- a/modules/common/permissions.nix
+++ b/modules/common/permissions.nix
@@ -27,6 +27,10 @@
 let
   homeDir = config.home.homeDirectory;
 
+  # Root of the git checkout tree — a consumer relocates the workspace by
+  # overriding `userConfig.paths.git` once instead of patching each path here.
+  gitHome = config.userConfig.paths.git;
+
   # Permission data vendored in nix-claude-code (data/permissions/*.nix,
   # exposed as lib.permissions). Verified meaning-equivalent to the legacy
   # ai-assistant-instructions/agentsmd/permissions JSON in
@@ -87,7 +91,7 @@ in
       "${homeDir}/workspace"
       "${homeDir}/src"
       "${homeDir}/dev"
-      "${homeDir}/git"
+      gitHome
     ];
 
     config = [
@@ -103,9 +107,9 @@ in
 
     # Public workspace root. Eval-time equivalent of GIT_HOME_PUBLIC (a runtime
     # env var in nix-home); nix-ai cannot read env vars at eval time, so it is
-    # derived here from homeDir. Consumed by the opencode formatter's
-    # external_directory rules.
-    public = [ "${homeDir}/git/public" ];
+    # derived here from userConfig.paths.git (which defaults to ~/git).
+    # Consumed by the opencode formatter's external_directory rules.
+    public = [ "${gitHome}/public" ];
   };
 
   # Tool-specific identifiers (non-shell, built-in tools)

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -200,6 +200,10 @@ in
       # Shared skill deployment for Codex/Antigravity compatibility layers.
       agentSkills.enable = true;
 
+      # Keep the shared-skill fan-out in step with a relocated opencode config
+      # dir (agent-skills declares its own option so it stays standalone).
+      agentSkills.opencodeConfigDir = lib.mkDefault config.programs.opencode.configDir;
+
       # MLX inference server (vllm-mlx on port 11434)
       mlx = {
         enable = true;

--- a/modules/maestro/options.nix
+++ b/modules/maestro/options.nix
@@ -34,7 +34,7 @@
 
       targetRepository = lib.mkOption {
         type = lib.types.str;
-        default = "${config.home.homeDirectory}/git/nix-darwin/main";
+        default = "${config.userConfig.paths.git}/nix-darwin/main";
         description = "Target repository for issue resolution";
       };
     };

--- a/modules/maintainer-profile.nix
+++ b/modules/maintainer-profile.nix
@@ -141,6 +141,17 @@ in
             workspace once instead of patching each hardcoded literal.
           '';
         };
+
+        paths.public = lib.mkOption {
+          type = lib.types.str;
+          default = "${config.userConfig.paths.git}/public";
+          description = ''
+            Public workspace root (defaults to `~/git/public`), the directory
+            under the git tree that holds public repositories. Shared by the
+            permission engine's `directories.public` and the Antigravity
+            sandbox allowlist, so the `public` literal lives in one place.
+          '';
+        };
       };
     };
     default = { };

--- a/modules/maintainer-profile.nix
+++ b/modules/maintainer-profile.nix
@@ -130,6 +130,17 @@ in
             set to your own workspace roots (e.g. [ "~/git/public/" ]).
           '';
         };
+
+        paths.git = lib.mkOption {
+          type = lib.types.str;
+          default = "${config.home.homeDirectory}/git";
+          description = ''
+            Root of the local git checkout tree (defaults to `~/git`). The
+            harnesses that trust or sandbox the workspace (Claude, Antigravity,
+            Maestro) derive their paths from this, so a consumer relocates the
+            workspace once instead of patching each hardcoded literal.
+          '';
+        };
       };
     };
     default = { };

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -8,6 +8,7 @@
 # (modules/agent-skills/harnesses.nix -> ~/.config/opencode/skills symlink).
 # Commands are linked per-file from commandDirs so future sources coexist.
 {
+  pkgs,
   config,
   lib,
   nix-claude-code,
@@ -54,6 +55,20 @@ let
     mcp = mcpServers;
   };
 
+  # Pretty-printed via jq (same convention as copilot.nix / antigravity-cli):
+  # builtins.toJSON is compact, so a runCommand + jq '.' derivation produces the
+  # human-readable layout the other harness configs use.
+  settingsJson =
+    pkgs.runCommand "opencode.json"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+        json = builtins.toJSON (lib.recursiveUpdate settings cfg.extraSettings);
+        passAsFile = [ "json" ];
+      }
+      ''
+        jq '.' "$jsonPath" > $out
+      '';
+
   mdFiles =
     dir:
     lib.optionalAttrs (builtins.pathExists dir) (
@@ -85,9 +100,7 @@ in
     }
     (lib.mkIf cfg.enable {
       home.file = {
-        ".config/opencode/opencode.json".text = builtins.toJSON (
-          lib.recursiveUpdate settings cfg.extraSettings
-        );
+        ".config/opencode/opencode.json".source = settingsJson;
       }
       // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
     })

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -17,6 +17,7 @@
 
 let
   cfg = config.programs.opencode;
+  inherit (cfg) configDir;
 
   aiCommon = import ../common { inherit lib config nix-claude-code; };
   permission = aiCommon.formatters.opencode.formatPermission aiCommon.permissions;
@@ -78,7 +79,7 @@ let
   mkCommandLinks =
     dir:
     lib.mapAttrs' (name: _: {
-      name = ".config/opencode/command/${name}";
+      name = "${configDir}/command/${name}";
       value = {
         source = "${dir}/${name}";
       };
@@ -100,7 +101,7 @@ in
     }
     (lib.mkIf cfg.enable {
       home.file = {
-        ".config/opencode/opencode.json".source = settingsJson;
+        "${configDir}/opencode.json".source = settingsJson;
       }
       // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
     })

--- a/modules/opencode/options.nix
+++ b/modules/opencode/options.nix
@@ -7,16 +7,26 @@ in
   options.programs.opencode = {
     enable = lib.mkEnableOption "OpenCode (sst/opencode terminal agent)";
 
+    configDir = lib.mkOption {
+      type = lib.types.str;
+      default = ".config/opencode";
+      description = ''
+        Directory (relative to $HOME) holding `opencode.json` and `command/`.
+        Also the path the agent-skills registry symlinks skills and AGENTS.md
+        into, so a consumer relocates the config dir here once.
+      '';
+    };
+
     commandDirs = lib.mkOption {
       type = lib.types.listOf lib.types.path;
       default = [ ];
-      description = "Directories whose *.md files are linked into ~/.config/opencode/command/.";
+      description = "Directories whose *.md files are linked into the opencode command directory (~/.config/opencode/command/ by default).";
     };
 
     extraSettings = lib.mkOption {
       type = lib.types.attrs;
       default = { };
-      description = "Attrs merged into ~/.config/opencode/opencode.json (wins over module defaults).";
+      description = "Attrs merged into the opencode config (~/.config/opencode/opencode.json; wins over module defaults).";
     };
   }
   // mcpClient.mkClientOptions "OpenCode";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes permission and sandbox path derivation and OpenCode external_directory rules; behavior should improve for the public root but misconfigured `userConfig.paths` could widen or narrow trusted paths.
> 
> **Overview**
> Introduces **`userConfig.paths.git`** and **`userConfig.paths.public`** as the single override surface for workspace roots, then rewires Antigravity sandbox paths, shared **`permissions.directories`**, and Maestro’s default target repo to read from those options instead of hardcoded `~/git` literals. **`maintainer-profile.nix`** is imported into every standalone home-manager bundle (Claude, Codex, OpenCode, etc.) so consumers get the same `userConfig` schema outside the full default stack.
> 
> **OpenCode** gains a relocatable **`programs.opencode.configDir`**, pretty-printed **`opencode.json`** (jq derivation, matching other harnesses), and **`external_directory` allow** rules for the public workspace root so cross-repo access there is not stuck on “ask”. **Agent-skills** follows the same dir via **`agentSkills.opencodeConfigDir`** (default-wired from OpenCode in the main module).
> 
> On macOS, **`aikey <HARNESS>`** in **`ai-aliases.zsh`** prints `<HARNESS>_ROUTER_API_KEY` from the keychain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef53ee0bd1c23d73e7d1f714863ea86aa61e1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->