### PR TITLE
feat(litellm-local): loopback proxy so clients name role aliases

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -217,6 +217,20 @@ let
       };
     }
   ];
+  # Evaluation with the local LiteLLM proxy enabled. The module is off by
+  # default, so without this fixture every `lib.optionalAttrs
+  # litellmLocal.enable` branch across the client modules would go unevaluated
+  # and a typo in one of them would pass CI.
+  hmConfigLitellmLocal = mkHmConfig [
+    {
+      programs.litellmLocal.enable = true;
+      services.aiStack = {
+        llmEndpoint = "router";
+        llmRouterEndpoint = "https://llm.example.invalid/v1";
+        llmEndpointTokenFile = "/run/secrets/LLM_ROUTER_BEARER";
+      };
+    }
+  ];
 in
 (import ./checks/lint.nix { inherit pkgs src; })
 // (import ./checks/token-meter.nix {
@@ -300,7 +314,13 @@ in
 // (import ./checks/mlx-cluster-soak.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-selfheal.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-recovery.nix { inherit pkgs src; })
-// (import ./checks/litellm-local.nix { inherit pkgs hmConfig; })
+// (import ./checks/litellm-local.nix {
+  inherit
+    pkgs
+    hmConfig
+    hmConfigLitellmLocal
+    ;
+})
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -300,6 +300,7 @@ in
 // (import ./checks/mlx-cluster-soak.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-selfheal.nix { inherit pkgs src; })
 // (import ./checks/mlx-cluster-recovery.nix { inherit pkgs src; })
+// (import ./checks/litellm-local.nix { inherit pkgs hmConfig; })
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks/fabric.nix
+++ b/lib/checks/fabric.nix
@@ -74,9 +74,12 @@ in
         actual = hmConfig.config.home.sessionVariables.FABRIC_PATTERNS_DIR;
         expected = "${hmConfig.config.home.homeDirectory}/.config/fabric/patterns";
       }
+      # DEFAULT_MODEL, not FABRIC_DEFAULT_MODEL: fabric derives each setting's
+      # env var as <VENDOR>_<SETTING>, and the vendor owning the default model
+      # is named "Default". The prefixed spelling was read by nothing.
       {
-        name = "fabric.env.FABRIC_DEFAULT_MODEL";
-        actual = hmConfig.config.home.sessionVariables.FABRIC_DEFAULT_MODEL;
+        name = "fabric.env.DEFAULT_MODEL";
+        actual = hmConfig.config.home.sessionVariables.DEFAULT_MODEL;
         expected = cfg.defaultModel;
       }
     ];

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -1,0 +1,57 @@
+# Local LiteLLM proxy regression tests
+#
+# The safety property this file exists for: the local proxy forwards the
+# calling client's own credentials to the `claude-*` deployment ONLY. That
+# deployment reaches Anthropic directly with the client's own credentials;
+# the wildcard deployment reaches a shared router. Forwarding the first leg's
+# credential onto the second is the one unacceptable outcome, and the only
+# thing standing between them is the scoped
+# `litellm_settings.model_group_settings.forward_client_headers_to_llm_api`
+# list. So assert on that list directly, and assert that the global
+# `general_settings.forward_client_headers_to_llm_api` boolean — which would
+# forward to EVERY deployment, router leg included — is absent.
+#
+# Reads programs.litellmLocal.renderedConfig, which the module sets
+# unconditionally, so this needs no second home-manager evaluation.
+{ pkgs, hmConfig }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+
+  rendered = hmConfig.config.programs.litellmLocal.renderedConfig;
+
+  forwardList = rendered.litellm_settings.model_group_settings.forward_client_headers_to_llm_api;
+
+  scopedToClaudeOnly = forwardList == [ "claude-*" ];
+
+  noGlobalForwarding = !(rendered.general_settings ? forward_client_headers_to_llm_api);
+
+  # The wildcard deployment must carry its own api_key, so it authenticates to
+  # the router as itself rather than relying on whatever a client sent.
+  wildcardDeployment = builtins.head (builtins.filter (m: m.model_name == "*") rendered.model_list);
+  claudeDeployment = builtins.head (
+    builtins.filter (m: m.model_name == "claude-*") rendered.model_list
+  );
+
+  wildcardHasOwnKey = wildcardDeployment.litellm_params ? api_key;
+
+  # Conversely the claude-* deployment must NOT carry one: a key here would
+  # override the forwarded client credential and silently bill the wrong
+  # account.
+  claudeHasNoKey = !(claudeDeployment.litellm_params ? api_key);
+in
+{
+  litellm-local-header-scope =
+    assert
+      scopedToClaudeOnly
+      || throw "litellm-local must forward client headers to the claude-* group ONLY (a forwarded client credential must never reach the router leg); got: ${builtins.toJSON forwardList}";
+    assert
+      noGlobalForwarding
+      || throw "litellm-local must not set general_settings.forward_client_headers_to_llm_api: that boolean forwards to every deployment, including the router leg";
+    assert
+      claudeHasNoKey
+      || throw "the litellm-local claude-* deployment must carry no api_key so the forwarded client credential is what authenticates it";
+    assert
+      wildcardHasOwnKey
+      || throw "the litellm-local wildcard deployment must carry its own api_key so it authenticates to the router as itself";
+    helpers.mkMarker "check-litellm-local-header-scope" "litellm-local: client-header forwarding scoped to claude-* only, router leg authenticates with its own key";
+}

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -76,6 +76,25 @@ let
   agyBase = enabled.home.sessionVariables.GOOGLE_GEMINI_BASE_URL;
   agyGetsRoot = agyBase == enabled.programs.litellmLocal.rootUrl && !lib.hasSuffix "/v1" agyBase;
 
