### PR TITLE
feat(cursor): add Cursor CLI home-manager module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ nix-claude-code's `rules` option verbatim. Mirror in
 
 ### What belongs here (nix-ai)
 
-- AI CLI tools (Claude Code, Antigravity, Codex, Copilot, qwen-code, cecli)
+- AI CLI tools (Claude Code, Antigravity, Codex, Copilot, Cursor, qwen-code, cecli)
 - MCP servers and wrappers (github-mcp-server, terraform-mcp-server, doppler-mcp, etc.)
 - AI tool configuration files (`.claude/`, `.gemini/`, `.copilot/`)
 - MLX inference server (vllm-mlx LaunchAgent + wrappers)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ identically, every time.
 | **Gemini / Antigravity** | CLI + IDE settings, custom commands, permission rules |
 | **GitHub Copilot** | Configuration, permissions |
 | **OpenAI Codex** | Settings, rules, approval policy |
+| **Cursor CLI** | Terminal agent (`agent`/`cursor-agent`) with shared MCP servers and permission allowlist |
 | **Qwen Code & Cecli** | Settings for the Alibaba and Aider-fork CLIs |
 | **MCP Servers** | One [catalog](modules/mcp/README.md) (GitHub, Terraform, Context7, filesystem, memory, …) fanned out to every agent |
 | **AI Dev Tools** | cclint, doppler-mcp, claude-flow, and more |
@@ -69,7 +70,7 @@ that merge into your existing configuration:
 | `homeManagerModules.codex` | Just OpenAI Codex |
 | `homeManagerModules.mcp` | Just the MCP server catalog |
 | `homeManagerModules.maestro` | Just Maestro orchestration |
-| *(also: `agent-skills`, `antigravity-cli`, `antigravity-ide`, `cecli`, `qwen-code`)* | One module per tool |
+| *(also: `agent-skills`, `antigravity-cli`, `antigravity-ide`, `cecli`, `cursor`, `qwen-code`)* | One module per tool |
 | `lib.ci.claudeSettingsJson` | Pure settings JSON for CI validation (no derivations) |
 | `lib.aiStackModels` | Role-name → model-ID registry, for foreign (non-module) consumers |
 
@@ -113,6 +114,7 @@ nix fmt           # auto-fix formatting
 modules/
 ├── claude/         # Claude Code — plugins, hooks, agents, rules
 ├── codex/          # OpenAI Codex
+├── cursor/         # Cursor CLI (agent / cursor-agent)
 ├── antigravity-*/  # Gemini / Antigravity CLI + IDE
 ├── cecli/          # Cecli (Aider fork)
 ├── qwen-code/      # Alibaba Qwen Code

--- a/flake.nix
+++ b/flake.nix
@@ -254,7 +254,14 @@
       checks =
         let
           system = "x86_64-linux";
-          pkgs = nixpkgs.legacyPackages.${system};
+          # Unfree tools (cursor-cli, claude-code) are evaluated by the module
+          # checks. Consumers set nixpkgs.config.allowUnfree themselves
+          # (nix-darwin modules/darwin/common.nix); the CI harness mirrors that
+          # so the same module eval that ships to production passes here.
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
         in
         {
           ${system} =

--- a/flake.nix
+++ b/flake.nix
@@ -254,10 +254,6 @@
       checks =
         let
           system = "x86_64-linux";
-          # Unfree tools (cursor-cli, claude-code) are evaluated by the module
-          # checks. Consumers set nixpkgs.config.allowUnfree themselves
-          # (nix-darwin modules/darwin/common.nix); the CI harness mirrors that
-          # so the same module eval that ships to production passes here.
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -204,6 +204,16 @@ in
     };
   };
 
+  cursor = {
+    imports = [
+      ../modules/mcp/module.nix
+      ../modules/cursor
+    ];
+    _module.args = {
+      inherit nix-claude-code;
+    };
+  };
+
   maestro = {
     imports = [ ../modules/maestro ];
   };

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -247,6 +247,7 @@ in
     ;
 })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
+// (import ./checks/cursor.nix { inherit pkgs hmConfig; })
 // (import ./checks/qwen-code.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
 // (import ./checks/vct-cli.nix {

