### PR TITLE
feat(mcp): add OpenWhispr CLI and shared MCP server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ CLOUDFLARE_API_TOKEN=cf___REPLACE_ME__
 
 # monarch MCP — NO env var. Auth is browser OAuth on first connect. Nothing to set.
 
+# [optional] openwhispr MCP — personal API key for hosted notes/transcriptions.
+# source: OpenWhispr desktop app (Integrations > API Keys) or agent-setup flow.
+# The CLI uses `openwhispr auth login` instead; MCP agents read this env var.
+OPENWHISPR_API_KEY=owk_live___REPLACE_ME__
+
 # ──────────────── AI provider keys (Doppler fallback paths) ────────────────
 # All [optional] — local MLX is the default. Used by the d-claude / cecli / qwen
 # fallback paths. source: Doppler ai-ci-automation/prd. Don't hand-set these —

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -25,6 +25,8 @@
   claudeFlow = "3.34.0";
   # renovate: datasource=npm depName=@googleworkspace/cli
   gwsCli = "0.22.5";
+  # renovate: datasource=npm depName=@openwhispr/cli
+  openwhisprCli = "0.1.2";
 
   # MCP servers (npm)
   # renovate: datasource=npm depName=@upstash/context7-mcp

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -52,6 +52,7 @@
 #   chatgpt: chatgpt-cli (ChatGPT terminal client)
 #   claude-flow: claude-flow (multi-agent orchestration)
 #   gws: @googleworkspace/cli (pinned version)
+#   openwhispr: @openwhispr/cli (voice notes / transcriptions CLI)
 #
 # UVX WRAPPER PACKAGES (Python packages not in nixpkgs/homebrew):
 #   hf: huggingface-hub CLI (model downloads, used with HuggingFace MCP)
@@ -81,6 +82,7 @@ let
   chatgptCliVersion = versions.chatgptCli;
   claudeFlowVersion = versions.claudeFlow;
   gwsCliVersion = versions.gwsCli;
