### PR TITLE
test(token-meter): drop the cleanup-activation regression assertion

### DIFF
--- a/lib/checks/token-meter.nix
+++ b/lib/checks/token-meter.nix
@@ -56,15 +56,7 @@ in
     assert
       !(hmConfig.config.launchd.agents ? token-meter-gate)
       || throw "token-meter gate must NOT be defined when programs.token-meter.enable = false (default)";
-    # Absence of the gate is not the same as the thing being off. Upstream's
-    # installer writes its own two LaunchAgents with RunAtLoad, which nix did
-    # not create and a rebuild therefore will not remove, so a disabled module
-    # must actively tear them down or `enable = false` silently leaves the
-    # dashboard running — measured at ~2.4 cores on the laptop.
-    assert
-      hmConfig.config.home.activation ? tokenMeterCleanup
-      || throw "programs.token-meter.enable = false must still run the cleanup activation that removes upstream's LaunchAgents";
-    helpers.mkMarker "check-token-meter-gate-negative" "token-meter disabled: gate absent and upstream agents torn down";
+    helpers.mkMarker "check-token-meter-gate-negative" "token-meter disabled: gate absent";
 
   # token-meter labels every answer with the runtime that asked, so each client
   # must render its own name — the one value the shared catalog cannot hold.


### PR DESCRIPTION
## Summary
`fix/70995a79-inline-token-meter-cleanup` (#1733) removed `home.activation.tokenMeterCleanup` from `modules/token-meter.nix` entirely — the raw file-path script it ran (`${./scripts/token-meter-cleanup.sh}`) had a lost executable bit that was crashing every activation on hosts with `programs.token-meter.enable = false`. That PR got merged into `develop` while its own `lib/checks/token-meter.nix` regression assertion — which explicitly requires `home.activation ? tokenMeterCleanup` to exist — was still failing CI, leaving `develop` currently broken: `checks.x86_64-linux.token-meter-gate-negative` throws on evaluation.

This PR is the follow-up that should have landed in the same PR: drop the now-permanently-false assertion and its rationale comment. The sibling assertion in the same check (the Caddy gate agent must not be defined when `enable = false`) is untouched — that invariant still holds independent of the cleanup activation.

Accepted tradeoff, already decided: disabling `token-meter` no longer tears down the two stray LaunchAgents upstream's installer writes outside Nix's management (previously measured at ~2.4 cores left running). No script replaces the removed one — this repo is not to have custom scripts performing proactive removal.

## Test plan
- [x] `nix eval .#checks.x86_64-linux.token-meter-gate-negative.name` on top of current `develop` — succeeds (previously threw)
- [x] `nix fmt` / `statix check` / `deadnix` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fifx8RuHLKmSFU5nYw4dLQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a Nix check; no runtime, auth, or data-handling behavior is modified.
> 
> **Overview**
> Aligns the `token-meter-gate-negative` check with the module after `home.activation.tokenMeterCleanup` was removed. The check still asserts the Caddy gate agent is absent when `programs.token-meter.enable = false`, but no longer requires a cleanup activation that no longer exists.
> 
> Disabling the module still does not tear down upstream LaunchAgents written outside Nix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37d17163041f9644bbb0d35072d8cae4767c116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->