### PR TITLE
chore(deps): bump nix-claude-code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787826818,
-        "narHash": "sha256-I90XKzjD61EHZlJ0ZJt49F6VBlaFMxGmGXH1rwvPyOw=",
+        "lastModified": 1787907038,
+        "narHash": "sha256-iJU5VFoT4VDuNBieQzkRA3wDOfqZqwwSl2xCd2bEEYM=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "6ab5a501100eed68c9878dae532da1ecc53e7767",
+        "rev": "3199c92110e5864a4a7be8c92aea530b5ebaf113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Bumps the `nix-claude-code` input to pick up the marketplace-refresh session guard (dryvist/nix-claude-code#173), so the hook this repo delivers only refreshes when it is the sole live session.

## Test Plan

`nix flake check` passes (exit 0).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only bump of an existing flake input; behavior change is limited to marketplace refresh timing in multi-session setups.
> 
> **Overview**
> Updates the **`nix-claude-code`** flake input in `flake.lock` to rev `3199c921` (from `6ab5a501`), pulling in upstream **dryvist/nix-claude-code#173**.
> 
> That change adds a **marketplace-refresh session guard** so the hook this flake delivers only runs marketplace refresh when this is the **sole live Claude Code session**, avoiding refresh churn when multiple sessions are open.
> 
> No local Nix module or package code changes—only the dependency pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45ada2f1d1d8c797b3d5696c20c3d527a6cc3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->