### PR TITLE
fix(scripts): clear a Nix-declared env block before the merge rebuilds it

### DIFF
--- a/modules/scripts/merge-json-settings.sh
+++ b/modules/scripts/merge-json-settings.sh
@@ -34,7 +34,20 @@ if [[ -f "$TARGET" ]] && [[ ! -L "$TARGET" ]]; then
   # Strip Nix-authoritative sections from existing config before merge.
   # This prevents stale entries (e.g. removed MCP servers) from persisting.
   # del(.mcpServers) is a no-op on files without that key (safe for Claude settings.json).
-  if ! STRIPPED=$(jq 'del(.mcpServers)' "$TARGET" 2>/dev/null); then
+  #
+  # `.env` is stripped only when the Nix side actually declares it. A deep
+  # merge cannot express a REMOVAL: once Nix stops emitting a variable, there
+  # is nothing to overwrite the runtime copy with and it keeps being applied
+  # forever. Observed here after a client moved from a local endpoint to the
+  # proxy — the dummy key from the old endpoint stayed behind.
+  #
+  # The condition matters because this script is shared by clients whose Nix
+  # config declares no env block at all. Stripping unconditionally would erase
+  # a whole runtime-owned block for those, trading one silent bug for another;
+  # when Nix declares the block it regenerates it in full, so removal is safe.
+  if ! STRIPPED=$(jq --slurpfile nix "$NIX_SETTINGS" \
+    'del(.mcpServers) | if ($nix[0] | type == "object") and ($nix[0] | has("env")) then del(.env) else . end' \
+    "$TARGET" 2>/dev/null); then
     echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to strip Nix-managed keys from existing ${TARGET_NAME}, using existing file contents as-is" >&2
     if ! STRIPPED=$(cat "$TARGET"); then
       echo "$(date '+%Y-%m-%d %H:%M:%S') [WARN] Failed to read existing ${TARGET_NAME}, using Nix config" >&2


### PR DESCRIPTION
The shared JSON merge overlays without ever clearing `env`, so a variable the Nix side stops emitting has nothing to overwrite it and keeps being applied. Found live: a client that moved from a local endpoint to the proxy still carries the dummy key from the old endpoint.

Stripping is conditional on the Nix side declaring the block. Four clients share this script and some declare no env block at all, owning theirs entirely at runtime — an unconditional strip would erase those, trading one silent bug for another.

Exercised against all three real shapes: the block is cleared where Nix owns it, preserved where Nix declares none, and declared values still apply. `nix flake check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared merge script changes how deployed tool settings env vars are reconciled; wrong stripping logic could drop runtime env for some clients.
> 
> **Overview**
> **`merge-json-settings.sh`** now drops the runtime file’s **`.env`** block before the deep merge, but **only when** the Nix-generated settings JSON includes an **`env`** key—same idea as the existing **`mcpServers`** strip.
> 
> Deep merge cannot remove keys Nix no longer emits, so stale env vars (e.g. after switching from a local endpoint to a proxy) would otherwise stick around forever. Clients whose Nix config has **no** **`env`** block keep a runtime-owned **`env`** untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ae864a331d69220311b8a2e2870753902e6447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->