+  # A caller that must ask the UPSTREAM router what a role resolves to cannot
+  # use OPENAI_API_KEY (the mkBefore override above makes it the local key) and
+  # cannot see through the local `*` wildcard. It gets the router address and
+  # the PATH of the bearer file — never the bearer itself.
+  zshInit = enabled.programs.zsh.initContent;
+  exportsRouterUrl = lib.hasInfix "export LLM_ROUTER_URL=" zshInit;
+  exportsTokenFilePath = lib.hasInfix "export LLM_ROUTER_TOKEN_FILE=" zshInit;
+
+  # Every credential in the snippet must be a runtime read (`cat <path>`) or a
+  # reference to a variable holding one. A literal would mean a secret was
+  # baked into the generated shell init, which lands in the Nix store.
+  keyFilePath = enabled.programs.litellmLocal.keyFile;
+  tokenFilePath = toString enabled.services.aiStack.llmEndpointTokenFile;
+  readsSecretsFromFiles =
+    lib.hasInfix "cat ${keyFilePath}" zshInit && lib.hasInfix "cat ${tokenFilePath}" zshInit;
+  # The token file's CONTENTS must never be exported under the router-token
+  # name: that variable carries the path only.
+  tokenFileIsPathOnly = lib.hasInfix "export LLM_ROUTER_TOKEN_FILE=${tokenFilePath}" zshInit;
+
   agent = enabled.launchd.agents.litellm-local.config;
   agentLoopbackOnly = enabled.programs.litellmLocal.port == 4100;
   # The router URL reaches the agent as plain env; the two secrets do not.
@@ -119,6 +138,18 @@ in
       agyGetsRoot
       || throw "the Gemini-format client must get the proxy root URL, not the /v1 OpenAI base: it appends /v1beta/models/<model>:generateContent itself; got: ${agyBase}";
     assert agentLoopbackOnly || throw "the proxy port default must stay 4100";
+    assert
+      exportsRouterUrl
+      || throw "shell init must export LLM_ROUTER_URL so a caller can reach the upstream router directly; the local wildcard hides what a role resolves to";
+    assert
+      exportsTokenFilePath
+      || throw "shell init must export LLM_ROUTER_TOKEN_FILE; OPENAI_API_KEY holds the local key after the override, so a caller needs a file to read the router bearer from";
+    assert
+      tokenFileIsPathOnly
+      || throw "LLM_ROUTER_TOKEN_FILE must carry the PATH of the bearer file, never its contents";
+    assert
+      readsSecretsFromFiles
+      || throw "every credential in the shell init must be read from its file at runtime; a literal would bake a secret into the generated init, which lands in the Nix store";
     assert
       agentCarriesNoSecret
       || throw "the launchd agent must take the router URL as plain env and read both secrets from files at exec time, never as EnvironmentVariables";

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -13,8 +13,13 @@
 #
 # Reads programs.litellmLocal.renderedConfig, which the module sets
 # unconditionally, so this needs no second home-manager evaluation.
-{ pkgs, hmConfig }:
+{
+  pkgs,
+  hmConfig,
+  hmConfigLitellmLocal,
+}:
 let
+  inherit (pkgs) lib;
   helpers = import ./helpers.nix { inherit pkgs; };
 
   rendered = hmConfig.config.programs.litellmLocal.renderedConfig;
@@ -38,6 +43,46 @@ let
   # override the forwarded client credential and silently bill the wrong
   # account.
   claudeHasNoKey = !(claudeDeployment.litellm_params ? api_key);
+
+  # ---- enabled-path wiring -------------------------------------------------
+  enabled = hmConfigLitellmLocal.config;
+  proxyBase = enabled.programs.litellmLocal.baseUrl;
+
+  claudeEnv = enabled.programs.claude.settings.env;
+
+  # The main model must stay on Anthropic: only the subagent and background
+  # tiers are repointed at roles.
+  claudeMainUntouched = !(claudeEnv ? ANTHROPIC_MODEL);
+
+  claudeSubagentRole = claudeEnv.CLAUDE_CODE_SUBAGENT_MODEL == "subagent";
+  claudeHaikuRole = claudeEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL == "cheap";
+
+  # The proxy master key must never be rendered into settings.json, which is
+  # a world-readable file in the Nix store. The module exports the header at
+  # shell init instead.
+  claudeNoHeaderInStore = !(claudeEnv ? ANTHROPIC_CUSTOM_HEADERS);
+
+  # Codex must gain the proxy as an ADDITIONAL provider without the default
+  # provider or model changing.
+  codexAgent = enabled.programs.codex;
+  codexDefaultUntouched = codexAgent.modelProvider == hmConfig.config.programs.codex.modelProvider;
+
+  # Every CLI that reads an OpenAI-compatible base URL points at the proxy.
+  fabricBase = enabled.home.sessionVariables.OPENAI_API_BASE_URL == proxyBase;
+  fabricRole = enabled.home.sessionVariables.DEFAULT_MODEL == "cheap";
+
+  # The Gemini-format client appends `/v1beta/...` itself, so it must get the
+  # root URL, not the OpenAI-compatible `/v1` base.
+  agyBase = enabled.home.sessionVariables.GOOGLE_GEMINI_BASE_URL;
+  agyGetsRoot = agyBase == enabled.programs.litellmLocal.rootUrl && !lib.hasSuffix "/v1" agyBase;
+
+  agent = enabled.launchd.agents.litellm-local.config;
+  agentLoopbackOnly = enabled.programs.litellmLocal.port == 4100;
+  # The router URL reaches the agent as plain env; the two secrets do not.
+  agentCarriesNoSecret =
+    (agent.EnvironmentVariables ? LLM_ROUTER_URL)
+    && !(agent.EnvironmentVariables ? OPENAI_API_KEY)
+    && !(agent.EnvironmentVariables ? LITELLM_LOCAL_KEY);
 in
 {
   litellm-local-header-scope =
@@ -54,4 +99,28 @@ in
       wildcardHasOwnKey
       || throw "the litellm-local wildcard deployment must carry its own api_key so it authenticates to the router as itself";
     helpers.mkMarker "check-litellm-local-header-scope" "litellm-local: client-header forwarding scoped to claude-* only, router leg authenticates with its own key";
+
+  litellm-local-client-wiring =
+    assert
+      claudeMainUntouched
+      || throw "enabling the proxy must not pin Claude Code's main model; ANTHROPIC_MODEL was set";
+    assert
+      claudeSubagentRole || throw "Claude Code's subagent tier must resolve to the `subagent` role";
+    assert claudeHaikuRole || throw "Claude Code's background tier must resolve to the `cheap` role";
+    assert
+      claudeNoHeaderInStore
+      || throw "ANTHROPIC_CUSTOM_HEADERS must not be rendered into settings.json: it carries the proxy master key, and settings.json lands in the Nix store";
+    assert
+      codexDefaultUntouched
+      || throw "enabling the proxy must not change Codex's default model provider; the `ox` profile is the opt-in";
+    assert fabricBase || throw "fabric must read the proxy through OPENAI_API_BASE_URL";
+    assert fabricRole || throw "fabric's default model must be the `cheap` role via DEFAULT_MODEL";
+    assert
+      agyGetsRoot
+      || throw "the Gemini-format client must get the proxy root URL, not the /v1 OpenAI base: it appends /v1beta/models/<model>:generateContent itself; got: ${agyBase}";
+    assert agentLoopbackOnly || throw "the proxy port default must stay 4100";
+    assert
+      agentCarriesNoSecret
+      || throw "the launchd agent must take the router URL as plain env and read both secrets from files at exec time, never as EnvironmentVariables";
+    helpers.mkMarker "check-litellm-local-client-wiring" "litellm-local: clients name roles, lead models untouched, no secret rendered into the store";
 }

