### PR TITLE
fix(claude): give the subagent tier a 1M context window

### DIFF
--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -102,7 +102,11 @@
     # A cheaper tier than the caller is the point — the parent corrects its
     # subagents. Repoint at a local model, or a cheap cloud one with zero data
     # retention, once either holds this tier's context.
-    CLAUDE_CODE_SUBAGENT_MODEL = "sonnet";
+    #
+    # The `[1m]` id, not the bare `sonnet` alias: measured subagent context runs
+    # to 284k at p90, which a 200k window truncates. The suffix only resolves on
+    # an explicit id — `sonnet[1m]` is not an alias the proxy can route.
+    CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-5[1m]";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the
     # `cheap` role targets the always-on small local model, whose 32k window


### PR DESCRIPTION
## Summary

`CLAUDE_CODE_SUBAGENT_MODEL` moves from the bare `sonnet` alias to the explicit `claude-sonnet-5[1m]` id.

Measured subagent context reaches 284k at p90, above a 200k window. The `[1m]` suffix resolves only on an explicit model id — the bare alias form is not routable through the proxy.

## Changes

- `modules/claude/settings-env.nix`: set the subagent tier to the 1M id.

## Test Plan

`nix eval .#checks.x86_64-linux.litellm-local-client-wiring.drvPath` passes — the id keeps the `claude-` prefix, so it resolves through the `claude-*` group without the `*` wildcard. Routing confirmed against the proxy: the id reaches Anthropic, while an alias-plus-suffix form does not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env default for the subagent tier under litellm-local; flake wiring still requires a `claude-*` id or alias, so mis-routing is caught at eval time.
> 
> **Overview**
> When the local LiteLLM proxy is enabled, **`CLAUDE_CODE_SUBAGENT_MODEL`** is switched from the bare **`sonnet`** alias to the explicit **`claude-sonnet-5[1m]`** id so subagents get a **1M** context window instead of **200k**.
> 
> Comments in `settings-env.nix` document why: measured subagent context hits **~284k** at p90 (truncation on the old window), and the **`[1m]`** suffix only routes through the proxy on a full model id—not on **`sonnet[1m]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b77af41b1047d38184b85b004b06f032d238c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->