--- a/lib/checks/cursor.nix
+++ b/lib/checks/cursor.nix
@@ -1,0 +1,69 @@
+# Cursor CLI module regression tests
+{ pkgs, hmConfig }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+  cfg = hmConfig.config.programs.cursor;
+in
+{
+  # Verify all expected Cursor option paths exist.
+  cursor-options-regression = helpers.mkOptionsRegression {
+    label = "Cursor";
+    checkName = "check-cursor-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "approvalMode"
+      "enable"
+      "excludedMcpServers"
+      "extraSettings"
+      "mcpServerNames"
+      "vimMode"
+    ];
+  };
+
+  # Verify evaluated config values match expected defaults.
+  cursor-defaults-regression = helpers.mkDefaultsRegression {
+    label = "Cursor";
+    checkName = "check-cursor-defaults-regression";
+    checks = [
+      {
+        name = "cursor.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "cursor.vimMode";
+        actual = cfg.vimMode;
+        expected = false;
+      }
+      {
+        name = "cursor.approvalMode";
+        actual = cfg.approvalMode;
+        expected = "allowlist";
+      }
+    ];
+  };
+
+  # Verify the wrapper-required binary symlinks and CLI config activation are
+  # wired when the module is enabled.
+  cursor-binaries-regression = helpers.mkOptionsRegression {
+    label = "Cursor binary symlinks";
+    checkName = "check-cursor-binaries-regression";
+    cfg = hmConfig.config.home.file;
+    expectedOptions = [
+      ".local/bin/agent"
+      ".local/bin/cursor-agent"
+    ];
+  };
+
+  cursor-activation-regression = helpers.mkDefaultsRegression {
+    label = "Cursor activation";
+    checkName = "check-cursor-activation-regression";
+    checks = [
+      {
+        name = "cursor.configMerge activation present";
+        actual = hmConfig.config.home.activation ? cursorConfigMerge;
+        expected = true;
+      }
+    ];
+  };
+}

--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -22,6 +22,7 @@ let
     antigravity-ide = hmConfig.config.programs.antigravity-ide.mcpServerNames;
     qwen-code = hmConfig.config.programs.qwen-code.mcpServerNames;
     opencode = hmConfig.config.programs.opencode.mcpServerNames;
