### PR TITLE
fix(claude): point the subagent tier at an alias, not a proxy role

### DIFF
--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -75,7 +75,27 @@ let
   # tiers are repointed at roles.
   claudeMainUntouched = !(claudeEnv ? ANTHROPIC_MODEL);
 
-  claudeSubagentRole = claudeEnv.CLAUDE_CODE_SUBAGENT_MODEL == "subagent";
+  # Every model name Claude Code is pointed at must be one the proxy can resolve
+  # WITHOUT the `*` wildcard — either an Anthropic capability alias / model id
+  # that lands in the `claude-*` group, or an explicit `model_name` in the
+  # model_list. Naming an upstream ROLE is what caused the outage: the router
+  # served no `subagent` group, so the request fell through `*` and 404'd on
+  # every subagent spawn. `*` must never be what makes a Claude Code tier work.
+  explicitGroups = map (d: d.model_name) rendered.model_list;
+  claudeTierNames = lib.filter (n: n != null) [
+    (claudeEnv.CLAUDE_CODE_SUBAGENT_MODEL or null)
+    (claudeEnv.ANTHROPIC_MODEL or null)
+  ];
+  claudeTierNamesResolveLocally = lib.all (
+    n:
+    lib.hasPrefix "claude" n
+    || lib.elem n [
+      "opus"
+      "sonnet"
+      "haiku"
+    ]
+    || lib.elem n explicitGroups
+  ) claudeTierNames;
 
   # The haiku tier stays on Anthropic: Claude Code's background requests carry
   # its full system prompt (~36k tokens), which the `cheap` role's 32k-window
@@ -154,7 +174,8 @@ in
       claudeMainUntouched
       || throw "enabling the proxy must not pin Claude Code's main model; ANTHROPIC_MODEL was set";
     assert
