### PR TITLE
feat(claude): configure outputStyle = "concise" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Everything is enabled with sensible defaults. Common toggles on the default modu
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | `programs.claude.model` | str or null | `null` | Override the default model (e.g. `"opus"`, `"sonnet"`) |
+| `programs.claude.outputStyle` | str or null | `null` | Output style (e.g. `"concise"`, `"explanatory"`); null = upstream default |
 | `programs.claude.effortLevel` | enum or null | `null` | Reasoning effort (`"low"` / `"medium"` / `"high"`); null = upstream default |
 | `programs.claude.settings.sandbox.enabled` | bool | `false` | Filesystem/network sandbox isolation |
 | `programs.claude.trustedProjectDirs` | list of str | `[]` | Directories auto-trusted for CLAUDE.md imports |

--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787661629,
-        "narHash": "sha256-a099I2GsDxI7d2HRNIOiPYLej5dHHPVnOrBZ6Ukp3UE=",
+        "lastModified": 1787826818,
+        "narHash": "sha256-I90XKzjD61EHZlJ0ZJt49F6VBlaFMxGmGXH1rwvPyOw=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "2423379182826f346686ed772e2c55b56e6d57de",
+        "rev": "6ab5a501100eed68c9878dae532da1ecc53e7767",
         "type": "github"
       },
       "original": {

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -35,6 +35,7 @@ in
         "mcpServerNames"
         "mcpServers"
         "model"
+        "outputStyle"
         "plugins"
         "remoteControlAtStartup"
         "rules"
@@ -114,6 +115,11 @@ in
         name = "model";
         actual = cfg.model;
         expected = "opusplan";
+      }
+      {
+        name = "outputStyle";
+        actual = cfg.outputStyle;
+        expected = "concise";
       }
       {
         # Intentionally unset → null → Claude Code uses the upstream default.

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -132,6 +132,10 @@ in
       # Model: opusplan — Opus for planning, Sonnet for execution (1M context).
       model = "opusplan";
 
+      # Output style: concise responses by default
+      # See: https://code.claude.com/docs/en/output-styles
+      outputStyle = "concise";
+
       # Effort intentionally left unset: nix-claude-code defaults `effortLevel`
       # to null, which Claude Code reads as the upstream default. Override
       # per-session via /effort.


### PR DESCRIPTION
Update nix-claude-code input and set `programs.claude.outputStyle = "concise";` by default in nix-ai claude configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default Claude response formatting and dependency pin only; no auth, data, or security surface changes.
> 
> **Overview**
> Sets **Claude Code’s default output style to concise** in nix-ai’s maintainer profile and documents the new `programs.claude.outputStyle` toggle in the README usage table.
> 
> The flake **bumps `nix-claude-code`** to a revision that exposes `outputStyle` in the home-manager schema. Regression checks now include the option in the expected schema list and assert `outputStyle = "concise"` alongside existing defaults like `model = "opusplan"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784f8813cd021581d6c92ebf31807ec6113e41ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->