--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -44,5 +44,14 @@ in
     home.file.".gemini/antigravity-cli/.keep".text = ''
       # Managed by Nix - programs.antigravity-cli module
     '';
+
+    # This CLI accepts only a Gemini-format endpoint, so it can follow the
+    # local proxy only because that proxy serves the Gemini generateContent
+    # route natively (`/v1beta/models/<model>:generateContent` and its
+    # streaming twin) alongside the OpenAI-compatible one. The root URL is
+    # what goes here — the CLI appends the `/v1beta/...` path itself.
+    home.sessionVariables = lib.mkIf config.programs.litellmLocal.enable {
+      GOOGLE_GEMINI_BASE_URL = config.programs.litellmLocal.rootUrl;
+    };
   };
 }

--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -53,5 +53,14 @@ in
     home.sessionVariables = lib.mkIf config.programs.litellmLocal.enable {
       GOOGLE_GEMINI_BASE_URL = config.programs.litellmLocal.rootUrl;
     };
+
+    # Select the role rather than a Gemini registry id, so this CLI resolves
+    # the same way as every other client. mkDefault, because whether this CLI
+    # accepts a model name outside its own registry is not verified here — a
+    # consumer that finds it rejected sets defaultModel back to an alias
+    # without editing this module.
+    programs.antigravity-cli.defaultModel = lib.mkIf config.programs.litellmLocal.enable (
+      lib.mkDefault "subagent"
+    );
   };
 }

--- a/modules/cecli/settings.nix
+++ b/modules/cecli/settings.nix
@@ -32,8 +32,9 @@ let
   # bearer-gated: omit the key so cecli reads OPENAI_API_KEY from the process
   # env, which ai-stack exports at shell init from llmEndpointTokenFile (never
   # baked into the Nix store).
-  endpointBase = resolvedLlmEndpoint;
-  isLocalEndpoint = llmEndpoint == "mlx_local";
+  inherit (config.programs) litellmLocal;
+  endpointBase = if litellmLocal.enable then litellmLocal.baseUrl else resolvedLlmEndpoint;
+  isLocalEndpoint = llmEndpoint == "mlx_local" && !litellmLocal.enable;
 
   # Model names are openai/<role>; llama-swap resolves each role to the
   # physical HF id via useModelName (see services.aiStack.models).
@@ -92,7 +93,15 @@ let
     output_cost_per_token = 0;
   };
 
-  modelMetadata = lib.mapAttrs' (role: _: lib.nameValuePair "openai/${role}" metadataEntry) models;
+  # See the qwen-code module for why these two live here and not in the
+  # shared registry: they resolve upstream, not on this host.
+  proxyOnlyRoles = lib.optionalAttrs litellmLocal.enable {
+    subagent = null;
+    cheap = null;
+  };
+  allRoles = models // proxyOnlyRoles;
+
+  modelMetadata = lib.mapAttrs' (role: _: lib.nameValuePair "openai/${role}" metadataEntry) allRoles;
 
   metadataJson = pkgs.writeText "cecli-model-metadata.json" (builtins.toJSON modelMetadata);
 
@@ -119,7 +128,7 @@ let
     }
     // lib.optionalAttrs (selectedFormat != null) { edit_format = selectedFormat; };
 
-  modelSettings = lib.mapAttrsToList (role: _: makeSettingsEntry "openai/${role}" role) models;
+  modelSettings = lib.mapAttrsToList (role: _: makeSettingsEntry "openai/${role}" role) allRoles;
 
   modelSettingsYaml = yamlFormat.generate "cecli-model-settings.yml" modelSettings;
 

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -207,7 +207,10 @@ in
         # this Nix default.
         alwaysThinkingEnabled = true;
         cleanupPeriodDays = 180;