-      claudeSubagentRole || throw "Claude Code's subagent tier must resolve to the `subagent` role";
+      claudeTierNamesResolveLocally
+      || throw "every model name Claude Code is pointed at must resolve without the `*` wildcard — an Anthropic alias (opus/sonnet/haiku), a claude-* id, or an explicit model_list group. Naming an upstream ROLE 404s every call in that tier the moment the router stops serving it; got: ${builtins.toJSON claudeTierNames}";
     assert
       claudeHaikuUntouched
       || throw "Claude Code's haiku tier must stay on Anthropic: the `cheap` role's local target cannot hold Claude Code's system prompt, so an override fails every background call";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -96,18 +96,15 @@
   {
     ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
     ANTHROPIC_CUSTOM_HEADERS = "x-litellm-api-key: Bearer ${litellmLocal.clientToken}";
-    # A capability ALIAS, never a router role. `subagent` was a role the router
-    # does not serve, so it fell through the proxy's `*` wildcard, reached the
-    # router, and 404'd — every subagent spawn on this host failed for days
-    # (`model_not_found`, "model sent to the API: subagent"). An alias always
-    # resolves to a real Anthropic model and reaches the `claude-*` group with
-    # this client's own credentials forwarded, so it cannot 404 that way.
+    # Must name something that always resolves — a capability alias or an
+    # explicit model_list group, never a bare role the proxy can only reach
+    # through its `*` wildcard. A role nothing serves 404s every call in this
+    # tier; the flake check enforces that.
     #
-    # `sonnet` and not the caller's own tier: a subagent on the same model as
-    # its caller does not split judgment from labor, it just doubles the price
-    # of it. The caller stays the judge and retries as needed. Measured over 7
-    # days, Opus and Fable SUBAGENTS were 19.3% of all spend while Sonnet
-    # subagents served a comparable call count for ~3.5x less.
+    # A cheaper tier than the caller is the point: the parent corrects its
+    # subagents, so buying far more subagent work for a fraction of the price is
+    # the trade. Repoint this at a local model, or a cheap cloud one with zero
+    # data retention, as soon as either can hold the context this tier needs.
     CLAUDE_CODE_SUBAGENT_MODEL = "sonnet";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -96,15 +96,12 @@
   {
     ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
     ANTHROPIC_CUSTOM_HEADERS = "x-litellm-api-key: Bearer ${litellmLocal.clientToken}";
-    # Must name something that always resolves — a capability alias or an
-    # explicit model_list group, never a bare role the proxy can only reach
-    # through its `*` wildcard. A role nothing serves 404s every call in this
-    # tier; the flake check enforces that.
+    # A capability alias or an explicit model_list group; the flake check
+    # enforces it.
     #
-    # A cheaper tier than the caller is the point: the parent corrects its
-    # subagents, so buying far more subagent work for a fraction of the price is
-    # the trade. Repoint this at a local model, or a cheap cloud one with zero
-    # data retention, as soon as either can hold the context this tier needs.
+    # A cheaper tier than the caller is the point — the parent corrects its
+    # subagents. Repoint at a local model, or a cheap cloud one with zero data
+    # retention, once either holds this tier's context.
     CLAUDE_CODE_SUBAGENT_MODEL = "sonnet";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -96,7 +96,19 @@
   {
     ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
     ANTHROPIC_CUSTOM_HEADERS = "x-litellm-api-key: Bearer ${litellmLocal.clientToken}";
-    CLAUDE_CODE_SUBAGENT_MODEL = "subagent";
+    # A capability ALIAS, never a router role. `subagent` was a role the router
+    # does not serve, so it fell through the proxy's `*` wildcard, reached the
+    # router, and 404'd — every subagent spawn on this host failed for days
+    # (`model_not_found`, "model sent to the API: subagent"). An alias always
+    # resolves to a real Anthropic model and reaches the `claude-*` group with
+    # this client's own credentials forwarded, so it cannot 404 that way.
+    #
+    # `sonnet` and not the caller's own tier: a subagent on the same model as
+    # its caller does not split judgment from labor, it just doubles the price
+    # of it. The caller stays the judge and retries as needed. Measured over 7
+    # days, Opus and Fable SUBAGENTS were 19.3% of all spend while Sonnet
+    # subagents served a comparable call count for ~3.5x less.
+    CLAUDE_CODE_SUBAGENT_MODEL = "sonnet";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the
     # `cheap` role targets the always-on small local model, whose 32k window


### PR DESCRIPTION
## What

- The subagent tier now uses the `sonnet` capability alias instead of a proxy
  role name. An alias resolves to a real model and reaches the Anthropic
  deployment with the client's own credentials forwarded.
- The regression check now asserts that every model name Claude Code is pointed
  at resolves without the catch-all wildcard: an alias, a `claude-*` id, or an
  explicit `model_list` group.

`sonnet` rather than the caller's own tier is deliberate: a subagent running the
same model as its caller does not separate judgment from labor, it only doubles
the price of it. The caller stays the judge and retries as needed.

## Test plan

The `checks` output is `x86_64-linux` only, so `nix flake check` on a darwin
workstation skips these checks. They were verified by evaluating the check
directly, in both directions.

| Check | Result |
| --- | --- |
| `nix fmt` | clean |
| `nix flake check` | pass |
| eval check, alias value | passes |
| eval check, previous value | blocks, with the new message |

The second eval is the one that matters: it proves the guard is not inert.

Runtime verification with a fresh session still to follow — static evaluation
does not prove runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which model subagents call through the local proxy and tightens Nix eval guards; misconfiguration would break subagent spawns but not auth or credential forwarding.
> 
> **Overview**
> **Subagent tier** now uses the **`sonnet` capability alias** instead of the upstream proxy role name `subagent`, so LiteLLM routes through the `claude-*` group with forwarded OAuth credentials instead of falling through the `*` wildcard when the router has no `subagent` group (the prior 404-on-every-subagent failure mode).
> 
> The **litellm-local flake check** no longer requires `CLAUDE_CODE_SUBAGENT_MODEL == "subagent"`. It now asserts that **every** model name Claude Code is configured with (`CLAUDE_CODE_SUBAGENT_MODEL` and optional `ANTHROPIC_MODEL`) resolves locally: `claude-*` id, `opus`/`sonnet`/`haiku` alias, or an explicit `model_list` entry — never an upstream role that only works via `*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dadef2c7d1577cfa675c93fba9025a15053248bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->