### PR TITLE
feat: wire oh-my-openagent into OpenCode and add omo-senpi wrapper

### DIFF
--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -27,6 +27,13 @@
   gwsCli = "0.22.5";
   # renovate: datasource=npm depName=@openwhispr/cli
   openwhisprCli = "0.1.2";
+  # oh-my-openagent Senpi edition (standalone `omo` command). Beta-channel
+  # only: every published version is a prerelease and the `latest` dist-tag
+  # points at a placeholder (0.0.0-beta.0), so a Renovate npm pin would track
+  # the wrong channel. Bump manually against `npm view omo-ai@beta version`.
+  # Deliberately carries no `renovate:` annotation — same rationale as
+  # mcpSdkBound above.
+  omoSenpi = "5.0.0-0.beta.17";
 
   # MCP servers (npm)
   # renovate: datasource=npm depName=@upstash/context7-mcp

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -53,6 +53,7 @@
 #   claude-flow: claude-flow (multi-agent orchestration)
 #   gws: @googleworkspace/cli (pinned version)
 #   openwhispr: @openwhispr/cli (voice notes / transcriptions CLI)
+#   omo-senpi: omo-ai (oh-my-openagent Senpi edition — standalone agent, beta)
 #
 # UVX WRAPPER PACKAGES (Python packages not in nixpkgs/homebrew):
 #   hf: huggingface-hub CLI (model downloads, used with HuggingFace MCP)
@@ -83,6 +84,7 @@ let
   claudeFlowVersion = versions.claudeFlow;
   gwsCliVersion = versions.gwsCli;
   openwhisprCliVersion = versions.openwhisprCli;
+  omoSenpiVersion = versions.omoSenpi;
 in
 {
   # AI-specific development tools
@@ -189,6 +191,22 @@ in
     # `openwhispr auth login` stores key in ~/.openwhispr/cli-config.json.
     (writeShellScriptBin "openwhispr" ''
       exec ${bun}/bin/bunx --bun @openwhispr/cli@${openwhisprCliVersion} "$@"
+    '')
+
+    # ==========================================================================
+    # Oh My OpenAgent — Senpi edition
+    # ==========================================================================
+    # Standalone senpi engine with the OMO extension built in (beta channel).
+    # Source: https://github.com/code-yeongyu/oh-my-openagent
+    # NPM: omo-ai (pinned beta version; `latest` tag is a placeholder, see
+    # lib/versions.nix). The Ultimate/Light plugin editions are NOT installed
+    # here — they load inside OpenCode/Codex via their own installers.
+    #
+    # Named omo-senpi, not `omo`: the Codex Light installer links its own
+    # runtime wrapper at ~/.local/bin/omo (ahead of this dir on PATH), and
+    # bare `omo` on npm is an unrelated package by a different author.
+    (writeShellScriptBin "omo-senpi" ''
+      exec ${bun}/bin/bunx --bun omo-ai@${omoSenpiVersion} "$@"
     '')
 
     # ==========================================================================

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -177,9 +177,15 @@ in
 
       # OpenCode — skills via the agent-skills registry; upstream's native
       # OpenCode command files come straight from the autoresearch input.
+      # oh-my-openagent (Ultimate) is declared here so the omo installer never
+      # needs to write through the Nix-owned opencode.json symlink: it sees the
+      # plugin entry already present and only manages its own ~/.omo state.
       opencode = {
         enable = true;
         commandDirs = [ "${marketplaceInputs.autoresearch}/.opencode/commands" ];
+        # @latest matches what the omo installer itself writes; bare
+        # "oh-my-openagent" also loads but doctor expects the tagged form.
+        extraSettings.plugin = [ "oh-my-openagent@latest" ];
       };
 
       # Antigravity IDE configuration (settings handled by modules/antigravity-ide/)


### PR DESCRIPTION
## Summary
- Declare `oh-my-openagent@latest` in OpenCode's plugin array via `programs.opencode.extraSettings`, matching what upstream's installer writes so its idempotent path skips editing the Nix-owned `opencode.json` symlink
- Add `omo-senpi` bunx wrapper (standalone Senpi edition) with a manual-bump pin in `lib/versions.nix` — no renovate annotation because every `omo-ai` release is a prerelease and the npm `latest` tag is a placeholder

## Verification
- `nix fmt` + `nix flake check` green (8/8 checks)
- Runtime-switched via darwin-rebuild override; live `opencode.json` carries the plugin entry
- `bunx oh-my-openagent doctor` exit 0 (deprecation notices only)
- Live session: `opencode run` responds under the Sisyphus agent header

Docs: dryvist/docs `ai-development/oh-my-openagent`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a home-manager plugin entry and a bunx CLI wrapper; no auth, secrets, or core infrastructure changes.
> 
> **Overview**
> Pre-declares `oh-my-openagent@latest` in OpenCode `extraSettings.plugin` so the upstream installer sees the plugin already present and does not try to write through the Nix-owned `opencode.json` symlink.
> 
> Adds an `omo-senpi` bunx wrapper for the standalone Senpi edition (`omo-ai` on npm). The pin is manual (no Renovate annotation) because every published version is a prerelease and npm `latest` is a placeholder. The binary is named `omo-senpi` to avoid colliding with Codex Light’s `~/.local/bin/omo` and an unrelated `omo` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01a960561dcfbec47c2533228930da2673b1a0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->