-        env = import ./claude/settings-env.nix { inherit lib userConfig; };
+        env = import ./claude/settings-env.nix {
+          inherit lib userConfig;
+          inherit (config.programs) litellmLocal;
+        };
 
         permissions = {
           allow = formatters.claude.formatAllowed permissions;

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -6,7 +6,11 @@
 #
 # See: https://code.claude.com/docs/en/settings
 # See: https://code.claude.com/docs/en/model-config
-{ lib, userConfig }:
+{
+  lib,
+  userConfig,
+  litellmLocal,
+}:
 {
   # Model is intentionally left unset (see claude-config.nix), so Claude Code
   # uses the account-tier default. Override per-session via /model, or here
@@ -65,6 +69,25 @@
   # Auto-compact threshold — using upstream default (~95% of context window)
   # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "95";
 
+}
+# Local LiteLLM proxy — route Claude Code through it so subagent-tier work
+# resolves to a role alias upstream instead of a physical model id.
+#
+# The main model is deliberately untouched: `claude-*` requests reach Anthropic
+# through the proxy with this client's own credentials forwarded, so the
+# session model is unchanged. Only the subagent and background tiers are
+# repointed at roles.
+#
+# ANTHROPIC_CUSTOM_HEADERS is NOT set here. It carries the proxy's master key,
+# and every value in this attrset is rendered literally into settings.json in
+# the Nix store. The module exports it at shell init from the key file instead.
+// lib.optionalAttrs litellmLocal.enable {
+  ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
+  CLAUDE_CODE_SUBAGENT_MODEL = "subagent";
+  ANTHROPIC_DEFAULT_HAIKU_MODEL = "cheap";
+  # Let the picker list what the proxy actually serves, so a role added
+  # upstream shows up without a rebuild.
+  CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
 }
 # OpenTelemetry — opt-in via userConfig.telemetry (maintainer profile). Off by
 # default so a fresh consumer emits no telemetry. Endpoint falls back to the

--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -13,6 +13,7 @@
 
 let
   cfg = config.programs.codex;
+  inherit (config.programs) litellmLocal;
   homeDir = config.home.homeDirectory;
 
   aiCommon = import ../common {
@@ -113,6 +114,25 @@ let
   // optionalValue "web_search" cfg.webSearch
   // lib.optionalAttrs (cfg.features != { }) {
     inherit (cfg) features;
+  }
+  # Local LiteLLM proxy as an ADDITIONAL provider, not the default one: the
+  # top-level model/model_provider above stay as they are, so the lead model
+  # is unchanged. `codex --profile ox` is the opt-in that runs a job on the
+  # `subagent` role instead.
+  #
+  # wire_api = "responses" because Codex speaks only the Responses API; the
+  # proxy translates /v1/responses to chat for backends that lack it.
+  // lib.optionalAttrs litellmLocal.enable {
+    model_providers.litellm = {
+      name = "LiteLLM (local)";
+      base_url = litellmLocal.baseUrl;
+      wire_api = "responses";
+      env_key = "LITELLM_LOCAL_KEY";
+    };
+    profiles.ox = {
+      model = "subagent";
+      model_provider = "litellm";
+    };
   };
 
   configJson = pkgs.writeText "codex-config.json" (builtins.toJSON configAttrs);

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -90,6 +90,7 @@ in
     ./antigravity-ide
     ./antigravity-cli
     ./fabric
+    ./litellm-local
     ./maestro
     ./mcp/module.nix
     ./mlx

--- a/modules/fabric/packages.nix
+++ b/modules/fabric/packages.nix
@@ -14,6 +14,11 @@
 let
   inherit (fabricShared) cfg fabricPkg;
   inherit (config.services.aiStack) resolvedLlmEndpoint llmEndpoint;
+  inherit (config.programs) litellmLocal;
+
+  # With the local proxy up it is the endpoint every CLI talks to; the router
+  # is reached only by the proxy itself.
+  endpointBase = if litellmLocal.enable then litellmLocal.baseUrl else resolvedLlmEndpoint;
 
   # Single source of truth for the patterns symlink location. The relative
   # path (patternsKey) is used as the home.file attribute key; the absolute
@@ -50,7 +55,12 @@ in
 
       sessionVariables = {
         FABRIC_PATTERNS_DIR = patternsDir;
-        FABRIC_DEFAULT_MODEL = cfg.defaultModel;
+        # DEFAULT_MODEL, not FABRIC_DEFAULT_MODEL. fabric builds each setting's
+        # env var as <VENDOR>_<SETTING>, and the vendor holding the default
+        # model is literally named "Default" — so the name carries no `FABRIC_`
+        # prefix. The prefixed spelling this module used before was read by
+        # nothing, which is why the value in the user-managed .env kept winning.
+        DEFAULT_MODEL = if litellmLocal.enable then "cheap" else cfg.defaultModel;
       }
       // lib.optionalAttrs (cfg.customPatternsDir != null) {
         FABRIC_CUSTOM_PATTERNS_DIR = cfg.customPatternsDir;
@@ -63,8 +73,13 @@ in
       # fabric on its .env value, unchanged); godotenv does not override an
       # already-set env var, so this shell export wins over any OPENAI_BASE_URL
       # in .env, but vendor selection and API keys in .env stay authoritative.