+  openwhisprCliVersion = versions.openwhisprCli;
 in
 {
   # AI-specific development tools
@@ -175,6 +177,18 @@ in
     # Key commands: gws gmail +triage, gws gmail +watch, gws drive +upload
     (writeShellScriptBin "gws" ''
       exec ${bun}/bin/bunx --bun @googleworkspace/cli@${gwsCliVersion} "$@"
+    '')
+
+    # ==========================================================================
+    # OpenWhispr CLI
+    # ==========================================================================
+    # Operates against the local desktop bridge or the cloud REST API.
+    # Source: https://github.com/OpenWhispr/openwhispr-cli
+    # NPM: @openwhispr/cli (pinned version)
+    # Local mode: desktop app running (see nix-openwhispr). Remote mode:
+    # `openwhispr auth login` stores key in ~/.openwhispr/cli-config.json.
+    (writeShellScriptBin "openwhispr" ''
+      exec ${bun}/bin/bunx --bun @openwhispr/cli@${openwhisprCliVersion} "$@"
     '')
 
     # ==========================================================================

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -177,6 +177,23 @@ Authentication is **browser OAuth handled by the MCP client** on first connect: 
 client opens Monarch in the browser to authorize access. No token, password, or header
 is stored in the Nix config — there is nothing to put in Doppler or Keychain.
 
+## OpenWhispr MCP and CLI
+
+The `openwhispr` MCP server is OpenWhispr's hosted connector — a remote
+Streamable-HTTP endpoint at `https://mcp.openwhispr.com/mcp`
+([setup guide](https://docs.openwhispr.com/integrations/mcp)).
+
+**Requires:** a personal API key (`owk_live_...`) in `OPENWHISPR_API_KEY` — inject
+at runtime (see [`.env.example`](../../.env.example)). Workspace keys are not
+supported. Create the key in the desktop app under **Integrations > API Keys**, or
+via the [agent setup](https://docs.openwhispr.com/integrations/agent-setup) flow.
+
+The `openwhispr` CLI (`@openwhispr/cli`, installed via [`ai-tools.nix`](../ai-tools.nix))
+uses a **separate credential path** for remote access: `openwhispr auth login`
+writes the key to `~/.openwhispr/cli-config.json`. When the desktop app is running,
+the CLI auto-detects the local bridge via `~/.openwhispr/cli-bridge.json` and needs
+no remote auth. Run `openwhispr doctor` to verify connectivity.
+
 ## MLX Inference (Local Apple Silicon)
 
 Two CLI tools work together for local MLX model workflows:

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -179,20 +179,8 @@ is stored in the Nix config — there is nothing to put in Doppler or Keychain.
 
 ## OpenWhispr MCP and CLI
 
-The `openwhispr` MCP server is OpenWhispr's hosted connector — a remote
-Streamable-HTTP endpoint at `https://mcp.openwhispr.com/mcp`
-([setup guide](https://docs.openwhispr.com/integrations/mcp)).
-
-**Requires:** a personal API key (`owk_live_...`) in `OPENWHISPR_API_KEY` — inject
-at runtime (see [`.env.example`](../../.env.example)). Workspace keys are not
-supported. Create the key in the desktop app under **Integrations > API Keys**, or
-via the [agent setup](https://docs.openwhispr.com/integrations/agent-setup) flow.
-
-The `openwhispr` CLI (`@openwhispr/cli`, installed via [`ai-tools.nix`](../ai-tools.nix))
-uses a **separate credential path** for remote access: `openwhispr auth login`
-writes the key to `~/.openwhispr/cli-config.json`. When the desktop app is running,
-the CLI auto-detects the local bridge via `~/.openwhispr/cli-bridge.json` and needs
-no remote auth. Run `openwhispr doctor` to verify connectivity.
+Hosted connector at `https://mcp.openwhispr.com/mcp` ([setup](https://docs.openwhispr.com/integrations/mcp)).
+**Requires:** `OPENWHISPR_API_KEY` (see [`.env.example`](../../.env.example)). CLI: [`ai-tools.nix`](../ai-tools.nix).
 
 ## MLX Inference (Local Apple Silicon)
 
@@ -273,32 +261,10 @@ into the login environment.
 
 ### doppler-mcp server shows "Failed to connect"
 
-**Root cause (diagnosed 2026-03-25):** Claude Code launches all MCP servers in parallel at
-session startup. The `doppler-mcp` wrapper previously ran a synchronous preflight check
-(`doppler run ... -- true`) before the actual MCP server could start. This Doppler API
-round-trip — fetching secrets just to run `true` — delayed the MCP server's stdio handshake
-past Claude Code's connection timeout. The preflight also doubled startup time by fetching
-secrets twice (once for check, once for real command).
-
-**Fix:** The preflight was removed from `doppler-mcp` (in `modules/ai-tools.nix`).
-The wrapper now goes straight to `exec doppler run ... -- "$@"`. Auth failures are handled
-natively by `doppler run` (exits non-zero with a clear error message).
-
-**If you still see failures after the fix:**
-
-1. Verify Doppler auth: `doppler me`
-2. Test the wrapper manually: `doppler-mcp <server-command>` (Ctrl-C to stop)
-3. Check the invocation log: `cat ~/.local/state/doppler-mcp.log`
-   - Records commands only, not error details
-   - Doppler auth errors go to stderr — re-run the logged command in a terminal to see them
-4. If Doppler auth expired: `doppler login`, then restart Claude Code
-5. Verify registration: `claude mcp list | grep "^<server>:"`
-
-**Mid-session recovery** (if a server failed at startup but Doppler is now healthy):
-
-```bash
-claude mcp remove <server> -s user && claude mcp add <server> -s user -- <command>
-```
-
-This reconnects the server, but tools won't appear in the current session's ToolSearch.
-Restart Claude Code for full tool availability.
+Claude Code launches MCP servers in parallel at startup. `doppler-mcp` runs
+`exec doppler run ... -- "$@"` with no preflight — auth failures exit non-zero from
+`doppler run` itself. If a server still fails: verify `doppler me`, test
+`doppler-mcp <server-command>` manually, check `~/.local/state/doppler-mcp.log`,
+re-auth with `doppler login` if needed, then restart Claude Code. Mid-session:
+`claude mcp remove <server> -s user && claude mcp add <server> -s user -- <command>`
+(restart for full ToolSearch availability).

--- a/modules/mcp/catalog-services.nix
+++ b/modules/mcp/catalog-services.nix
@@ -168,6 +168,25 @@
   };
 
   # ================================================================
+  # OpenWhispr - voice notes, transcriptions, and folders
+  # ================================================================
+  # Source: https://docs.openwhispr.com/integrations/mcp
+  # Remote Streamable-HTTP endpoint. Requires a personal API key
+  # (`owk_live_...`) in OPENWHISPR_API_KEY — inject at runtime (see
+  # .env.example). Workspace keys are not supported. The CLI uses a
+  # separate credential path (`openwhispr auth login` →
+  # ~/.openwhispr/cli-config.json); MCP and CLI share the same key
+  # material but not the delivery mechanism.
+  # Opt-in: ships disabled. Requires an OpenWhispr account and API key.
+  openwhispr = {
+    type = "http";
+    url = "https://mcp.openwhispr.com/mcp";
+    headers.Authorization = "Bearer \${OPENWHISPR_API_KEY}";
+    bearer_token_env_var = "OPENWHISPR_API_KEY";
+    disabled = true;
+  };
+
+  # ================================================================
   # grep.app - literal code search across ~1M public GitHub repositories
   # ================================================================
   # Source: https://grep.app — remote Streamable-HTTP, stateless, keyless.


### PR DESCRIPTION
Ship @openwhispr/cli on PATH via a pinned bunx wrapper and register the hosted OpenWhispr MCP endpoint (disabled by default).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in, disabled-by-default catalog and bunx wrapper additions; no auth, secrets storage, or core MCP runtime changes.
> 
> **Overview**
> Puts `@openwhispr/cli` on PATH as a pinned bunx wrapper (`0.1.2`) and registers the hosted OpenWhispr MCP endpoint (`https://mcp.openwhispr.com/mcp`) in the shared catalog.
> 
> The MCP server is **disabled by default**. Agents authenticate with a personal `OPENWHISPR_API_KEY` Bearer header; the CLI uses a separate `openwhispr auth login` path. Docs and `.env.example` cover the key. Also shortens the `doppler-mcp` troubleshooting note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9038d54cac90177b68f8c9e45ba9bffaf29a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->