### PR TITLE
feat: gate experimental MTP profiles

### DIFF
--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -28,6 +28,23 @@ in
     }
     {
       assertion = lib.all (
+        modelId:
+        let
+          profile = cfg.modelMtpProfiles.${modelId};
+          backend = cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+        in
+        !profile.enable
+        || (
+          backend == "vllm-mlx"
+          && lib.elem "vllm-mlx" cfg.enabledBackends
+          && (cfg.modelConcurrencyLimits.${modelId} or cfg.proxy.concurrencyLimit) == 1
+          && !config.programs.mlx.clusterMode.enable
+        )
+      ) (lib.attrNames cfg.modelMtpProfiles);
+      message = "An enabled programs.mlx.modelMtpProfiles entry requires enabled vllm-mlx, a c1 model concurrency limit, and non-cluster mode. MTP evidence is experimental c1-only and must not silently enter a clustered or production-concurrent role.";
+    }
+    {
+      assertion = lib.all (
         role:
         let
           physical = config.services.aiStack.models.${role};

--- a/modules/mlx/catalog-lib.nix
+++ b/modules/mlx/catalog-lib.nix
@@ -55,13 +55,15 @@
 # An entry only offers the classes it has been validated for; requesting an
 # unoffered class fails the eval.
 #
-# KV-QUANT / MTP FLAGS: DO NOT ADD to any entry. Measured against the
+# KV-QUANT / MTP FLAGS: DO NOT ADD to normal catalog entries. Measured against the
 # deployed release mlx-lm 0.31.3 wrapper's own --help (2026-08): no
 # --kv-bits/--kv-group-size, no MTP flag exists on the release server at all.
 # The backend is official mlx-lm only (vllm-mlx disabled, enforced by
 # lib/checks/mlx-catalog.nix); #1334's KV-quant half is not actionable until
 # mlx-lm ships the flags, and its MTP half is vllm-mlx-only and stays
-# unavailable unless that backend is re-enabled. A future git-wheel
+# unavailable unless that backend is re-enabled. `modelMtpProfiles` provides a
+# separate, opt-in c1-only experimental contract when a served snapshot and
+# backend have both been verified. A future git-wheel
 # serverVariant (staged DeepSeek rollout) adds --mtp but drops
 # --harmony-tool-parser — never select it for gpt-oss.
 {

--- a/modules/mlx/imports.nix
+++ b/modules/mlx/imports.nix
@@ -26,6 +26,7 @@
   ./options-filters.nix
   ./options-parsers.nix
   ./options-runtime.nix
+  ./options-mtp-profiles.nix
   ./options-model-backends.nix
   ./options-residency.nix
   ./options-cluster.nix

--- a/modules/mlx/model-server-cmd.nix
+++ b/modules/mlx/model-server-cmd.nix
@@ -53,6 +53,11 @@ rec {
     modelId:
     let
       backend = cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+      mtp =
+        cfg.modelMtpProfiles.${modelId} or {
+          enable = false;
+          draftBlockSize = null;
+        };
       serverPkg = mlxModelServerPkgs.${backend} or mlxModelServerPkg;
       overrides = cfg.modelFlagOverrides.${modelId} or { };
       unknown = lib.filter (k: !(lib.elem k overridableFlags)) (lib.attrNames overrides);
@@ -94,6 +99,11 @@ rec {
           (toString c.autoUnloadIdleSeconds)
         ]
         ++ lib.optionals c.enableMetrics [ "--enable-metrics" ]
+        ++ lib.optionals mtp.enable [ "--enable-mtp" ]
+        ++ lib.optionals (mtp.enable && mtp.draftBlockSize != null) [
+          "--draft-block-size"
+          (toString mtp.draftBlockSize)
+        ]
         ++ lib.optionals c.continuousBatching [ "--continuous-batching" ]
         # Applied server-side so every request carries the same logits
         # processor — a batch mixing penalized with penalty-free requests

--- a/modules/mlx/options-mtp-profiles.nix
+++ b/modules/mlx/options-mtp-profiles.nix
@@ -1,0 +1,19 @@
+{ lib, ... }:
+{
+  options.programs.mlx.modelMtpProfiles = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption "experimental multi-token prediction for this model";
+          draftBlockSize = lib.mkOption {
+            type = lib.types.nullOr (lib.types.ints.between 2 8);
+            default = null;
+            description = "Optional vllm-mlx MTP draft block size. Values below 2 are rejected because a one-token run is not a speculative-decoding measurement.";
+          };
+        };
+      }
+    );
+    default = { };
+    description = "Opt-in experimental MTP profiles. An enabled profile requires the vllm-mlx backend and a serialized model concurrency limit; it never changes a model's default profile.";
+  };
+}

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -200,8 +200,8 @@
       description = "Per-physical-model override of programs.mlx.proxy.concurrencyLimit (llama-swap in-flight cap), for models that must be serialized independent of the global default.";
     };
 
-    # modelBackends — the per-model counterpart of modelServerBackend above —
-    # lives in ./options-model-backends.nix (12 KB gate).
+    # modelMtpProfiles and modelBackends — per-model backend capabilities —
+    # live in dedicated files at the 12 KB gate.
 
     # Per-physical-id llama-swap lifecycle for role-registry models. This is
     # backend-neutral: unlike vllm-mlx's worker-side auto-unload flag, the


### PR DESCRIPTION
Adds an opt-in MTP capability contract with vllm-mlx, c1, and non-cluster safety assertions. Normal model profiles remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect vllm-mlx serve flags and add eval assertions, but MTP stays opt-in and blocked under cluster or concurrent serving unless misconfigured.
> 
> **Overview**
> Introduces **`programs.mlx.modelMtpProfiles`**, an opt-in per-model contract for experimental multi-token prediction that does not alter default catalog or serve profiles.
> 
> When a profile has **`enable`**, eval-time assertions require **`vllm-mlx`** as the model backend (and in **`enabledBackends`**), a **concurrency limit of 1** (per-model override or global proxy default), and **cluster mode off**. Catalog docs are updated to keep MTP out of normal entries and point hosts at this separate path.
> 
> The **vllm-mlx** command builder now appends **`--enable-mtp`** and optional **`--draft-block-size`** (2–8) from the profile; the new option module is wired through **`imports.nix`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3f191501445d422642d676b746549ceeab33f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->