-      // lib.optionalAttrs (llmEndpoint != "mlx_local") {
-        OPENAI_BASE_URL = resolvedLlmEndpoint;
+      // lib.optionalAttrs (llmEndpoint != "mlx_local" || litellmLocal.enable) {
+        # OPENAI_API_BASE_URL, not OPENAI_BASE_URL — same <VENDOR>_<SETTING>
+        # derivation as above, with the OpenAI vendor's `API Base URL` setting.
+        # godotenv.Load (not Overload) leaves an already-set variable alone, so
+        # under the correct name this export wins over the user-managed .env.
+        OPENAI_API_BASE_URL = endpointBase;
+        DEFAULT_VENDOR = "OpenAI";
       };
 
       activation = lib.optionalAttrs (cfg.customPatternsDir != null) {

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -105,13 +105,23 @@ in
       # Generate the master key once, on first activation. Regenerating it on
       # every rebuild would invalidate the header every already-running client
       # is sending, so the guard is `absent`, not `stale`.
+      #
+      # The whole sequence is one script rather than $DRY_RUN_CMD-prefixed
+      # lines: a `>` redirect runs in the activation shell whether or not
+      # DRY_RUN_CMD is a no-op, so the inline form would write the echoed
+      # command line into the key file on a dry run and the guard below would
+      # then treat that constant as a valid key forever. umask closes the
+      # window a write-then-chmod would leave open.
       home.activation.litellmLocalKey = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        if [ ! -s ${lib.escapeShellArg cfg.keyFile} ]; then
-          $DRY_RUN_CMD mkdir -p ${lib.escapeShellArg (builtins.dirOf cfg.keyFile)}
-          $DRY_RUN_CMD ${lib.getExe' pkgs.openssl "openssl"} rand -hex 32 \
-            > ${lib.escapeShellArg cfg.keyFile}
-          $DRY_RUN_CMD chmod 600 ${lib.escapeShellArg cfg.keyFile}
-        fi
+        $DRY_RUN_CMD ${pkgs.writeShellScript "litellm-local-keygen" ''
+          set -euo pipefail
+          key=${lib.escapeShellArg cfg.keyFile}
+          if [ ! -s "$key" ]; then
+            umask 077
+            mkdir -p "$(dirname "$key")"
+            ${lib.getExe' pkgs.openssl "openssl"} rand -hex 32 > "$key"
+          fi
+        ''}
       '';
 
       launchd.agents.litellm-local = {

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -38,8 +38,16 @@ let
     model_list = [
       {
         model_name = "claude-*";
-        # No api_key: this deployment is reached with the credentials the
-        # calling client already holds, forwarded by the scoped rule below.
+        # No api_key, deliberately: this deployment is reached with the OAuth
+        # bearer the calling client already holds, forwarded by the scoped rule
+        # below. An api_key here would override that bearer and bill the wrong
+        # account.
+        #
+        # LiteLLM only treats a client bearer as forwardable OAuth when it
+        # carries the `sk-ant-oat` prefix (see its anthropic common_utils
+        # optionally_handle_anthropic_oauth). A client sending any other token
+        # shape therefore gets no credential on this leg rather than the wrong
+        # one — the failure is a 401, not a silent mis-auth.
         litellm_params.model = "anthropic/*";
       }
       {

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -163,6 +163,15 @@ in
       # the bearer they need is this proxy's key, not the router's. The router
       # bearer stays confined to the launchd agent's own environment.
       #
+      # LLM_ROUTER_URL and LLM_ROUTER_TOKEN_FILE are exported for callers that
+      # must reach the UPSTREAM router directly rather than through this proxy
+      # — asking what a role actually resolves to, which the local `*` wildcard
+      # hides. Such a caller cannot borrow OPENAI_API_KEY for that: after the
+      # override above it holds the local key, not the router bearer. Both
+      # values are non-secret (an address and a path); the token file's
+      # CONTENTS are never exported, so a caller reads the file itself at the
+      # moment it needs the bearer.
+      #
       # ANTHROPIC_CUSTOM_HEADERS lives here rather than in Claude Code's
       # settings.json because settings.json values are literals: rendering the
       # key there would copy it into the Nix store.
@@ -171,6 +180,8 @@ in
         export LITELLM_LOCAL_KEY
         export OPENAI_API_KEY="$LITELLM_LOCAL_KEY"
         export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $LITELLM_LOCAL_KEY"
+        export LLM_ROUTER_URL=${lib.escapeShellArg aiStack.llmRouterEndpoint}
+        export LLM_ROUTER_TOKEN_FILE=${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)}
       '';
     })
   ];

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -1,0 +1,159 @@
+# Local LiteLLM Proxy — Aggregator, Configuration, Runtime Wiring
+#
+# A loopback-only LiteLLM proxy that lets every CLI on this host name a stable
+# *role* (`lead`, `subagent`, `judge`, `cheap`, ...) instead of a physical
+# model id. Roles resolve upstream in the shared router, so changing which
+# model a role means is an upstream edit, not a change to this repo.
+#
+# Two model groups, and the split between them is the whole point:
+#
+#   claude-*  ->  anthropic/*  with the calling client's own credentials
+#                 forwarded (no api_key here on purpose).
+#   *         ->  the router named by services.aiStack.llmRouterEndpoint,
+#                 authenticated with that endpoint's own bearer.
+#
+# Header forwarding is scoped to the `claude-*` group through
+# `litellm_settings.model_group_settings.forward_client_headers_to_llm_api`,
+# never the global `general_settings` boolean. A client credential must not
+# reach the router leg, and the scoped list is what enforces that — the flake
+# check `litellm-local-header-scope` asserts the list stays exactly `claude-*`.
+#
+# Secrets: the router bearer and the proxy's own master key are read from
+# files at exec time by the launchd wrapper, and exported at shell init for
+# the clients. Neither value is ever written into the Nix store.
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.litellmLocal;
+  aiStack = config.services.aiStack;
+
+  # `os.environ/NAME` is LiteLLM's own indirection: the literal string is what
+  # goes in the config file, and LiteLLM resolves it from the process
+  # environment at load time. That is what keeps every secret out of the store.
+  proxyConfig = {
+    model_list = [
+      {
+        model_name = "claude-*";
+        # No api_key: this deployment is reached with the credentials the
+        # calling client already holds, forwarded by the scoped rule below.
+        litellm_params.model = "anthropic/*";
+      }
+      {
+        model_name = "*";
+        litellm_params = {
+          model = "openai/*";
+          api_base = "os.environ/LLM_ROUTER_URL";
+          api_key = "os.environ/OPENAI_API_KEY";
+        };
+      }
+    ];
+
+    litellm_settings = {
+      # Clients disagree about which sampling params they send; dropping the
+      # ones a given backend rejects keeps a role swap from breaking a client.
+      drop_params = true;
+      model_group_settings.forward_client_headers_to_llm_api = [ "claude-*" ];
+    };
+
+    general_settings.master_key = "os.environ/LITELLM_LOCAL_KEY";
+  };
+
+  configYaml = (pkgs.formats.yaml { }).generate "litellm-local-config.yaml" proxyConfig;
+
+  litellmPkg = pkgs.litellm;
+
+  # launchd agents get no shell init, so the wrapper reads both secrets from
+  # their files itself. This is also why the assertion below requires
+  # llmEndpointTokenFile: llmEndpointBearerFromEnv provisions the bearer into
+  # an interactive shell, which this agent never has.
+  proxyScript = pkgs.writeShellScript "litellm-local-start" ''
+    set -euo pipefail
+    OPENAI_API_KEY="$(cat ${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)})"
+    LITELLM_LOCAL_KEY="$(cat ${lib.escapeShellArg cfg.keyFile})"
+    export OPENAI_API_KEY LITELLM_LOCAL_KEY
+    exec ${lib.getExe' litellmPkg "litellm"} \
+      --config ${configYaml} \
+      --host 127.0.0.1 \
+      --port ${toString cfg.port}
+  '';
+in
+{
+  imports = [ ./options.nix ];
+
+  config = lib.mkMerge [
+    # Set unconditionally so a flake check can read the rendered config (and
+    # assert on the forwarding scope) without enabling the launchd agent —
+    # the same introspection pattern as programs.codex.mcpServerNames.
+    { programs.litellmLocal.renderedConfig = proxyConfig; }
+
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = aiStack.llmEndpoint == "router";
+          message = "programs.litellmLocal.enable requires services.aiStack.llmEndpoint = \"router\": the proxy's non-Anthropic model group forwards to services.aiStack.llmRouterEndpoint, which only the router endpoint provides.";
+        }
+        {
+          assertion = aiStack.llmEndpointTokenFile != null && aiStack.llmEndpointTokenFile != "";
+          message = "programs.litellmLocal.enable requires services.aiStack.llmEndpointTokenFile: the proxy runs as a launchd agent, which has no shell init, so services.aiStack.llmEndpointBearerFromEnv cannot reach it. Point llmEndpointTokenFile at the file holding the router bearer.";
+        }
+      ];
+
+      # Generate the master key once, on first activation. Regenerating it on
+      # every rebuild would invalidate the header every already-running client
+      # is sending, so the guard is `absent`, not `stale`.
+      home.activation.litellmLocalKey = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        if [ ! -s ${lib.escapeShellArg cfg.keyFile} ]; then
+          $DRY_RUN_CMD mkdir -p ${lib.escapeShellArg (builtins.dirOf cfg.keyFile)}
+          $DRY_RUN_CMD ${lib.getExe' pkgs.openssl "openssl"} rand -hex 32 \
+            > ${lib.escapeShellArg cfg.keyFile}
+          $DRY_RUN_CMD chmod 600 ${lib.escapeShellArg cfg.keyFile}
+        fi
+      '';
+
+      launchd.agents.litellm-local = {
+        enable = true;
+        config = {
+          Label = "dev.litellm-local";
+          ProgramArguments = [ "${proxyScript}" ];
+          RunAtLoad = true;
+          KeepAlive = true;
+          # Throttle restarts so a bad config or an unreadable secret file
+          # fails visibly in the log instead of spinning.
+          ThrottleInterval = 30;
+          ProcessType = "Background";
+          EnvironmentVariables = {
+            # Not a secret — the router URL is a plain address, so it needs no
+            # exec-time file read.
+            LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
+            HOME = config.home.homeDirectory;
+          };
+          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.log";
+          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.error.log";
+        };
+      };
+
+      # Exec-time client credentials, mirroring ai-stack/endpoint.nix.
+      #
+      # mkBefore, deliberately: endpoint.nix appends a `:-` guarded
+      # OPENAI_API_KEY export that defers to an already-set value, so running
+      # first makes this the winner. That is the correct precedence — with the
+      # proxy enabled, no interactive client talks to the router directly, so
+      # the bearer they need is this proxy's key, not the router's. The router
+      # bearer stays confined to the launchd agent's own environment.
+      #
+      # ANTHROPIC_CUSTOM_HEADERS lives here rather than in Claude Code's
+      # settings.json because settings.json values are literals: rendering the
+      # key there would copy it into the Nix store.
+      programs.zsh.initContent = lib.mkBefore ''
+        LITELLM_LOCAL_KEY="$(cat ${lib.escapeShellArg cfg.keyFile} 2>/dev/null || echo "")"
+        export LITELLM_LOCAL_KEY
+        export OPENAI_API_KEY="$LITELLM_LOCAL_KEY"
+        export ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: Bearer $LITELLM_LOCAL_KEY"
+      '';
+    })
+  ];
+}

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -1,0 +1,72 @@
+# Local LiteLLM Proxy — Option Declarations
+#
+# All `options.programs.litellmLocal` declarations live here, mirroring the
+# per-module options.nix split used by fabric and the other agent modules.
+{ config, lib, ... }:
+let
+  cfg = config.programs.litellmLocal;
+in
+{
+  options.programs.litellmLocal = {
+    enable = lib.mkEnableOption ''
+      a loopback-only LiteLLM proxy in front of the shared router.
+
+      It serves two model groups: `claude-*` deployments reach Anthropic
+      directly with the calling client's own credentials forwarded, and every
+      other model name is a role alias proxied to the router named by
+      `services.aiStack.llmRouterEndpoint`. Clients therefore name a stable
+      role and the role-to-model mapping changes upstream, with no change here
+    '';
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 4100;
+      description = ''
+        Loopback port for the proxy.
+
+        Default 4100 avoids the ports already allocated by this repo's stack:
+        8180 (fabric REST API), 11434 (llama-swap proxy), 11436 (vllm-mlx).
+      '';
+    };
+
+    keyFile = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.stateHome}/litellm-local/master-key";
+      defaultText = lib.literalExpression ''"''${config.xdg.stateHome}/litellm-local/master-key"'';
+      description = ''
+        Path to the proxy's master key. Generated on activation when absent
+        and never regenerated, so the value survives rebuilds; only the path
+        is committed, mirroring `services.aiStack.llmEndpointTokenFile`.
+
+        The proxy listens on loopback only, so this key is a guard against
+        other local processes rather than a network credential. It is read at
+        exec time by the launchd agent and exported at shell init for the
+        clients — it is never written into the Nix store.
+      '';
+    };
+
+    baseUrl = lib.mkOption {
+      type = lib.types.str;
+      readOnly = true;
+      default = "http://127.0.0.1:${toString cfg.port}/v1";
+      defaultText = lib.literalExpression ''"http://127.0.0.1:''${port}/v1"'';
+      description = ''
+        Read-only OpenAI-compatible `/v1` base URL of the local proxy. The
+        CLI consumers read this instead of composing the loopback URL
+        themselves, so the port is declared once.
+      '';
+    };
+
+    renderedConfig = lib.mkOption {
+      type = lib.types.attrs;
+      readOnly = true;
+      internal = true;
+      description = ''
+        The proxy configuration as an attrset, before YAML serialization.
+        Exists so a flake check can assert on it without parsing YAML —
+        specifically that client-header forwarding stays scoped to the
+        `claude-*` group and never reaches the router deployment.
+      '';
+    };
+  };
+}

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -45,11 +45,25 @@ in
       '';
     };
 
