### PR TITLE
feat(mlx): expose Qwen3.8 128k context window

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -74,6 +74,9 @@ in
       c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
       || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
     assert
+      c.modelContextWindows.${judge27b} == 131072
+      || throw "catalog: Qwen3.8 must compile its 131072-token production window";
+    assert
       c.modelServerBackend == "mlx-lm"
       || throw "catalog: the goal judge must use the selected mlx_lm.server deployment path";
     assert

--- a/modules/cecli/settings.nix
+++ b/modules/cecli/settings.nix
@@ -86,8 +86,15 @@ let
 
   # Model metadata — cecli uses LiteLLM. Unknown models fall back to GPT
   # limits which may be wrong. Generate an entry per openai/<role> alias.
-  metadataEntry = {
-    max_input_tokens = 32768;
+  maxInputTokensFor =
+    model:
+    if model == null then
+      32768
+    else
+      lib.attrByPath [ model ] 32768 config.programs.mlx.modelContextWindows;
+
+  metadataEntry = model: {
+    max_input_tokens = maxInputTokensFor model;
     max_output_tokens = 8192;
     input_cost_per_token = 0;
     output_cost_per_token = 0;
@@ -101,7 +108,9 @@ let
   };
   allRoles = models // proxyOnlyRoles;
 
-  modelMetadata = lib.mapAttrs' (role: _: lib.nameValuePair "openai/${role}" metadataEntry) allRoles;
+  modelMetadata = lib.mapAttrs' (
+    role: model: lib.nameValuePair "openai/${role}" (metadataEntry model)
+  ) allRoles;
 
   metadataJson = pkgs.writeText "cecli-model-metadata.json" (builtins.toJSON modelMetadata);
 

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -51,6 +51,10 @@ in
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;
+    # The model supports a native 262,144-token window. Production roles use
+    # 131,072 so the remaining range is available for separately managed 200K
+    # feasibility work rather than silently becoming a fleet default.
+    contextWindowTokens = 131072;
     args = [
       "--chat-template-args"
       (builtins.toJSON {

--- a/modules/mlx/catalog-lib.nix
+++ b/modules/mlx/catalog-lib.nix
@@ -12,6 +12,10 @@
 # Entry schema:
 #   model            physical Hugging Face id
 #   weightGb         4-bit weight footprint (co-residency budget accounting)
+#   contextWindowTokens (optional) maximum accepted prompt-plus-generation
+#                    tokens advertised to clients and used for conservative
+#                    admission sizing. It is distinct from maxRequestTokens,
+#                    which is a vllm-mlx generation guard.
 #   kv               (optional) per-token KV-cache geometry for admission control.
 #                    Fields fetched from the model's HF config.json:
 #                      kvLayers     count of KV-BEARING attention layers. For a

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -79,9 +79,19 @@ let
     acc: name: acc // lib.genAttrs enabled.${name}.roles (_role: (entryFor name).model)
   ) { } (lib.attrNames enabled);
   selectedRoles = lib.concatMap (name: enabled.${name}.roles) (lib.attrNames enabled);
+  catalogContextWindows = lib.mapAttrs' (
+    name: _: lib.nameValuePair (entryFor name).model ((entryFor name).contextWindowTokens or 32768)
+  ) enabled;
 in
 {
   options.programs.mlx = {
+    modelContextWindows = lib.mkOption {
+      type = lib.types.attrsOf lib.types.ints.positive;
+      default = { };
+      internal = true;
+      description = "Selected catalog context windows keyed by physical model id.";
+    };
+
     catalog = lib.mkOption {
       type = lib.types.attrsOf (
         lib.types.submodule {
@@ -151,6 +161,7 @@ in
   };
 
   config = lib.mkIf (cfg.enable && enabled != { }) {
+    programs.mlx.modelContextWindows = catalogContextWindows;
     assertions = [
       {
         assertion = residentWeightGb <= cfg.residentWeightBudgetGb;

--- a/modules/mlx/options-proxy.nix
+++ b/modules/mlx/options-proxy.nix
@@ -23,11 +23,12 @@ let
   # Dense-attention KV cache cost per token, the pessimistic bound (MoE
   # families cost less, at 20 KiB/token). See docs/architecture/mlx-stack.md.
   kvPerTokenDenseKiB = 64;
-  # Largest maxRequestTokens actually granted by a catalog entry (the HIGH
-  # agentic-context profile; modules/mlx/catalog-data.nix,
-  # modules/mlx/catalog-data-qwen38-27b.nix). One in-flight request at this
-  # ceiling sets the largest single-request KV reservation to budget for.
-  maxGrantedRequestTokens = 65536;
+  # Largest catalog context window actually compiled into a selected model.
+  # One in-flight request at this ceiling sets the largest KV reservation to
+  # budget for. maxRequestTokens is a vllm generation guard, not an MLX-LM
+  # context declaration, so it must not stand in for this calculation.
+  configuredContextWindows = lib.attrValues config.programs.mlx.modelContextWindows;
+  maxGrantedRequestTokens = lib.foldl' lib.max 32768 configuredContextWindows;
   kvPerSeqGiB = (kvPerTokenDenseKiB * maxGrantedRequestTokens) / (1024 * 1024);
   # Memory-only headroom after the peak weight, sliced into pessimistic-KV
   # portions: how many concurrent max-length requests the budget FITS.


### PR DESCRIPTION
Expose the selected Qwen3.8 128k context window through the model catalog, generated client metadata, and proxy admission sizing. Add a catalog regression assertion for the compiled window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy memory-fit and concurrency ceiling math plus client context limits; mis-sized windows could admit too much KV load or under-report capacity to tools like cecli.
> 
> **Overview**
> Introduces **`contextWindowTokens`** on MLX catalog entries as the advertised prompt-plus-generation limit (separate from vllm **`maxRequestTokens`**). Selected entries compile into internal **`programs.mlx.modelContextWindows`**, keyed by physical model id, with a **32,768** default when omitted.
> 
> **Qwen3.8-27B** is pinned to **131,072** tokens for production roles (half of its native window), and a catalog regression check asserts that value is compiled for the judge model.
> 
> **Downstream consumers** now read those windows instead of hardcoded limits: **cecli** LiteLLM metadata sets **`max_input_tokens`** per role from the resolved physical model, and **proxy admission sizing** uses the max compiled context window (not **`maxRequestTokens`**) when deriving KV reservations and the **`concurrencyLimit`** memory-fit ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bebba57dd83b07fc929a6c1a013a8fff92fb801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->