### PR TITLE
docs(rules): extend the plugin-cache rule to hooks

### DIFF
--- a/.claude/rules/plugin-cache-architecture.md
+++ b/.claude/rules/plugin-cache-architecture.md
@@ -39,10 +39,16 @@ loop that requires force-killing the process.
 Cache staleness is handled automatically by `verify-cache-integrity.sh` on every
 `darwin-rebuild switch`. No manual cache deletion is ever needed.
 
-## Never Mutate Plugin Cache from Activation Scripts
+## Never Mutate Plugin Cache While Any Session Is Live
 
 `home.activation` scripts MUST NOT run `claude plugins update`, `claude plugins marketplace update`,
 or any command that creates/deletes directories under `~/.claude/plugins/cache/`.
+
+The same prohibition applies to **hooks**, including `sessionStart` hooks. The hazard is a live
+session, not an activation script — a `sessionStart` hook runs while every *other* session is
+mid-flight, so `claude plugin install` from one starting session re-points paths the others
+already resolved. A hook that mutates the cache must first confirm it is the only live session
+and defer otherwise, leaving its work marker in place so the next solo session picks it up.
 
 These commands regenerate cache directories with new hashes, which breaks `${CLAUDE_PLUGIN_ROOT}`
 references in active Claude Code sessions. All registered hooks (PreToolUse, PostToolUse, Stop)
@@ -87,4 +93,9 @@ version and `installPath`. When a marketplace's Nix store path changes, `verify-
 purges the stale cache dir, which orphans those `installPath`s; the `marketplace-refresh`
 sessionStart hook then has Claude natively reinstall the affected enabled plugins so the registry
 is re-pointed. Both live in `nix-claude-code`. Never edit `installed_plugins.json` from an
-activation script while Claude may be running.
+activation script or a hook while Claude may be running.
+
+Both halves need the live-session check independently. `verify-cache-integrity` defers its purge
+when a session is running, but it writes the refresh marker *before* that check — so the marker
+survives and the reinstall is what reaches the cache. `marketplace-refresh` therefore counts live
+sessions itself and refreshes only when it is the sole one.


### PR DESCRIPTION
## Summary

`.claude/rules/plugin-cache-architecture.md` prohibited plugin-cache mutation from `home.activation` scripts. The constraint is really about a live session, so a `sessionStart` hook is covered by the same reasoning — it runs while other sessions are mid-flight.

## Changes

- Retitle the section to name the actual condition rather than one mechanism.
- State that hooks, `sessionStart` included, are held to the same rule, and that a hook which mutates the cache must confirm it is the only live session and defer otherwise.
- Note in the reconciliation section that the purge and the reinstall each need their own live-session check, since the marker is written before the purge's check.

Documentation only — no behaviour change. The corresponding hook change is dryvist/nix-claude-code#173.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown rule updates only; no runtime or config changes in this repo.
> 
> **Overview**
> Updates **plugin-cache-architecture** so the “don’t mutate cache” rule is framed around **any live Claude session**, not only `home.activation` scripts.
> 
> The renamed section **Never Mutate Plugin Cache While Any Session Is Live** now explicitly covers **hooks** (including `sessionStart`): cache-changing work must run only when this is the sole live session, otherwise defer and leave a work marker for a later solo session. **Runtime Registry Reconciliation** extends the `installed_plugins.json` edit ban to hooks and documents that **`verify-cache-integrity`** and **`marketplace-refresh`** each need their own live-session gate—the refresh marker can be written before a deferred purge, so reinstall logic must still count sessions independently.
> 
> Documentation only; behavior is implemented in `nix-claude-code` (e.g. related hook work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32f7f1710155c5da417b95a23e0a3b87d7e777f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->