+    rootUrl = lib.mkOption {
+      type = lib.types.str;
+      readOnly = true;
+      default = "http://127.0.0.1:${toString cfg.port}";
+      defaultText = lib.literalExpression ''"http://127.0.0.1:''${port}"'';
+      description = ''
+        Read-only root URL of the local proxy, with no API prefix. Clients
+        that append their own prefix read this: Claude Code appends the
+        Anthropic paths, and a Gemini-format client appends
+        `/v1beta/models/<model>:generateContent`. Clients wanting the
+        OpenAI-compatible base read `baseUrl` instead.
+      '';
+    };
+
     baseUrl = lib.mkOption {
       type = lib.types.str;
       readOnly = true;
-      default = "http://127.0.0.1:${toString cfg.port}/v1";
-      defaultText = lib.literalExpression ''"http://127.0.0.1:''${port}/v1"'';
+      default = "${cfg.rootUrl}/v1";
+      defaultText = lib.literalExpression ''"''${rootUrl}/v1"'';
       description = ''
         Read-only OpenAI-compatible `/v1` base URL of the local proxy. The
         CLI consumers read this instead of composing the loopback URL

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -18,6 +18,7 @@
 let
   cfg = config.programs.opencode;
   inherit (cfg) configDir;
+  inherit (config.programs) litellmLocal;
 
   aiCommon = import ../common { inherit lib config nix-claude-code; };
   permission = aiCommon.formatters.opencode.formatPermission aiCommon.permissions;
@@ -50,10 +51,37 @@ let
     client = "opencode";
   };
 
