### PR TITLE
chore(deps): bump nix-claude-code for the settings env strip

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787577939,
-        "narHash": "sha256-xuPuiy/ga5SGd6VHLU5f6w1LMIIGgANxPe+9XPd/h5E=",
+        "lastModified": 1787661629,
+        "narHash": "sha256-a099I2GsDxI7d2HRNIOiPYLej5dHHPVnOrBZ6Ukp3UE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "bd66034269e6966c83c8c4df41891ad96c73f20c",
+        "rev": "2423379182826f346686ed772e2c55b56e6d57de",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Picks up the activation-merge fix: the environment block is cleared before it is rebuilt, so a variable removed from configuration stops reaching sessions instead of persisting in the runtime file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only bump of a home-manager module; behavior change is localized to how declared env vars are applied at activation, with no direct edits in this repo.
> 
> **Overview**
> Updates **`flake.lock`** only: the **`nix-claude-code`** input moves from `bd66034…` to `2423379…` on `dryvist/nix-claude-code` **main**, with no other lock nodes touched in this diff.
> 
> That upstream revision carries the **activation-merge / settings environment** fix: the runtime environment section is **cleared before it is rebuilt**, so variables you remove from Nix/home-manager config no longer linger in the merged settings file and still reach Claude Code sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4daded63b0d3b3fb867bc57907d0895712ae32cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->