### PR TITLE
docs(cluster): trim cluster-lifecycle.md under the token budget

### DIFF
--- a/docs/runbooks/cluster-lifecycle.md
+++ b/docs/runbooks/cluster-lifecycle.md
@@ -106,29 +106,26 @@ unplugging the cable is meant to be sufficient on its own, and since 2026-07-25
 the watcher enforces the parts a human used to have to get right.
 
 **Start order no longer matters.** A worker whose coordinator had no rank yet
-used to kickstart into a rendezvous that did not exist (`[jaccl] Couldn't
-connect (error: 60)`), and every failed `mx.distributed.init()` leaks a
-**reboot-only** RDMA protection domain — three attempts turned "peer not up yet"
-into a mandatory reboot (2026-07-24). Both ranks now hold for a shared
-wall-clock boundary and reach distributed init together, inside jaccl's fixed
-~15 s connect budget. Domains lost anyway are counted in a boot-scoped ledger,
-and a start is refused at a cap that *reserves* what is left of the device's 11
-— see [rdma-protection-domains.md](rdma-protection-domains.md).
+used to kickstart into a nonexistent rendezvous, leaking a **reboot-only**
+RDMA protection domain per failed attempt (2026-07-24 mandatory reboot). Both
+ranks now hold for a shared wall-clock boundary and reach distributed init
+together, inside jaccl's ~15 s connect budget. Domains lost anyway are still
+counted in a boot-scoped ledger, capped against the device's 11 — see
+[rdma-protection-domains.md](rdma-protection-domains.md).
 
 **A boot does not produce a usable link.** cluster-link prep runs in root
-`postActivation`, before Thunderbolt carrier settles, so it can find no
-carrier-active port and address nothing — leaving a rank to die with `Couldn't
-bind socket (error: 49)` (EADDRNOTAVAIL). The watcher now requires this host to
-hold its own link address before starting a rank, and repairs it in place when it
-does not (`linkRepair`; direct granted alias first, bounded `activate` second).
+`postActivation`, before Thunderbolt carrier settles, so it used to find no
+carrier-active port and leave a rank to die with `Couldn't bind socket (error:
+49)` (EADDRNOTAVAIL). The watcher now requires this host to hold its own link
+address before starting a rank, and repairs it in place when it does not
+(`linkRepair`; direct granted alias first, bounded `activate` second).
 
-**The halt is not just a file.** The marker records *why* (`cause=...`) beside a
-sticky `rank-halt-latched`, so deleting `rank-halted` by hand is a *request*: the
-watcher re-verifies the preconditions before the first retry, accepts the clear
-(resetting the attempt counter) if they pass, and **re-halts** with
-`cause=manual-clear-rejected` naming the still-failing precondition if they do
-not. That is how the remaining domains were burned on 2026-07-24, and it can no
-longer happen. Sanctioned resets: a real link cycle, or `cluster-join`.
+**The halt is not just a file.** The marker records *why* (`cause=...`) beside
+a sticky `rank-halt-latched`; deleting `rank-halted` by hand is only a
+*request* — the watcher re-verifies preconditions first, clears on pass, or
+**re-halts** with `cause=manual-clear-rejected` naming what still fails. That
+stopped the pattern that burned the remaining domains on 2026-07-24.
+Sanctioned resets: a real link cycle, or `cluster-join`.
 
 **Unplug is debounced in seconds, not probes.** `linkDownSettleSecs` (default
 60 s) converts to consecutive failed probes against `tickIntervalSecs` (default
@@ -137,9 +134,9 @@ debounce is asymmetric on purpose: "up" is believed at the first reply, "down"
 must be earned, because a false down tears the rank down *and* resets the PD
 guard — a flapping link could otherwise never accumulate toward a halt.
 
-**A page that reaches nobody still reaches the log.** Halt alerts log their full
-text on any non-delivery (no pager configured, encode failure, non-200) and
-append it to `alerts-undelivered.log` beside the link-state file.
+**Alerting matches the non-load-bearing doctrine in
+[cluster-link-truths.md](cluster-link-truths.md) §5:** a failed page still
+logs its full text to `alerts-undelivered.log`.
 
 **Detached-while-plugged self-corrects.** Once no standalone lease holds, the
 watcher re-admin-ups the port cluster-detach downed and rejoins. Generation


### PR DESCRIPTION
## Summary

Trims `docs/runbooks/cluster-lifecycle.md` back under the shared token-limit
gate (3000 for `docs/*.md`) by tightening three paragraphs in the "zero-click
flow" section and replacing a paragraph that duplicated
`cluster-link-truths.md`'s alert-channel doctrine with a pointer to it. No
doctrine content changed — the generation-drift correction added by #1713
(drift is detected and refused before any clustering step, does not
self-heal, pages once per deploy revision, stays refused until a human
deploys) is preserved verbatim.

## Test plan

- [x] `pre-commit run --files docs/runbooks/cluster-lifecycle.md` passes
      (markdownlint-cli2 and the rest)
- [x] Measured with the same tokenizer the CI gate uses (`tiktoken`
      `o200k_base`, whole-file count): before 3021 tokens, after 2934 tokens
      (limit 3000)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation wording only; no code, config, or operational behavior changes.
> 
> **Overview**
> Tightens the zero-click watcher section in `docs/runbooks/cluster-lifecycle.md` so the file fits the docs token gate (~3021 → ~2934 tokens).
> 
> Three paragraphs are shortened (start-order/RDMA PD leak, boot-time link bind, halt-latch vs manual delete). The alerting paragraph is replaced with a pointer to `cluster-link-truths.md` §5. Operational doctrine is unchanged, including generation-drift as a hard, non-self-healing gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435b5342a35b59fa6ff17f181fa2c4d9aeb8e07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->