+  # Role aliases the local proxy serves. Each is a stable name; which physical
+  # model it resolves to is an upstream setting, so this list does not change
+  # when the mapping does.
+  litellmRoles = [
+    "lead"
+    "subagent"
+    "judge"
+    "cheap"
+  ];
+
   settings = {
     "$schema" = "https://opencode.ai/config.json";
     inherit permission;
     mcp = mcpServers;
+  }
+  # The primary agent's model is deliberately NOT set: it stays whatever the
+  # user has chosen. Only the cheap background tier is repointed, plus the
+  # provider itself so `litellm/<role>` is selectable per agent.
+  // lib.optionalAttrs litellmLocal.enable {
+    provider.litellm = {
+      npm = "@ai-sdk/openai-compatible";
+      name = "LiteLLM (local)";
+      options = {
+        baseURL = litellmLocal.baseUrl;
+        apiKey = "{env:LITELLM_LOCAL_KEY}";
+      };
+      models = lib.genAttrs litellmRoles (role: {
+        name = role;
+      });
+    };
+    small_model = "litellm/cheap";
   };
 
   # Pretty-printed via jq (same convention as copilot.nix / antigravity-cli):

--- a/modules/qwen-code/settings.nix
+++ b/modules/qwen-code/settings.nix
@@ -42,18 +42,33 @@ let
   # The router is bearer-gated: point qwen-code's envKey at OPENAI_API_KEY,
   # which ai-stack exports at shell init from llmEndpointTokenFile (never in
   # the Nix store), and drop the literal so the real token is read from env.
-  endpointBase = resolvedLlmEndpoint;
-  isLocalEndpoint = llmEndpoint == "mlx_local";
-  apiKeyEnvVar = if isLocalEndpoint then "QWEN_LOCAL_DUMMY_KEY" else "OPENAI_API_KEY";
+  inherit (config.programs) litellmLocal;
+  endpointBase = if litellmLocal.enable then litellmLocal.baseUrl else resolvedLlmEndpoint;
+  isLocalEndpoint = llmEndpoint == "mlx_local" && !litellmLocal.enable;
+  apiKeyEnvVar =
+    if litellmLocal.enable then
+      "LITELLM_LOCAL_KEY"
+    else if isLocalEndpoint then
+      "QWEN_LOCAL_DUMMY_KEY"
+    else
+      "OPENAI_API_KEY";
   providerKey = "mlx-local-llama-swap";
 
   # llama-swap routes capability-class aliases (default, coding, ...). The
   # qwen-code model schema only accepts `name` and `description` — routing
   # is implicit in the provider's baseUrl, not a per-model field.
