### PR TITLE
fix(codex): move the ox profile into its own profile file

### DIFF
--- a/modules/codex/settings.nix
+++ b/modules/codex/settings.nix
@@ -129,11 +129,23 @@ let
       wire_api = "responses";
       env_key = "LITELLM_LOCAL_KEY";
     };
-    profiles.ox = {
-      model = "subagent";
-      model_provider = "litellm";
-    };
   };
+
+  # The `ox` profile is a FILE, not a table in the config above. Codex dropped
+  # the legacy `[profiles.<name>]` table (and the top-level `profile =`
+  # selector) in 0.134.0: a config still carrying one is refused outright, so
+  # `--profile ox` failed to start rather than falling back. Each profile now
+  # lives in its own `~/.codex/<name>.config.toml` with its keys at the TOP
+  # level, selected the same way on the command line.
+  oxProfileAttrs = {
+    model = "subagent";
+    model_provider = "litellm";
+  };
+
+  oxProfileJson = pkgs.writeText "codex-ox-profile.json" (builtins.toJSON oxProfileAttrs);
+  oxProfileToml = pkgs.runCommand "codex-ox.config.toml" { nativeBuildInputs = [ pkgs.yj ]; } ''
+    yj -jt < ${oxProfileJson} > $out
+  '';
 
   configJson = pkgs.writeText "codex-config.json" (builtins.toJSON configAttrs);
   configToml = pkgs.runCommand "codex-config.toml" { nativeBuildInputs = [ pkgs.yj ]; } ''
@@ -159,7 +171,12 @@ in
             "${homeDir}/.codex/config.toml"
         '';
 
-        file."${configDir}/rules/default.rules".text = formatters.codex.formatRulesFile permissions;
+        file = {
+          "${configDir}/rules/default.rules".text = formatters.codex.formatRulesFile permissions;
+        }
+        // lib.optionalAttrs litellmLocal.enable {
+          "${configDir}/ox.config.toml".source = oxProfileToml;
+        };
       };
     })
   ];

--- a/modules/scripts/merge-toml-settings.sh
+++ b/modules/scripts/merge-toml-settings.sh
@@ -45,7 +45,14 @@ if [[ -f "$TARGET" ]] && [[ ! -L "$TARGET" ]]; then
   }
   # Strip Nix-authoritative sections from existing config before merge.
   # This prevents stale entries (e.g. removed MCP servers) from persisting.
-  if STRIPPED_EXISTING_JSON=$(jq 'del(.mcp_servers)' <<< "$EXISTING_JSON"); then
+  #
+  # The legacy profile table and selector are stripped for a sharper reason
+  # than staleness: the CLI now REFUSES to start on a config that still
+  # carries either, and named profiles live in their own per-profile file
+  # instead. Nix stopped emitting them, and a merge that only overlays would
+  # leave the rejected keys in place forever — so the deployed config would
+  # keep failing even after the fix shipped. Nothing regenerates them.
+  if STRIPPED_EXISTING_JSON=$(jq 'del(.mcp_servers, .profiles, .profile)' <<< "$EXISTING_JSON"); then
     EXISTING_JSON="$STRIPPED_EXISTING_JSON"
   else
     echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to strip Nix-authoritative sections from existing ${TARGET_NAME}, preserving existing runtime state for merge" >&2


### PR DESCRIPTION
`--profile ox` could not start: the CLI dropped the legacy profile table and top-level selector in 0.134.0 and now refuses outright on a config that still carries either, rather than falling back. Named profiles live in their own per-profile file with keys at the top level.

- The profile is rendered to its own file instead of a table in the main config.
- The TOML merge strips both legacy keys. Nothing regenerates them, so an overlay-only merge would leave an already-deployed config failing forever even after this ships — the same shape as the settings env fix.

Verified against the installed CLI by applying exactly what this emits: the profile reaches the delegation role through the proxy's Responses API and returns the expected reply. `nix flake check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and merge-script changes for Codex profiles; no auth, payment, or core runtime logic beyond fixing CLI compatibility.
> 
> **Overview**
> Fixes **`codex --profile ox`** failing to start after Codex **0.134.0**, which rejects main `config.toml` files that still contain the legacy **`profiles`** table or top-level **`profile`** selector.
> 
> The **`ox`** profile is no longer embedded in the merged main config. When local LiteLLM is enabled, Nix now deploys a separate **`ox.config.toml`** with **`model = "subagent"`** and **`model_provider = "litellm"`** at the top level, matching the new per-profile file layout.
> 
> The **`merge-toml-settings.sh`** activation merge **deletes** **`.profiles`** and **`.profile`** from the existing on-disk config before overlaying Nix defaults (alongside **`mcp_servers`**), so upgraded machines do not keep stale legacy keys that would block startup even after the module stops emitting them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65cba679f2b9594e0eb8ea5d402ae544cfad7a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->