+    cursor = hmConfig.config.programs.cursor.mcpServerNames;
   };
   rendererMismatches = builtins.filter (name: rendererNames.${name} != cfg.enabledServerNames) (
     builtins.attrNames rendererNames
@@ -74,7 +75,7 @@ in
     assert
       rendererMismatches == [ ]
       || throw "MCP renderer parity mismatch: ${builtins.toJSON rendererMismatches}; shared=${builtins.toJSON cfg.enabledServerNames}; renderers=${builtins.toJSON rendererNames}";
-    helpers.mkMarker "check-shared-mcp-renderer-parity" "Shared MCP renderer parity verified for Claude, Codex, Antigravity CLI/IDE, Qwen, and OpenCode";
+    helpers.mkMarker "check-shared-mcp-renderer-parity" "Shared MCP renderer parity verified for Claude, Codex, Antigravity CLI/IDE, Qwen, OpenCode, and Cursor";
 
   splunk-mcp-canonical-launcher =
     assert

--- a/modules/common/formatters.nix
+++ b/modules/common/formatters.nix
@@ -16,6 +16,7 @@ let
   copilot = import ./formatters/copilot.nix { inherit lib flattenCommands; };
   codex = import ./formatters/codex.nix { inherit lib flattenCommands; };
   opencode = import ./formatters/opencode.nix { inherit lib flattenCommands; };
+  cursor = import ./formatters/cursor.nix { inherit lib flattenCommands; };
   qwen = import ./formatters/qwen.nix { inherit lib flattenCommands; };
 in
 {
@@ -25,6 +26,7 @@ in
     copilot
     codex
     opencode
+    cursor
     qwen
     utils
     ;

--- a/modules/common/formatters/cursor.nix
+++ b/modules/common/formatters/cursor.nix
@@ -1,0 +1,73 @@
+# Cursor Formatter
+#
+# Maps the shared permission engine onto Cursor CLI permission tokens
+# (~/.cursor/cli-config.json `permissions.allow` / `permissions.deny`).
+#
+# Cursor has no "ask" tier — anything not in `allow` either prompts
+# (approvalMode = allowlist) or routes through the auto-review classifier
+# (approvalMode = auto-review). Ask-listed commands are therefore left
+# unlisted so they keep requiring a human decision, matching the shared
+# engine's semantics.
+#
+# Token shapes (https://cursor.com/docs/cli/reference/permissions):
+#   Shell(cmd)   — command match against the first token + args
+#   Read(glob)   — file read allow/deny
+#   Write(glob)  — file write allow/deny
+#   WebFetch(domain) — domain allow for the web-fetch tool
+#
+# Deny always wins at runtime. Shell-only metacharacters that would confuse
+# the matcher force a skip, mirroring the codex formatter's
+# representability filter.
+{ lib, flattenCommands }:
+
+let
+  representable =
+    cmd:
+    let
+      tokens = lib.filter (token: token != "") (lib.splitString " " cmd);
+      tokenOk =
+        token:
+        !(lib.any (char: lib.hasInfix char token) [
+          "*"
+          "?"
+          "<"
+          ">"
+          "|"
+          "&"
+          ";"
+          "$"
+          "("
+          ")"
+          "{"
+          "}"
+          "\""
+          "'"
+          "\\"
+          "`"
+          "~"
+        ]);
+    in
+    tokens != [ ] && lib.all tokenOk tokens;
+
+  supportedCommands = cmds: lib.filter representable cmds;
+
+  shellTokens = cmds: lib.map (cmd: "Shell(${cmd})") (supportedCommands cmds);
+in
+{
+  formatPermission =
+    permissions:
+    let
+      allowCommands = flattenCommands permissions.allow;
+      denyCommands = flattenCommands permissions.deny;
+    in
+    {
+      allow =
+        shellTokens allowCommands ++ lib.map (domain: "WebFetch(${domain})") permissions.webfetchDomains;
+      deny =
+        shellTokens denyCommands
+        ++ lib.concatMap (pattern: [
+          "Read(${pattern})"
+          "Write(${pattern})"
+        ]) permissions.denyPatterns;
+    };
+}

--- a/modules/cursor/default.nix
+++ b/modules/cursor/default.nix
@@ -39,14 +39,18 @@ let
   mcpClient = import ../mcp/client.nix { inherit lib; };
 
   # Cursor MCP schema (~/.cursor/mcp.json): local servers carry a "stdio"
-  # type tag plus command/args/env; remote servers carry "remote" plus url and
-  # optional headers. env values may use Cursor's ${env:NAME} / ${userHome}
+  # type tag plus command/args/env; remote servers carry a url plus optional
+  # headers. The Cursor CLI parser only accepts type values "stdio", "http",
+  # and "sse" — any other value makes it silently drop the whole file, so
+  # remote servers must use "http" (Streamable HTTP; SSE is deprecated) rather
+  # than OpenCode's "remote". The IDE ignores the type field and routes on
+  # command/url. env values may use Cursor's ${env:NAME} / ${userHome}
   # interpolation — catalog values pass through untouched.
   normalizeMcpServer =
     server:
     if server.url != null then
       {
-        type = "remote";
+        type = "http";
         inherit (server) url;
       }
       // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }

--- a/modules/cursor/default.nix
+++ b/modules/cursor/default.nix
@@ -1,0 +1,116 @@
+# Cursor CLI Module
+#
+# Installs and configures Cursor's terminal coding agent (`agent` /
+# `cursor-agent`). The IDE stays installed via nix-darwin
+# (home.packages = [ code-cursor ]) — this module only manages the CLI.
+#
+# The `code-cursor` IDE wrapper (`cursor agent`) requires the standalone CLI
+# at ~/.local/bin/cursor-agent. The two symlinks here make the wrapper exec
+# the nixpkgs binary instead of curl-installing its own copy, and put the
+# official `agent` command name on PATH (curl installer contract: both names).
+#
+# Config files:
+# - ~/.cursor/cli-config.json — deep-merge activation. The CLI rewrites this
+#   file at runtime (self-repairing schema, permission list updates), so a
+#   store symlink would break; merge-json-settings.sh overlays Nix-managed
+#   keys onto existing runtime state (same pattern as codex config.toml).
+# - ~/.cursor/mcp.json — declarative home.file. Cursor auto-detects this file
+#   and never rewrites it at runtime (same rationale as opencode.json).
+#
+# Skills: Cursor natively reads ~/.agents/skills/ (plus ~/.claude/skills/ and
+# ~/.codex/skills/), so an agent-skills registry symlink would double-scan the
+# shared tree — same exclusion rationale as the Codex entry in
+# modules/agent-skills/harnesses.nix.
+{
+  config,
+  lib,
+  pkgs,
+  nix-claude-code,
+  ...
+}:
+
+let
+  cfg = config.programs.cursor;
+  homeDir = config.home.homeDirectory;
+
+  aiCommon = import ../common { inherit lib config nix-claude-code; };
+  inherit (aiCommon) permissions formatters;
+
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+
+  # Cursor MCP schema (~/.cursor/mcp.json): local servers carry a "stdio"
+  # type tag plus command/args/env; remote servers carry "remote" plus url and
+  # optional headers. env values may use Cursor's ${env:NAME} / ${userHome}
+  # interpolation — catalog values pass through untouched.
+  normalizeMcpServer =
+    server:
+    if server.url != null then
+      {
+        type = "remote";
+        inherit (server) url;
+      }
+      // lib.optionalAttrs (server.headers != { }) { inherit (server) headers; }
+    else
+      {
+        type = "stdio";
+        inherit (server) command;
+      }
+      // lib.optionalAttrs (server.args != [ ]) { inherit (server) args; }
+      // lib.optionalAttrs (server.env != { }) { inherit (server) env; };
+
+  mcpServers = mcpClient.renderServers {
+    inherit (config.programs.aiMcp) enabledServers;
+    excluded = cfg.excludedMcpServers;
+    normalize = normalizeMcpServer;
+    client = "cursor";
+  };
+
+  # Nix-managed defaults for cli-config.json (schema: version, editor,
+  # permissions, approvalMode). Deep-merged over runtime state on activation.
+  cliConfig = {
+    version = 1;
+    inherit (cfg) approvalMode;
+    editor.vimMode = cfg.vimMode;
+    permissions = formatters.cursor.formatPermission permissions;
+  };
+
+  cliConfigJson = pkgs.writeText "cursor-cli-config.json" (
+    builtins.toJSON (lib.recursiveUpdate cliConfig cfg.extraSettings)
+  );
+in
+{
+  imports = [ ./options.nix ];
+
+  # Shadow home-manager 26.05's upstream programs.cursor module — that one is
+  # the Cursor IDE (mkVscodeModule: argv.json, extensions, code-cursor
+  # package) and would fight this CLI module and nix-darwin's own IDE install
+  # for ownership of ~/.cursor/. Same pattern as opencode / antigravity-cli.
+  disabledModules = [ "programs/cursor.nix" ];
+
+  config = lib.mkMerge [
+    # Read-only introspection option set unconditionally so module evaluation
+    # (and the shared MCP renderer-parity check) succeeds even when
+    # programs.cursor.enable = false.
+    {
+      programs.cursor.mcpServerNames = lib.attrNames mcpServers;
+    }
+    (lib.mkIf cfg.enable {
+      home = {
+        packages = [ pkgs.cursor-cli ];
+
+        file = {
+          ".local/bin/cursor-agent".source = "${pkgs.cursor-cli}/bin/cursor-agent";
+          ".local/bin/agent".source = "${pkgs.cursor-cli}/bin/cursor-agent";
+          ".cursor/mcp.json".text = builtins.toJSON { inherit mcpServers; };
+        };
+
+        activation.cursorConfigMerge = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          export PATH="${pkgs.jq}/bin:$PATH"
+          $DRY_RUN_CMD ${../scripts/merge-json-settings.sh} \
+            "${cliConfigJson}" \
+            "${homeDir}/.cursor/cli-config.json"
+        '';
+      };
+    })
+  ];
+}

--- a/modules/cursor/options.nix
+++ b/modules/cursor/options.nix
@@ -1,0 +1,37 @@
+# Cursor CLI Module Options
+{ lib, ... }:
+let
+  mcpClient = import ../mcp/client.nix { inherit lib; };
+in
+{
+  options.programs.cursor = {
+    enable = lib.mkEnableOption "Cursor CLI (cursor-agent terminal agent)";
+
+    vimMode = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable vim mode in the Cursor CLI (editor.vimMode in cli-config.json).";
+    };
+
+    approvalMode = lib.mkOption {
+      type = lib.types.enum [
+        "allowlist"
+        "auto-review"
+        "unrestricted"
+      ];
+      default = "allowlist";
+      description = ''
+        How the Cursor CLI decides to run commands not in `permissions.allow`:
+        `allowlist` (prompt for anything not allowed), `auto-review`
+        (route through the built-in classifier), or `unrestricted`.
+      '';
+    };
+
+    extraSettings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Attrs merged into ~/.cursor/cli-config.json (wins over module defaults).";
+    };
+  }
+  // mcpClient.mkClientOptions "Cursor";
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -86,6 +86,7 @@ in
     ./claude-config.nix
     ./claude/skill-packs.nix
     ./codex
+    ./cursor
     ./antigravity-ide
     ./antigravity-cli
     ./fabric
@@ -175,6 +176,12 @@ in
 
       # OpenAI Codex configuration (settings handled by modules/codex/)
       codex = {
+        enable = true;
+      };
+
+      # Cursor CLI configuration (settings handled by modules/cursor/; the
+      # Cursor IDE itself stays installed via nix-darwin home.packages).
+      cursor = {
         enable = true;
       };
 


### PR DESCRIPTION
Adds a `programs.cursor` home-manager module for Cursor's terminal coding agent (`agent` / `cursor-agent`):

- Installs `pkgs.cursor-cli`; symlinks the binary to both `~/.local/bin/cursor-agent` (required by the `code-cursor` IDE wrapper) and `~/.local/bin/agent` (the CLI's canonical command name).
- Declarative `~/.cursor/mcp.json` via `home.file` — shared MCP catalog rendered to Cursor's schema: local servers as `type: "stdio"` + command/args/env, remote servers as `type: "remote"` + url/headers. Same `excludedMcpServers`/`mcpServerNames` client options as the other agents.
- Deep-merge activation for `~/.cursor/cli-config.json` (`approvalMode`, `vimMode`, permission allowlist from the shared permission engine) using `merge-json-settings.sh`, since the CLI rewrites that file at runtime.
- Shadows home-manager 26.05's upstream `programs/cursor.nix` (the Cursor IDE module) via `disabledModules` — the IDE remains installed through nix-darwin `home.packages`.
- Options: `enable`, `vimMode`, `approvalMode` (`allowlist`/`auto-review`/`unrestricted`), `extraSettings`, `excludedMcpServers`, `mcpServerNames`.
- Regression checks (options, defaults, binary symlinks, activation) and MCP renderer-parity check wired into the shared check set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent config paths, permission allowlists, and MCP fan-out; flake check import now allows unfree packages for Linux CI.
> 
> **Overview**
> Adds **`programs.cursor`** as a first-class agent in the nix-ai stack: installs **`cursor-cli`**, wires **`agent`** / **`cursor-agent`** symlinks under `~/.local/bin`, and enables the module by default in the aggregate home-manager config.
> 
> **CLI config** uses a deep-merge activation for `~/.cursor/cli-config.json` (approval mode, vim mode, shared permission allow/deny via a new **cursor formatter**), and a declarative `~/.cursor/mcp.json` from the shared MCP catalog with Cursor-specific normalization (**`stdio`** locally, **`http`** for remote URLs). **`disabledModules`** blocks upstream home-manager’s IDE-oriented `programs.cursor` so it doesn’t fight this CLI setup.
> 
> Exports a standalone **`homeManagerModules.cursor`** (MCP + cursor), extends MCP renderer-parity checks to Cursor, adds **cursor regression checks**, and sets **`allowUnfree`** on the Linux flake check `pkgs` import so `cursor-cli` can evaluate in CI. README/CLAUDE docs list Cursor alongside the other agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cccaa9232fb662bf930ab5d42148aea22b4e0c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->