+  # The proxy serves two role aliases that the local llama-swap registry has
+  # no equivalent for, so enumerate them alongside it rather than adding them
+  # to the shared registry (they resolve upstream, not on this host).
+  proxyOnlyRoles = lib.optionalAttrs litellmLocal.enable {
+    subagent = null;
+    cheap = null;
+  };
+
   modelEntries = lib.mapAttrsToList (role: physical: {
     name = role;
-    description = "${role} → ${physical} via llama-swap";
-  }) models;
+    description = if physical == null then "${role} via the local proxy" else "${role} → ${physical}";
+  }) (models // proxyOnlyRoles);
 
   defaultModelName = cfg.model;
 


### PR DESCRIPTION
## Summary

Adds `modules/litellm-local/`, a loopback-only LiteLLM proxy, and repoints
this repo's AI CLIs at stable **role names** (`lead`, `subagent`, `judge`,
`cheap`) instead of physical model ids. Which model a role means is a setting
outside this repo, so changing it needs no commit here.

The proxy serves two model groups:

- `claude-*` — reached with the calling client's own credentials forwarded.
- everything else — a role alias, authenticated with its own bearer.

## Safety gate

Client-header forwarding is scoped to the `claude-*` group through
`litellm_settings.model_group_settings.forward_client_headers_to_llm_api`,
never the global `general_settings` boolean, so a forwarded client credential
cannot reach the other group. `litellm-local-header-scope` asserts that scope,
that the global boolean is absent, that the `claude-*` deployment carries no
`api_key`, and that the wildcard deployment carries its own. Verified to fail
when the wildcard group is added to the forwarding list.

No secret enters the Nix store: the launchd agent reads both values from files
at exec time, and the master key is generated once on activation when absent.

## Client changes

Each lead model is left alone; only subagent and background tiers move.

| Client | Change |
| --- | --- |
| Claude Code | base URL, subagent tier `subagent`, background tier `cheap`, gateway model discovery |
| Codex | `litellm` provider (responses wire API) + `ox` profile; default provider unchanged |
| OpenCode | `litellm` provider exposing the four roles, `small_model` on `cheap`, built-in non-primary agents (`general`, `explore`) on `subagent`; primary agents unset |
| qwen-code, cecli | base URL and bearer follow the proxy |
| Antigravity CLI | accepts only a Gemini-format endpoint, which the proxy serves natively; selects the `subagent` role via `mkDefault` |

## Incidental fix

fabric was reading neither variable this repo exported. It derives each
setting's env var as `<VENDOR>_<SETTING>`, so the correct names are
`OPENAI_API_BASE_URL` and `DEFAULT_MODEL`; the previously exported
`OPENAI_BASE_URL` and `FABRIC_DEFAULT_MODEL` matched nothing, which is why
the user-managed `.env` kept winning. Its loader does not override an
already-set variable, so the corrected names now take effect.

## Verification

- `nix eval '.#checks.x86_64-linux' --apply` forcing all 121 check drvPaths — passes.
  (Checks are x86_64-linux-only, so `nix flake check` passes them vacuously on
  a Mac; forcing drvPaths is what actually runs the assertions.)
- New fixture evaluates every `enable`-gated branch, which would otherwise
  never be exercised since the module is off by default.
- Rendered proxy config and Claude env inspected directly and match the spec.
- `nixfmt`, `statix`, `deadnix`, `pre-commit run --all-files` clean.
- Config keys confirmed present in the pinned `litellm` 1.89.0, including the
  scoped forwarding path and the native Gemini route.

- `nix flake check` — exit 0.

Not verified, stated plainly:

- No runtime run. `darwin-rebuild` was deliberately not executed, so nothing
  here is confirmed against a live proxy.
- Whether the Gemini-format CLI accepts a model name outside its own registry
  is untested; that is why its model is set with `mkDefault`.
- The activation script's generated text was not read back — a darwin build of
  it could not be realised here. What is verified is the property that was
  broken: the rendered activation line now contains no redirect at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D8GY81ZqkDL8t8Er9UBT28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a credential-forwarding LLM proxy and rewires OPENAI_API_KEY / Anthropic headers for all local CLIs. A mis-scoped forward list or a secret landing in the store would mis-bill or leak tokens.
> 
> **Overview**
> Adds an opt-in loopback LiteLLM proxy (`programs.litellmLocal`) so CLIs name stable roles (`subagent`, `cheap`, …) while the role-to-model mapping lives on the shared router.
> 
> The proxy splits traffic: `claude-*` forwards the calling client's own credentials to Anthropic (no `api_key` on that deployment); everything else authenticates to the router with the router's bearer. Header forwarding is scoped to `claude-*` only — never the global LiteLLM boolean — so a client credential cannot leak onto the router leg. Secrets stay out of the Nix store: launchd reads both keys from files at exec time; the master key is generated once on activation.
> 
> When enabled, lead models stay put. Claude Code, Codex (`ox` profile), OpenCode, qwen-code, cecli, fabric, and Antigravity CLI are wired to the proxy for subagent/background tiers. Fabric env names are also corrected (`OPENAI_API_BASE_URL`, `DEFAULT_MODEL`) so they actually take effect over `~/.config/fabric/.env`.
> 
> New flake checks assert forwarding scope, no store-baked secrets, and the enabled-path client wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf23ec3b9809f317c988b2820eac1f2129d09e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->