### PR TITLE
fix(telemetry): export OTLP over http/protobuf and require an endpoint

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -60,6 +60,17 @@ flake. Reference implementations: `modules/cecli/` (`buildPythonApplication`) an
 modules (Claude/Antigravity/Codex/fabric) to the uniform layout, or extracting a module
 into a standalone flake.
 
+### [telemetry-coverage.md](telemetry-coverage.md)
+
+Per-CLI OpenTelemetry support: which tools are wired here, which support OTLP
+upstream but are not wired, which are degraded, and which have no support at
+all — each with the vendor source cited. Also records why the telemetry
+endpoint options carry no default.
+
+**Read when**: Wiring a new AI CLI for telemetry, deciding whether a tool can be
+observed at all, or checking whether "no telemetry" means unsupported or
+merely unconfigured.
+
 ### [plugin-scoping.md](plugin-scoping.md)
 
 The two-layer model partitioning Claude Code plugins between user-level (every session)

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -115,8 +115,13 @@ and adding any required runtime secret injection.
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |
 | 9379 | LiteRT-LM classifier (Antigravity CLI gemma router, opt-in) | HTTP | `modules/antigravity-cli/` |
 | 30030 | Cribl MCP | HTTP | `orbstack-kubernetes` repo |
-| 30317 | OTEL Collector (gRPC receiver) | gRPC | `orbstack-kubernetes` repo |
-| 4317 | Cribl OTEL ingest | gRPC | `orbstack-kubernetes` repo |
+
+OTLP collector endpoints are **not** listed here. They are site-specific and
+carry no default: set `userConfig.telemetry.otlpEndpoint` (Claude Code) and
+`programs.mlx.telemetry.otlpEndpoint` in your own configuration. This table
+previously listed a loopback OTEL port that nothing served, and both modules
+defaulted to it — the export silently went nowhere. A row here is a claim that
+something listens; do not add one for a planned service.
 
 Reserved but avoid: **11435** (macOS app conflict, see PR #230).
 
@@ -125,22 +130,35 @@ Reserved but avoid: **11435** (macOS app conflict, see PR #230).
 ```mermaid
 graph LR
     CC["Claude Code\n(metrics + logs)"]
-    MLX["MLX model server\n(traces, when telemetry.enable=true)"]
-    OTEL["OTEL Collector\n:30317"]
-    CRIBL["Cribl Stream\n:4317"]
-    SPLUNK["Splunk HEC"]
-    GAL["Galileo SaaS\napi.galileo.ai/otel/traces"]
+    CCT["Claude Code\n(spans, when tracesEndpoint is set)"]
+    MLX["MLX model server\n(when telemetry.enable + otlpEndpoint)"]
+    OTEL["OTLP collector\n(site-configured endpoint)"]
+    LOGS["Log platform"]
+    EVAL["Eval platform (gated)"]
 
-    CC -->|grpc OTLP| OTEL
-    MLX -->|grpc OTLP| OTEL
-    OTEL -->|grpc OTLP| CRIBL
-    CRIBL --> SPLUNK
-    OTEL -->|"otlphttp (gated: X-Trace-Sink header\n+ content denylist)"| GAL
+    CC -->|"OTLP http/protobuf\n(base URL, exporter appends /v1/*)"| OTEL
+    CCT -->|"OTLP http/protobuf\n(full /v1/traces path)"| OTEL
+    MLX -->|OTLP http/protobuf| OTEL
+    OTEL --> LOGS
+    OTEL -->|"gated: X-Trace-Sink header\n+ content denylist"| EVAL
 ```
 
-**Galileo gate:** only spans carrying `X-Trace-Sink: galileo` AND passing the
-content denylist (no Splunk/Cisco/client keywords) are forwarded to Galileo.
-All other spans flow only to Cribl/Splunk. See [ADR 0003](../adr/0003-galileo-ai-observability.md).
+Both signals are **OTLP over HTTP protobuf**, not gRPC. Two endpoint options
+exist because Claude Code treats traces separately:
+
+| Option | Signals | Path shape |
+|---|---|---|
+| `telemetry.otlpEndpoint` | metrics, logs | base URL — exporter appends `/v1/metrics`, `/v1/logs` |
+| `telemetry.tracesEndpoint` | spans | full `/v1/traces` path, and it also turns on the enhanced-telemetry beta |
+
+Setting `telemetry.enable` alone emits nothing: each endpoint is null by
+default and null means no export for that signal. Spans in particular require
+`tracesEndpoint` — plain `enable` yields counters and log events only, never
+the interaction / llm_request / tool / subagent span tree.
+
+**Eval-platform gate:** only spans carrying `X-Trace-Sink: galileo` AND passing
+the content denylist are forwarded onward. All other spans flow only to the log
+platform. See [ADR 0003](../adr/0003-galileo-ai-observability.md).
 
 ## Fabric's Four Integration Channels
 

--- a/docs/architecture/telemetry-coverage.md
+++ b/docs/architecture/telemetry-coverage.md
@@ -1,0 +1,53 @@
+# AI CLI Telemetry Coverage
+
+Which AI CLIs in this stack can emit OpenTelemetry, which are wired, and — for
+the ones that cannot — the vendor source that says so. A tool absent from this
+page has not been assessed; "no telemetry configured" is not evidence that the
+tool lacks support.
+
+Endpoint values are site-specific and live in the consumer's own configuration,
+never here. See [system-integration-map](system-integration-map.md#telemetry-pipeline)
+for the signal/endpoint shape.
+
+## Supported and wired here
+
+| Tool | Configured via | Signals |
+|---|---|---|
+| Claude Code | `userConfig.telemetry.{enable,otlpEndpoint,tracesEndpoint}` → `modules/claude/settings-env.nix` | metrics, logs, spans |
+| MLX model server | `programs.mlx.telemetry.{enable,otlpEndpoint}` → `modules/mlx/launchd.nix` | inherited by llama-swap and worker children |
+
+## Supported upstream, not wired here
+
+Each of these has first-party OTLP support. None is wired in this repo yet;
+wiring one means adding its own config surface, not reusing Claude Code's.
+
+| Tool | Configuration surface | Protocol notes | Source |
+|---|---|---|---|
+| OpenAI Codex CLI | `[otel]` in `~/.codex/config.toml` (`exporter`, `metrics_exporter`, `trace_exporter`, each with an `otlp-http`/`otlp-grpc` sub-table); also honors `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp-http` supported. Opt-in, off by default. `codex mcp-server` emits nothing; `codex exec` emits traces and logs but no metrics | [openai/codex observability](https://deepwiki.com/openai/codex/9.4-observability-and-telemetry) |
+| Gemini CLI | `telemetry` object in `.gemini/settings.json` (`enabled`, `target`, `otlpEndpoint`, `otlpProtocol`); env vars override settings, CLI flags override both | OTLP is the wire protocol for both the local-collector and hosted targets | [gemini-cli docs/cli/telemetry.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/telemetry.md) |
+| GitHub Copilot CLI | `COPILOT_OTEL_ENABLED` + `OTEL_EXPORTER_OTLP_ENDPOINT`, forwarded from the editor extension to the agent-host process; enterprise-managed settings can mandate an endpoint centrally | HTTP only — a gRPC config is silently downgraded | [Copilot SDK observability](https://docs.github.com/en/copilot/how-tos/copilot-sdk/observability/opentelemetry) |
+| qwen-code | `telemetry.otlpEndpoint`/`otlpProtocol` in `.qwen/settings.json`; `QWEN_TELEMETRY_OTLP_*` env vars take precedence over generic `OTEL_*`; `--telemetry-otlp-endpoint` flag | `otlpProtocol: "http"` auto-appends the signal path; gRPC also supported | [qwen-code telemetry docs](https://github.com/QwenLM/qwen-code/blob/main/docs/developers/development/telemetry.md) |
+| Cursor | **Org-level only** — configured in Cursor's web admin (Team Settings → OpenTelemetry Export), not per-process env vars. There is no documented client-side `OTEL_*` support | OTLP/HTTP binary protobuf only; gRPC and JSON are explicitly unsupported | [Cursor OpenTelemetry export](https://cursor.com/docs/enterprise/opentelemetry-export) |
+
+## Degraded
+
+| Tool | State | Source |
+|---|---|---|
+| OpenCode | Advertises `experimental_opentelemetry` in `opencode.json`, but no span collector is wired behind it — effectively non-functional as documented. The working path is a third-party plugin (`OPENCODE_ENABLE_TELEMETRY`, `OPENCODE_OTLP_ENDPOINT`, `OPENCODE_OTLP_PROTOCOL`), not first-party | [opencode-plugin-otel](https://github.com/DEVtheOPS/opencode-plugin-otel) |
+
+## No OTLP support
+
+| Tool | Finding | Source |
+|---|---|---|
+| Antigravity CLI (`agy`) | Distinct from Gemini CLI despite the shared settings-directory lineage. Standard `OTEL_EXPORTER_OTLP_*` env vars produce no output — reproduced by a user in an open feature request. Only a non-OTLP product-analytics toggle exists | [antigravity-cli#366](https://github.com/google-antigravity/antigravity-cli/issues/366) |
+| fabric | No telemetry, OTLP, or tracing surface. `--debug` is local verbosity and `--show-metadata` writes token counts to stderr; neither is exported | [fabric README](https://github.com/danielmiessler/fabric) |
+| cecli | No telemetry surface found across the documented configuration sections. Not exhaustive — the per-format config subpages were not individually checked, so treat this as "none found", not "proven absent" | [cecli docs](https://cecli.dev/docs/) |
+
+## Not OTLP: the transcript-file path
+
+Several tools that emit no OTLP still produce observable data, because their
+session transcripts are tailed off disk by a separate log-shipping agent and
+forwarded to the log platform. That path is owned by the host configuration,
+not by this repo, and it covers tools regardless of their OTLP support. It
+carries per-message token counts but no latency, tool duration, or subagent
+structure — which is what spans add and files cannot.

--- a/docs/architecture/telemetry-coverage.md
+++ b/docs/architecture/telemetry-coverage.md
@@ -23,7 +23,7 @@ wiring one means adding its own config surface, not reusing Claude Code's.
 
 | Tool | Configuration surface | Protocol notes | Source |
 |---|---|---|---|
-| OpenAI Codex CLI | `[otel]` in `~/.codex/config.toml` (`exporter`, `metrics_exporter`, `trace_exporter`, each with an `otlp-http`/`otlp-grpc` sub-table); also honors `OTEL_EXPORTER_OTLP_ENDPOINT` | `otlp-http` supported. Opt-in, off by default. `codex mcp-server` emits nothing; `codex exec` emits traces and logs but no metrics | [openai/codex observability](https://deepwiki.com/openai/codex/9.4-observability-and-telemetry) |
+| OpenAI Codex CLI | `[otel]` in `~/.codex/config.toml`. Schema read from the 0.150.1 binary: `{tool_result, log_user_prompt, environment, exporter, trace_exporter, metrics_exporter, span_attributes, tracestate}`, exporter kinds `none \| statsig \| otlp-http{endpoint,headers,protocol,tls} \| otlp-grpc`, protocol `binary \| json` | Embeds the Rust `opentelemetry-otlp` 0.31.0 exporter, so it also honors the standard `OTEL_EXPORTER_OTLP_*` env vars — **including their `http://localhost:4318` default**, which is the same silent-export shape this repo removed from its own options. Opt-in, off by default. `codex mcp-server` emits nothing | [openai/codex observability](https://deepwiki.com/openai/codex/9.4-observability-and-telemetry) |
 | Gemini CLI | `telemetry` object in `.gemini/settings.json` (`enabled`, `target`, `otlpEndpoint`, `otlpProtocol`); env vars override settings, CLI flags override both | OTLP is the wire protocol for both the local-collector and hosted targets | [gemini-cli docs/cli/telemetry.md](https://github.com/google-gemini/gemini-cli/blob/main/docs/cli/telemetry.md) |
 | GitHub Copilot CLI | `COPILOT_OTEL_ENABLED` + `OTEL_EXPORTER_OTLP_ENDPOINT`, forwarded from the editor extension to the agent-host process; enterprise-managed settings can mandate an endpoint centrally | HTTP only — a gRPC config is silently downgraded | [Copilot SDK observability](https://docs.github.com/en/copilot/how-tos/copilot-sdk/observability/opentelemetry) |
 | qwen-code | `telemetry.otlpEndpoint`/`otlpProtocol` in `.qwen/settings.json`; `QWEN_TELEMETRY_OTLP_*` env vars take precedence over generic `OTEL_*`; `--telemetry-otlp-endpoint` flag | `otlpProtocol: "http"` auto-appends the signal path; gRPC also supported | [qwen-code telemetry docs](https://github.com/QwenLM/qwen-code/blob/main/docs/developers/development/telemetry.md) |
@@ -42,6 +42,19 @@ wiring one means adding its own config surface, not reusing Claude Code's.
 | Antigravity CLI (`agy`) | Distinct from Gemini CLI despite the shared settings-directory lineage. Standard `OTEL_EXPORTER_OTLP_*` env vars produce no output — reproduced by a user in an open feature request. Only a non-OTLP product-analytics toggle exists | [antigravity-cli#366](https://github.com/google-antigravity/antigravity-cli/issues/366) |
 | fabric | No telemetry, OTLP, or tracing surface. `--debug` is local verbosity and `--show-metadata` writes token counts to stderr; neither is exported | [fabric README](https://github.com/danielmiessler/fabric) |
 | cecli | No telemetry surface found across the documented configuration sections. Not exhaustive — the per-format config subpages were not individually checked, so treat this as "none found", not "proven absent" | [cecli docs](https://cecli.dev/docs/) |
+
+## Why the unwired tools are not wired yet
+
+Wiring a tool here means shipping a config that a vendor binary parses at
+startup. Codex refuses to start on a config it cannot parse — that is how the
+legacy `[profiles.*]` table broke `--profile` — so a guessed schema is not a
+cheap mistake. More to the point, this repo's whole position on telemetry is
+that configuration which *looks* right proves nothing: a signal counts as
+wired when an event from it has been seen in the backend.
+
+Each tool above therefore stays documented rather than configured until its
+wiring can be verified against a real event. The schema notes are recorded so
+that work starts from evidence rather than from a search result.
 
 ## Not OTLP: the transcript-file path
 

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -65,38 +65,6 @@ let
 
   hmConfig = mkHmConfig [ ];
 
-  # Telemetry evaluations. Three profiles, because the interesting behaviour is
-  # what does NOT render: an endpoint is required, and traces are a separate
-  # opt-in on top of it. See lib/checks/telemetry.nix.
-  hmConfigTelemetryFull = mkHmConfigWith {
-    telemetry = {
-      enable = true;
-      otlpEndpoint = "https://otel.test.invalid";
-      tracesEndpoint = "https://otel.test.invalid/v1/traces";
-    };
-  } [ ];
-
-  hmConfigTelemetryNoTraces = mkHmConfigWith {
-    telemetry = {
-      enable = true;
-      otlpEndpoint = "https://otel.test.invalid";
-    };
-  } [ ];
-
-  hmConfigTelemetryNoEndpoint = mkHmConfigWith {
-    telemetry.enable = true;
-  } [ ];
-
-  # Traces wired, metrics/logs deliberately not — the shape used against a
-  # collector whose pipeline extracts spans only.
-  hmConfigTelemetryTracesOnly = mkHmConfigWith {
-    telemetry = {
-      enable = true;
-      tracesEndpoint = "https://otel.test.invalid/v1/traces";
-      resourceAttributes."host.name" = "test-host";
-    };
-  } [ ];
-
   hmConfigAgentSkillsShared = mkHmConfig [
     {
       programs.agentSkills.root = "agents";
@@ -300,15 +268,7 @@ in
 // (import ./checks/ai-stack.nix { inherit pkgs testLocalModelId; })
 // (import ./checks/ai-stack-endpoint.nix { inherit pkgs; })
 // (import ./checks/claude.nix { inherit pkgs hmConfig; })
-// (import ./checks/telemetry.nix {
-  inherit
-    pkgs
-    hmConfigTelemetryFull
-    hmConfigTelemetryNoTraces
-    hmConfigTelemetryNoEndpoint
-    hmConfigTelemetryTracesOnly
-    ;
-})
+// (import ./checks/telemetry.nix { inherit pkgs mkHmConfigWith; })
 // (import ./checks/agent-skills.nix {
   inherit
     pkgs

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -87,6 +87,16 @@ let
     telemetry.enable = true;
   } [ ];
 
+  # Traces wired, metrics/logs deliberately not — the shape used against a
+  # collector whose pipeline extracts spans only.
+  hmConfigTelemetryTracesOnly = mkHmConfigWith {
+    telemetry = {
+      enable = true;
+      tracesEndpoint = "https://otel.test.invalid/v1/traces";
+      resourceAttributes."host.name" = "test-host";
+    };
+  } [ ];
+
   hmConfigAgentSkillsShared = mkHmConfig [
     {
       programs.agentSkills.root = "agents";
@@ -296,6 +306,7 @@ in
     hmConfigTelemetryFull
     hmConfigTelemetryNoTraces
     hmConfigTelemetryNoEndpoint
+    hmConfigTelemetryTracesOnly
     ;
 })
 // (import ./checks/agent-skills.nix {

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -29,11 +29,17 @@ let
   # parameterized).
   testLocalModelId = "mlx-community/test-model";
 
-  # Shared test module configuration — used by claude, mlx, and fabric regression checks
-  baseTestModule = {
+  # Shared test module configuration — used by claude, mlx, and fabric regression
+  # checks. `userConfig` reaches modules through `_module.args`, which admits
+  # exactly one non-default definition, so the maintainer-profile knobs cannot be
+  # overridden from an extra module the way an ordinary option can. Taking the
+  # extra attrs here instead lets a check evaluate the stack under a different
+  # profile (e.g. telemetry on) without a definition conflict.
+  mkBaseTestModule = userConfigExtra: {
     _module.args.userConfig = {
       user.fullName = "JacobPEvans";
-    };
+    }
+    // userConfigExtra;
     services.aiStack.defaultLocalModelId = testLocalModelId;
     home = {
       username = "test-user";
@@ -42,18 +48,44 @@ let
     };
   };
 
-  mkHmConfig =
-    extraModules:
+  baseTestModule = mkBaseTestModule { };
+
+  mkHmConfigWith =
+    userConfigExtra: extraModules:
     home-manager.lib.homeManagerConfiguration {
       inherit pkgs;
       modules = [
         aiModule
-        baseTestModule
+        (mkBaseTestModule userConfigExtra)
       ]
       ++ extraModules;
     };
 
+  mkHmConfig = mkHmConfigWith { };
+
   hmConfig = mkHmConfig [ ];
+
+  # Telemetry evaluations. Three profiles, because the interesting behaviour is
+  # what does NOT render: an endpoint is required, and traces are a separate
+  # opt-in on top of it. See lib/checks/telemetry.nix.
+  hmConfigTelemetryFull = mkHmConfigWith {
+    telemetry = {
+      enable = true;
+      otlpEndpoint = "https://otel.test.invalid";
+      tracesEndpoint = "https://otel.test.invalid/v1/traces";
+    };
+  } [ ];
+
+  hmConfigTelemetryNoTraces = mkHmConfigWith {
+    telemetry = {
+      enable = true;
+      otlpEndpoint = "https://otel.test.invalid";
+    };
+  } [ ];
+
+  hmConfigTelemetryNoEndpoint = mkHmConfigWith {
+    telemetry.enable = true;
+  } [ ];
 
   hmConfigAgentSkillsShared = mkHmConfig [
     {
@@ -258,6 +290,14 @@ in
 // (import ./checks/ai-stack.nix { inherit pkgs testLocalModelId; })
 // (import ./checks/ai-stack-endpoint.nix { inherit pkgs; })
 // (import ./checks/claude.nix { inherit pkgs hmConfig; })
+// (import ./checks/telemetry.nix {
+  inherit
+    pkgs
+    hmConfigTelemetryFull
+    hmConfigTelemetryNoTraces
+    hmConfigTelemetryNoEndpoint
+    ;
+})
 // (import ./checks/agent-skills.nix {
   inherit
     pkgs

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -48,8 +48,6 @@ let
     };
   };
 
-  baseTestModule = mkBaseTestModule { };
-
   mkHmConfigWith =
     userConfigExtra: extraModules:
     home-manager.lib.homeManagerConfiguration {

--- a/lib/checks/telemetry.nix
+++ b/lib/checks/telemetry.nix
@@ -1,0 +1,101 @@
+# Telemetry wiring regression tests
+#
+# These pin values nix-ai itself sets, and one behaviour that is easy to
+# regress silently: an OTLP endpoint has NO default, and without one nothing
+# is exported at all.
+#
+# Both telemetry options previously defaulted to a loopback port that no
+# collector has ever served. `telemetry.enable = true` therefore rendered a
+# complete, plausible-looking OTLP config whose every metric and log went
+# nowhere — a failure with no error message, no dropped-export warning, and no
+# way to tell from the config that it was broken. The fix was to remove the
+# default entirely; these checks keep it removed.
+{
+  pkgs,
+  hmConfigTelemetryFull,
+  hmConfigTelemetryNoTraces,
+  hmConfigTelemetryNoEndpoint,
+}:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+  envOf = c: c.config.programs.claude.settings.env;
+
+  full = envOf hmConfigTelemetryFull;
+  noTraces = envOf hmConfigTelemetryNoTraces;
+  noEndpoint = envOf hmConfigTelemetryNoEndpoint;
+
+  has = env: k: builtins.hasAttr k env;
+in
+{
+  telemetry-otlp-wiring = helpers.mkDefaultsRegression {
+    label = "Telemetry";
+    checkName = "check-telemetry-otlp-wiring";
+    checks = [
+      # The collector speaks OTLP over HTTP protobuf. gRPC was the previous
+      # value and pairs with the dead loopback port; it must not come back
+      # without the endpoint changing too.
+      {
+        name = "metrics/logs protocol is http/protobuf";
+        actual = full.OTEL_EXPORTER_OTLP_PROTOCOL;
+        expected = "http/protobuf";
+      }
+      {
+        name = "traces protocol is http/protobuf";
+        actual = full.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
+        expected = "http/protobuf";
+      }
+      # Base URL, no /v1 suffix: the exporter appends the signal path itself.
+      {
+        name = "generic endpoint passed through verbatim";
+        actual = full.OTEL_EXPORTER_OTLP_ENDPOINT;
+        expected = "https://otel.test.invalid";
+      }
+      # Signal-specific, so it carries the full path.
+      {
+        name = "traces endpoint passed through verbatim";
+        actual = full.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+        expected = "https://otel.test.invalid/v1/traces";
+      }
+      {
+        name = "telemetry enabled";
+        actual = full.CLAUDE_CODE_ENABLE_TELEMETRY;
+        expected = "1";
+      }
+      # Spans need the beta flag AND a signal-specific traces endpoint. With
+      # only the generic endpoint set, Claude Code emits counters and log
+      # events and no span tree at all.
+      {
+        name = "span beta on when tracesEndpoint is set";
+        actual = full.CLAUDE_CODE_ENHANCED_TELEMETRY_BETA;
+        expected = "1";
+      }
+      {
+        name = "span beta absent when tracesEndpoint is null";
+        actual = has noTraces "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA";
+        expected = false;
+      }
+      {
+        name = "traces endpoint absent when tracesEndpoint is null";
+        actual = has noTraces "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+        expected = false;
+      }
+      # The black-hole guard. enable alone must render NOTHING: no endpoint to
+      # fall back to means no export, not an export to a guessed default.
+      {
+        name = "no endpoint rendered when otlpEndpoint is null";
+        actual = has noEndpoint "OTEL_EXPORTER_OTLP_ENDPOINT";
+        expected = false;
+      }
+      {
+        name = "telemetry not enabled when otlpEndpoint is null";
+        actual = has noEndpoint "CLAUDE_CODE_ENABLE_TELEMETRY";
+        expected = false;
+      }
+      {
+        name = "no protocol rendered when otlpEndpoint is null";
+        actual = has noEndpoint "OTEL_EXPORTER_OTLP_PROTOCOL";
+        expected = false;
+      }
+    ];
+  };
+}

--- a/lib/checks/telemetry.nix
+++ b/lib/checks/telemetry.nix
@@ -15,6 +15,7 @@
   hmConfigTelemetryFull,
   hmConfigTelemetryNoTraces,
   hmConfigTelemetryNoEndpoint,
+  hmConfigTelemetryTracesOnly,
 }:
 let
   helpers = import ./helpers.nix { inherit pkgs; };
@@ -23,6 +24,7 @@ let
   full = envOf hmConfigTelemetryFull;
   noTraces = envOf hmConfigTelemetryNoTraces;
   noEndpoint = envOf hmConfigTelemetryNoEndpoint;
+  tracesOnly = envOf hmConfigTelemetryTracesOnly;
 
   has = env: k: builtins.hasAttr k env;
 in
@@ -94,6 +96,68 @@ in
       {
         name = "no protocol rendered when otlpEndpoint is null";
         actual = has noEndpoint "OTEL_EXPORTER_OTLP_PROTOCOL";
+        expected = false;
+      }
+      # An OTel SDK with no endpoint falls back to a conventional loopback
+      # address, so every exporter must be pinned explicitly rather than left
+      # unset — otherwise "not configured" silently becomes "exporting into
+      # nothing", which is the failure this whole change exists to remove.
+      {
+        name = "metrics exporter pinned off when otlpEndpoint is null";
+        actual = noEndpoint.OTEL_METRICS_EXPORTER;
+        expected = "none";
+      }
+      {
+        name = "logs exporter pinned off when otlpEndpoint is null";
+        actual = noEndpoint.OTEL_LOGS_EXPORTER;
+        expected = "none";
+      }
+      {
+        name = "traces exporter pinned off when tracesEndpoint is null";
+        actual = noTraces.OTEL_TRACES_EXPORTER;
+        expected = "none";
+      }
+      # Traces-only: each signal is gated on its OWN endpoint, so wiring spans
+      # alone must not drag metrics and logs along to a pipeline that discards
+      # them.
+      {
+        name = "traces-only still enables telemetry";
+        actual = tracesOnly.CLAUDE_CODE_ENABLE_TELEMETRY;
+        expected = "1";
+      }
+      {
+        name = "traces-only exports spans";
+        actual = tracesOnly.OTEL_TRACES_EXPORTER;
+        expected = "otlp";
+      }
+      {
+        name = "traces-only pins metrics off";
+        actual = tracesOnly.OTEL_METRICS_EXPORTER;
+        expected = "none";
+      }
+      {
+        name = "traces-only pins logs off";
+        actual = tracesOnly.OTEL_LOGS_EXPORTER;
+        expected = "none";
+      }
+      {
+        name = "traces-only sets no generic endpoint";
+        actual = has tracesOnly "OTEL_EXPORTER_OTLP_ENDPOINT";
+        expected = false;
+      }
+      {
+        name = "service name identifies the emitter";
+        actual = tracesOnly.OTEL_SERVICE_NAME;
+        expected = "claude-code";
+      }
+      {
+        name = "resource attributes rendered";
+        actual = tracesOnly.OTEL_RESOURCE_ATTRIBUTES;
+        expected = "host.name=test-host";
+      }
+      {
+        name = "prompt content off unless explicitly enabled";
+        actual = has tracesOnly "OTEL_LOG_USER_PROMPTS";
         expected = false;
       }
     ];

--- a/lib/checks/telemetry.nix
+++ b/lib/checks/telemetry.nix
@@ -10,21 +10,42 @@
 # nowhere — a failure with no error message, no dropped-export warning, and no
 # way to tell from the config that it was broken. The fix was to remove the
 # default entirely; these checks keep it removed.
-{
-  pkgs,
-  hmConfigTelemetryFull,
-  hmConfigTelemetryNoTraces,
-  hmConfigTelemetryNoEndpoint,
-  hmConfigTelemetryTracesOnly,
-}:
+{ pkgs, mkHmConfigWith }:
 let
   helpers = import ./helpers.nix { inherit pkgs; };
-  envOf = c: c.config.programs.claude.settings.env;
 
-  full = envOf hmConfigTelemetryFull;
-  noTraces = envOf hmConfigTelemetryNoTraces;
-  noEndpoint = envOf hmConfigTelemetryNoEndpoint;
-  tracesOnly = envOf hmConfigTelemetryTracesOnly;
+  # Four profiles, because the interesting behaviour is what does NOT render.
+  # `userConfig` reaches modules through `_module.args`, which admits one
+  # non-default definition, so each profile needs its own evaluation rather
+  # than an override layered on a shared one.
+  envOf = userConfigExtra: (mkHmConfigWith userConfigExtra [ ]).config.programs.claude.settings.env;
+
+  endpoint = "https://otel.test.invalid";
+  traces = "${endpoint}/v1/traces";
+
+  full = envOf {
+    telemetry = {
+      enable = true;
+      otlpEndpoint = endpoint;
+      tracesEndpoint = traces;
+    };
+  };
+  noTraces = envOf {
+    telemetry = {
+      enable = true;
+      otlpEndpoint = endpoint;
+    };
+  };
+  noEndpoint = envOf { telemetry.enable = true; };
+  # Traces wired, metrics/logs deliberately not — the shape used against a
+  # collector whose pipeline extracts spans only.
+  tracesOnly = envOf {
+    telemetry = {
+      enable = true;
+      tracesEndpoint = traces;
+      resourceAttributes."host.name" = "test-host";
+    };
+  };
 
   has = env: k: builtins.hasAttr k env;
 in
@@ -50,13 +71,13 @@ in
       {
         name = "generic endpoint passed through verbatim";
         actual = full.OTEL_EXPORTER_OTLP_ENDPOINT;
-        expected = "https://otel.test.invalid";
+        expected = endpoint;
       }
       # Signal-specific, so it carries the full path.
       {
         name = "traces endpoint passed through verbatim";
         actual = full.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
-        expected = "https://otel.test.invalid/v1/traces";
+        expected = traces;
       }
       {
         name = "telemetry enabled";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -126,18 +126,24 @@
   }
 )
 # OpenTelemetry — opt-in via userConfig.telemetry (maintainer profile). Off by
-# default so a fresh consumer emits no telemetry. Endpoint falls back to the
-# registry port so flipping telemetry.enable alone reaches the local collector.
-// lib.optionalAttrs (userConfig.telemetry.enable or false) {
-  CLAUDE_CODE_ENABLE_TELEMETRY = "1";
-  OTEL_EXPORTER_OTLP_ENDPOINT =
-    userConfig.telemetry.otlpEndpoint
-      or "http://localhost:${toString (import ../../vars/ai-stack.nix).nodeports.otel_grpc}";
-  OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
-  OTEL_METRICS_EXPORTER = "otlp";
-  OTEL_LOGS_EXPORTER = "otlp";
-  OTEL_TRACES_EXPORTER = "otlp";
-}
+# default so a fresh consumer emits no telemetry. BOTH enable and a non-null
+# otlpEndpoint are required: there is no fallback endpoint, because a default
+# that points nowhere exports into a black hole that is indistinguishable from
+# working telemetry. This config previously defaulted to a loopback registry
+# port that nothing has ever served, and every metric and log went nowhere for
+# as long as it was enabled.
+//
+  lib.optionalAttrs
+    ((userConfig.telemetry.enable or false) && (userConfig.telemetry.otlpEndpoint or null) != null)
+    {
+      CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+      # Base URL only — the exporter appends /v1/metrics and /v1/logs itself.
+      OTEL_EXPORTER_OTLP_ENDPOINT = userConfig.telemetry.otlpEndpoint;
+      OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
+      OTEL_METRICS_EXPORTER = "otlp";
+      OTEL_LOGS_EXPORTER = "otlp";
+      OTEL_TRACES_EXPORTER = "otlp";
+    }
 # Trace spans → a dedicated OTLP/HTTP endpoint, separate from the metrics/logs
 # collector above. Only when telemetry.tracesEndpoint is set. Turns on the
 # enhanced-telemetry tracing beta (the flag that makes Claude Code emit the

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -126,36 +126,93 @@
   }
 )
 # OpenTelemetry — opt-in via userConfig.telemetry (maintainer profile). Off by
-# default so a fresh consumer emits no telemetry. BOTH enable and a non-null
-# otlpEndpoint are required: there is no fallback endpoint, because a default
-# that points nowhere exports into a black hole that is indistinguishable from
-# working telemetry. This config previously defaulted to a loopback registry
-# port that nothing has ever served, and every metric and log went nowhere for
-# as long as it was enabled.
+# default so a fresh consumer emits no telemetry.
+#
+# The two endpoints are INDEPENDENT, and each signal is exported only when its
+# own endpoint is set. Neither carries a default. That is the whole point: an
+# OTel SDK given no endpoint falls back to a conventional loopback address, so
+# "leave it unset" is not the same as "do not export" — it silently exports to
+# somewhere nothing is listening. Every exporter is therefore pinned to an
+# explicit `otlp` or `none` below, never left to the SDK's default. A collector
+# address is site-specific; a wrong-but-plausible one is indistinguishable from
+# working telemetry at every layer, which is why no default is offered here.
+#
+# Splitting metrics/logs from traces also matters downstream: a collector may
+# accept and acknowledge all three signals while its pipeline only extracts
+# one, so pointing a signal at a collector that discards it reproduces the same
+# silent loss one layer further away.
+
+# Master switch: on when telemetry is enabled AND at least one signal has
+# somewhere to go. Without it Claude Code emits nothing, whatever the exporters
+# and endpoints below say.
+//
+  lib.optionalAttrs
+    (
+      (userConfig.telemetry.enable or false)
+      && (
+        (userConfig.telemetry.otlpEndpoint or null) != null
+        || (userConfig.telemetry.tracesEndpoint or null) != null
+      )
+    )
+    (
+      {
+        CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+        OTEL_SERVICE_NAME = userConfig.telemetry.serviceName or "claude-code";
+      }
+      // lib.optionalAttrs (userConfig.telemetry.logUserPrompts or false) {
+        OTEL_LOG_USER_PROMPTS = "1";
+      }
+      // lib.optionalAttrs (userConfig.telemetry.logToolDetails or false) {
+        OTEL_LOG_TOOL_DETAILS = "1";
+      }
+      // lib.optionalAttrs ((userConfig.telemetry.resourceAttributes or { }) != { }) {
+        OTEL_RESOURCE_ATTRIBUTES = lib.concatStringsSep "," (
+          lib.mapAttrsToList (k: v: "${k}=${v}") userConfig.telemetry.resourceAttributes
+        );
+      }
+    )
+
+# Metrics and logs. The generic endpoint is a BASE url — the exporter appends
+# /v1/metrics and /v1/logs itself.
 //
   lib.optionalAttrs
     ((userConfig.telemetry.enable or false) && (userConfig.telemetry.otlpEndpoint or null) != null)
     {
-      CLAUDE_CODE_ENABLE_TELEMETRY = "1";
-      # Base URL only — the exporter appends /v1/metrics and /v1/logs itself.
       OTEL_EXPORTER_OTLP_ENDPOINT = userConfig.telemetry.otlpEndpoint;
       OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
       OTEL_METRICS_EXPORTER = "otlp";
       OTEL_LOGS_EXPORTER = "otlp";
-      OTEL_TRACES_EXPORTER = "otlp";
     }
-# Trace spans → a dedicated OTLP/HTTP endpoint, separate from the metrics/logs
-# collector above. Only when telemetry.tracesEndpoint is set. Turns on the
-# enhanced-telemetry tracing beta (the flag that makes Claude Code emit the
-# interaction/llm_request/tool/tool.execution/subagent span tree at all — plain
-# telemetry.enable exports only counters and log events, no spans). A
-# signal-specific TRACES endpoint is required: with only the generic
-# OTEL_EXPORTER_OTLP_ENDPOINT set, the CLI emits zero trace traffic.
+
+# ...and explicitly off when it is not set, so the SDK cannot fall back to its
+# conventional loopback default and export into nothing.
+//
+  lib.optionalAttrs
+    ((userConfig.telemetry.enable or false) && (userConfig.telemetry.otlpEndpoint or null) == null)
+    {
+      OTEL_METRICS_EXPORTER = "none";
+      OTEL_LOGS_EXPORTER = "none";
+    }
+
+# Trace spans → a signal-specific endpoint carrying the full /v1/traces path;
+# nothing is appended to it. Setting it also turns on the enhanced-telemetry
+# beta, which is the flag that makes Claude Code emit the
+# interaction/llm_request/tool/tool.execution/subagent span tree at all. With
+# only the generic endpoint set, the CLI emits zero trace traffic.
 //
   lib.optionalAttrs
     ((userConfig.telemetry.enable or false) && (userConfig.telemetry.tracesEndpoint or null) != null)
     {
       CLAUDE_CODE_ENHANCED_TELEMETRY_BETA = "1";
+      OTEL_TRACES_EXPORTER = "otlp";
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = userConfig.telemetry.tracesEndpoint;
       OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "http/protobuf";
+    }
+
+# ...and explicitly off otherwise, for the same reason as metrics and logs.
+//
+  lib.optionalAttrs
+    ((userConfig.telemetry.enable or false) && (userConfig.telemetry.tracesEndpoint or null) == null)
+    {
+      OTEL_TRACES_EXPORTER = "none";
     }

--- a/modules/maintainer-profile.nix
+++ b/modules/maintainer-profile.nix
@@ -21,11 +21,6 @@
 # and stays `mkDefault` so a consumer that injects `_module.args.userConfig`
 # directly (as nix-darwin does via extraSpecialArgs) takes precedence.
 { lib, config, ... }:
-let
-  # OTEL endpoint comes from the cross-repo registry so the port stays in one
-  # place (vars/ai-stack.nix nodeports.otel_grpc).
-  aiVars = import ../vars/ai-stack.nix;
-in
 {
   options.userConfig = lib.mkOption {
     type = lib.types.submodule {
@@ -86,14 +81,29 @@ in
             default = false;
             description = ''
               Emit Claude Code OpenTelemetry to `otlpEndpoint`. Off by default;
-              requires a reachable OTLP collector.
+              requires a reachable OTLP collector. Enabling this without also
+              setting `otlpEndpoint` emits nothing — see that option.
             '';
           };
 
           otlpEndpoint = lib.mkOption {
-            type = lib.types.str;
-            default = "http://localhost:${toString aiVars.nodeports.otel_grpc}";
-            description = "OTLP gRPC endpoint for Claude Code telemetry when enabled.";
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "https://otel.example.internal";
+            description = ''
+              OTLP/HTTP base URL for Claude Code metrics and logs. The OTLP spec
+              has the exporter append the signal path itself (`/v1/metrics`,
+              `/v1/logs`), so this is the BASE url with no `/v1/...` suffix —
+              unlike `tracesEndpoint`, which is signal-specific and must carry
+              the full path.
+
+              Null by default, and null means no OTLP export even when
+              `enable` is true. There is deliberately no fallback default: a
+              collector address is site-specific, and a wrong-but-plausible one
+              exports into a black hole that looks identical to working
+              telemetry. Kept out of the committed default for the same reason
+              as `tracesEndpoint` — no private hostname in a public config.
+            '';
           };
 
           tracesEndpoint = lib.mkOption {
@@ -104,10 +114,14 @@ in
               Optional OTLP/HTTP endpoint for Claude Code *trace spans* only. When
               set (alongside telemetry.enable), the enhanced-telemetry tracing beta
               is turned on and trace spans are exported here over http/protobuf,
-              while metrics and logs continue to otlpEndpoint. Leave null to keep
-              all signals on otlpEndpoint. Kept out of the committed default so no
-              private hostname is baked into a public config — set it in your own
-              user config.
+              while metrics and logs continue to otlpEndpoint. Unlike
+              otlpEndpoint this is a signal-specific endpoint, so it must carry
+              the full `/v1/traces` path — the exporter appends nothing. Leave
+              null to emit no spans at all: plain `enable` yields counters and
+              log events only, never the interaction/llm_request/tool/subagent
+              span tree. Kept out of the committed default so no private
+              hostname is baked into a public config — set it in your own user
+              config.
             '';
           };
         };

--- a/modules/maintainer-profile.nix
+++ b/modules/maintainer-profile.nix
@@ -106,6 +106,46 @@
             '';
           };
 
+          serviceName = lib.mkOption {
+            type = lib.types.str;
+            default = "claude-code";
+            description = ''
+              `service.name` on every exported signal. Identifies this emitter
+              in the backend against everything else writing to the same
+              collector.
+            '';
+          };
+
+          resourceAttributes = lib.mkOption {
+            type = lib.types.attrsOf lib.types.str;
+            default = { };
+            example = {
+              "host.name" = "workstation-01";
+            };
+            description = ''
+              Extra OTel resource attributes, rendered into
+              OTEL_RESOURCE_ATTRIBUTES. Use for the identity a backend needs to
+              tell one emitting host from another; a span without it is hard to
+              attribute once more than one machine reports.
+            '';
+          };
+
+          logUserPrompts = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Include full user prompt text in exported telemetry. Off by
+              default: this ships conversation content off the machine, so only
+              enable it against a collector whose whole path you control.
+            '';
+          };
+
+          logToolDetails = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Include MCP server and tool names in exported telemetry.";
+          };
+
           tracesEndpoint = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -101,12 +101,8 @@ in
               MLX_WORKER_PORT_COUNT = toString workerPortCount;
             }
             // lib.optionalAttrs (cfg.telemetry.enable && cfg.telemetry.otlpEndpoint != null) {
-              # Standard OTel env vars inherited by llama-swap and mlx_lm.server
-              # children. The collector fans out to the log platform and
-              # (optionally) to the eval platform — see
-              # docs/adr/0003-galileo-ai-observability.md. Gated on a non-null
-              # endpoint: there is no default, because the previous loopback
-              # default served nothing and exported into a black hole.
+              # OTel env inherited by llama-swap and mlx_lm.server children.
+              # Gated on a non-null endpoint — see options-server.nix.
               OTEL_SERVICE_NAME = "mlx-model-server";
               # Base URL only — the exporter appends the signal path itself.
               OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;

--- a/modules/mlx/launchd.nix
+++ b/modules/mlx/launchd.nix
@@ -100,13 +100,17 @@ in
               MLX_WORKER_PORT_RANGE_START = toString llamaSwapConfigAttrs.startPort;
               MLX_WORKER_PORT_COUNT = toString workerPortCount;
             }
-            // lib.optionalAttrs cfg.telemetry.enable {
-              # Standard OTel env vars inherited by llama-swap and mlx_lm.server children.
-              # The OTEL Collector at :30317 fans out to Cribl/Splunk and (optionally)
-              # to Galileo — see docs/adr/0003-galileo-ai-observability.md.
+            // lib.optionalAttrs (cfg.telemetry.enable && cfg.telemetry.otlpEndpoint != null) {
+              # Standard OTel env vars inherited by llama-swap and mlx_lm.server
+              # children. The collector fans out to the log platform and
+              # (optionally) to the eval platform — see
+              # docs/adr/0003-galileo-ai-observability.md. Gated on a non-null
+              # endpoint: there is no default, because the previous loopback
+              # default served nothing and exported into a black hole.
               OTEL_SERVICE_NAME = "mlx-model-server";
+              # Base URL only — the exporter appends the signal path itself.
               OTEL_EXPORTER_OTLP_ENDPOINT = cfg.telemetry.otlpEndpoint;
-              OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
+              OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
               OTEL_RESOURCE_ATTRIBUTES = "service.namespace=mlx,deployment.environment=homelab";
             };
             StandardOutPath = "${config.home.homeDirectory}/Library/Logs/mlx-model-server/server.log";

--- a/modules/mlx/options-server.nix
+++ b/modules/mlx/options-server.nix
@@ -5,9 +5,6 @@
 # default-model passthrough that ties this server to the ai-stack registry.
 #
 { config, lib, ... }:
-let
-  aiStackVars = import ../../vars/ai-stack.nix;
-in
 {
   options.programs.mlx = {
     enable = lib.mkEnableOption "MLX inference server";
@@ -54,11 +51,19 @@ in
       enable = lib.mkEnableOption "OpenTelemetry trace export from the MLX inference stack";
 
       otlpEndpoint = lib.mkOption {
-        type = lib.types.str;
-        default = "http://localhost:${toString aiStackVars.nodeports.otel_grpc}";
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "https://otel.example.internal";
         description = ''
-          gRPC OTLP endpoint for the OpenTelemetry Collector.
-          Matches the existing Claude Code telemetry pipeline endpoint.
+          OTLP/HTTP base URL for the OpenTelemetry Collector — no `/v1/...`
+          suffix, the exporter appends the signal path itself. Matches the
+          Claude Code telemetry pipeline endpoint
+          (userConfig.telemetry.otlpEndpoint).
+
+          Null by default, and null means no export even when `enable` is true.
+          No fallback default is provided on purpose: this previously defaulted
+          to a loopback port nothing served, so the agent exported into a black
+          hole indistinguishable from working telemetry.
         '';
       };
     };

--- a/vars/ai-stack.nix
+++ b/vars/ai-stack.nix
@@ -68,10 +68,15 @@
 
   # OrbStack NodePort allocations. Authoritative source for any consumer
   # that needs to know where a service listens.
+  #
+  # otel_grpc/otel_http were removed: they named loopback ports that no
+  # collector has ever served, and the telemetry options that defaulted to
+  # them exported into a black hole for as long as telemetry was enabled. A
+  # port entry here is a claim that something listens — do not add one for a
+  # service that is only planned. OTLP endpoints are site-specific and now
+  # come from userConfig.telemetry.otlpEndpoint / programs.mlx.telemetry.
   nodeports = {
     cribl_mcp = 30030;
-    otel_grpc = 30317;
-    otel_http = 30318;
     cribl_hec = 30088;
     cribl_stream_ui = 30900;
     cribl_edge_ui = 30910;


### PR DESCRIPTION
## Summary

Telemetry export uses OTLP over HTTP protobuf, and an endpoint is required
rather than defaulted.

## Changes

- `OTEL_EXPORTER_OTLP_PROTOCOL` is `http/protobuf` for the Claude Code and MLX
  emitters.
- `telemetry.otlpEndpoint` and `programs.mlx.telemetry.otlpEndpoint` are
  `nullOr str` defaulting to null. Null suppresses every OTEL variable, so a
  consumer supplies its own endpoint or exports nothing. Collector addresses
  are site-specific, so no default is carried here.
- Option docs state the endpoint-shape distinction: the generic endpoint is a
  base URL that the exporter appends the signal path to, while the traces
  endpoint is signal-specific and carries `/v1/traces` itself. Spans require
  both `tracesEndpoint` and the enhanced-telemetry beta flag.
- Remove the two OTLP entries from the port registry, which records ports that
  are served.
- Add `telemetry-otlp-wiring` regression checks covering the protocol, verbatim
  pass-through of both endpoints, the span opt-in, and that `enable` alone
  renders no OTEL variables.
- Add `docs/architecture/telemetry-coverage.md`: per-CLI OTLP support with a
  vendor source for each, so a tool with no wiring here is distinguishable from
  one with no upstream support.

## Test Plan

- `nix flake check` green.
- All 120 `x86_64-linux` checks evaluate clean; `nix flake check` skips them on
  darwin, so they were evaluated explicitly.
- The new checks were verified to fail as well as pass: substituting `grpc`
  trips the protocol assertion, and substituting an endpoint fallback trips the
  three no-endpoint assertions by name.
- `nix build .#darwinConfigurations.<host>.system` succeeds with this branch
  overridden in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability wiring and breaks implicit telemetry for configs that enabled telemetry without setting endpoints; behavior is safer but consumers must explicitly configure collectors.
> 
> **Overview**
> Fixes **silent OTLP export to nowhere** by removing loopback collector defaults and switching Claude Code and MLX to **OTLP/HTTP protobuf**. **`telemetry.otlpEndpoint`** and **`programs.mlx.telemetry.otlpEndpoint`** are now **`null` by default**; **`telemetry.enable` alone exports nothing** unless a consumer sets at least one endpoint.
> 
> Claude telemetry env wiring is **split per signal**: metrics/logs use a **base URL** (exporter appends `/v1/*`), spans need **`tracesEndpoint`** (full `/v1/traces`) plus the enhanced-telemetry beta, and unset signals get **`OTEL_*_EXPORTER=none`** so SDK loopback fallbacks cannot resume. Maintainer options gain **`serviceName`**, **`resourceAttributes`**, and opt-in prompt/tool logging.
> 
> **`vars/ai-stack.nix`** drops **`otel_grpc`/`otel_http`**; architecture docs add **`telemetry-coverage.md`** and refresh the integration map. **`telemetry-otlp-wiring`** regression checks and **`mkHmConfigWith`** keep the no-default behavior from regressing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e660c16dc6a0fb2a615f44558af249365ee4eb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->