### PR TITLE
docs(telemetry): state that MLX telemetry env emits nothing

### DIFF
--- a/docs/architecture/telemetry-coverage.md
+++ b/docs/architecture/telemetry-coverage.md
@@ -14,7 +14,12 @@ for the signal/endpoint shape.
 | Tool | Configured via | Signals |
 |---|---|---|
 | Claude Code | `userConfig.telemetry.{enable,otlpEndpoint,tracesEndpoint}` → `modules/claude/settings-env.nix` | metrics, logs, spans |
-| MLX model server | `programs.mlx.telemetry.{enable,otlpEndpoint}` → `modules/mlx/launchd.nix` | inherited by llama-swap and worker children |
+
+## Wired, but emits nothing
+
+| Tool | State |
+|---|---|
+| MLX model server | `programs.mlx.telemetry` sets the standard `OTEL_*` variables on the llama-swap LaunchAgent, inherited by the `mlx_lm.server` children. **No component in that chain is OpenTelemetry-instrumented**, so setting an endpoint produces no telemetry — verified by scanning the installed `mlx_lm` package and the `llama-swap` binary for any OpenTelemetry reference (none in either). The option is retained because the env is the right shape the moment either gains instrumentation, but do not read its presence as evidence that MLX is observable. |
 
 ## Supported upstream, not wired here
 

--- a/modules/mlx/options-server.nix
+++ b/modules/mlx/options-server.nix
@@ -64,6 +64,15 @@
           No fallback default is provided on purpose: this previously defaulted
           to a loopback port nothing served, so the agent exported into a black
           hole indistinguishable from working telemetry.
+
+          Setting this is currently NOT sufficient to get telemetry out of MLX.
+          These variables are inherited by llama-swap and the mlx_lm.server
+          children, but no component in that chain is OpenTelemetry-instrumented
+          — scanning the installed mlx_lm package and the llama-swap binary
+          finds no OpenTelemetry reference in either. The option is kept because
+          the environment is the right shape the moment either gains
+          instrumentation; until then, a configured endpoint here means nothing
+          is being emitted, not that emission is going somewhere.
         '';
       };
     };


### PR DESCRIPTION
## Summary

`programs.mlx.telemetry` sets the standard `OTEL_*` variables on the llama-swap
LaunchAgent, inherited by the `mlx_lm.server` children. No component in that
chain is OpenTelemetry-instrumented, so a configured endpoint produces no
telemetry.

## Evidence

Scanned the installed `mlx_lm` package and the `llama-swap` binary for any
OpenTelemetry reference. Zero in either.

## Changes

- The coverage table listed MLX alongside Claude Code under "supported and
  wired here". That invited the reading this repo's telemetry work set out to
  remove — configuration that looks complete standing in for evidence that
  something arrives. MLX now has its own category, "wired, but emits nothing".
- The option description says the same thing at the point someone would set it,
  so the correction is visible without reading the architecture docs.

The option is retained: the environment is the right shape the moment either
component gains instrumentation.

## Test Plan

- `nix flake check` green; `deadnix` and `statix` run directly, both clean.
- The `telemetry-otlp-wiring` and `mlx-options-regression` checks still
  evaluate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Nix option descriptions only; no runtime or telemetry wiring behavior changes.
> 
> **Overview**
> **MLX is no longer listed as fully wired telemetry.** The architecture doc moves it from “Supported and wired here” into a new **“Wired, but emits nothing”** section, explaining that `programs.mlx.telemetry` still sets standard `OTEL_*` on the llama-swap LaunchAgent (inherited by `mlx_lm.server` children), but neither `mlx_lm` nor `llama-swap` is OpenTelemetry-instrumented—so a configured endpoint does not produce signals.
> 
> The **`programs.mlx.telemetry.otlpEndpoint`** option text now repeats that warning at configuration time: setting an endpoint is **not** enough for observable MLX telemetry until upstream gains instrumentation. The options and env wiring are **kept** so they are ready when that happens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d579cfcb8e7f10316e913fe8a4de7f7481ba2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->