### PR TITLE
Declare Qwen3.6 64k context window

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -94,6 +94,11 @@ let
             roles = [ "goal-judge" ];
           };
           qwen36-optiq.class = "resident";
+          # Stock Qwen3.6 sibling, swap-class: enabled so the compiled
+          # modelContextWindows carries its declared 65536 window for
+          # mlx-catalog.nix to assert. Resident would push the fixture past
+          # residentWeightBudgetGb for no added coverage.
+          qwen36-35b.class = "swap";
           qwen3-coder-30b.class = "resident";
           gpt-oss-120b.class = "swap";
           qwen3-next-80b = {

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -78,8 +78,11 @@ in
       c.modelContextWindows.${judge27b} == 131072
       || throw "catalog: Qwen3.8 must compile its 131072-token production window";
     assert
+      c.modelFlagOverrides.${judge27b}.maxRequestTokens == 131072
+      || throw "catalog: Qwen3.8 must admit its declared 131072-token production window";
+    assert
       c.modelContextWindows.${qwen36} == 65536
-      || throw "catalog: Qwen3.6 must advertise its 65536-token resident window";
+      || throw "catalog: Qwen3.6 must advertise its 65536-token declared window";
     assert
       c.modelServerBackend == "mlx-lm"
       || throw "catalog: the goal judge must use the selected mlx_lm.server deployment path";

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -77,6 +77,9 @@ in
       c.modelContextWindows.${judge27b} == 131072
       || throw "catalog: Qwen3.8 must compile its 131072-token production window";
     assert
+      c.modelContextWindows.${qwen36} == 65536
+      || throw "catalog: Qwen3.6 must advertise its 65536-token resident window";
+    assert
       c.modelFlagOverrides.${judge27b}.maxRequestTokens == 131072
       || throw "catalog: Qwen3.8 must admit its declared 131072-token production window";
     assert

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -81,12 +81,6 @@ in
       c.modelContextWindows.${qwen36} == 65536
       || throw "catalog: Qwen3.6 must advertise its 65536-token resident window";
     assert
-      c.modelFlagOverrides.${judge27b}.maxRequestTokens == 131072
-      || throw "catalog: Qwen3.8 must admit its declared 131072-token production window";
-    assert
-      builtins.match ".*--max-tokens 131072.*" judgeCmd != null
-      || throw "catalog: Qwen3.8 worker limit must follow its declared admission limit";
-    assert
       c.modelServerBackend == "mlx-lm"
       || throw "catalog: the goal judge must use the selected mlx_lm.server deployment path";
     assert

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -80,6 +80,9 @@ in
       c.modelFlagOverrides.${judge27b}.maxRequestTokens == 131072
       || throw "catalog: Qwen3.8 must admit its declared 131072-token production window";
     assert
+      builtins.match ".*--max-tokens 131072.*" judgeCmd != null
+      || throw "catalog: Qwen3.8 worker limit must follow its declared admission limit";
+    assert
       c.modelServerBackend == "mlx-lm"
       || throw "catalog: the goal judge must use the selected mlx_lm.server deployment path";
     assert

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -16,6 +16,7 @@ in
       gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8";
       next80 = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
       next80Instruct = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
+      qwen36 = "mlx-community/Qwen3.6-35B-A3B-4bit";
       judge27b = "mlx-community/Qwen3.8-27B-4bit";
       optiqFlags = c.modelFlagOverrides.${optiq};
       judgeArgs = builtins.concatStringsSep " " c.modelExtraArgs.${judge27b};

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -167,10 +167,6 @@ in
   qwen36-35b = {
     model = "mlx-community/Qwen3.6-35B-A3B-4bit";
     weightGb = 19.4;
-    # The checkpoint supports 262144 positions, but this resident profile is
-    # deliberately admitted and served at 65536.  Keep the advertised window
-    # aligned with its worker request cap so campaign inventory does not
-    # schedule a cell the live worker will reject.
     contextWindowTokens = 65536;
     args = [
       "--chat-template-args"

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -167,6 +167,11 @@ in
   qwen36-35b = {
     model = "mlx-community/Qwen3.6-35B-A3B-4bit";
     weightGb = 19.4;
+    # The checkpoint supports 262144 positions, but this resident profile is
+    # deliberately admitted and served at 65536.  Keep the advertised window
+    # aligned with its worker request cap so campaign inventory does not
+    # schedule a cell the live worker will reject.
+    contextWindowTokens = 65536;
     args = [
       "--chat-template-args"
       (builtins.toJSON {

--- a/modules/mlx/model-server-cmd.nix
+++ b/modules/mlx/model-server-cmd.nix
@@ -70,7 +70,13 @@ rec {
           cfg // overrides
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
-      effectiveMlxLmMaxTokens = if c.maxTokens == null then 8192 else c.maxTokens;
+      effectiveMlxLmMaxTokens =
+        if c.maxTokens != null then
+          c.maxTokens
+        else if c.maxRequestTokens != null then
+          c.maxRequestTokens
+        else
+          8192;
       # Honor the configured prompt-cache budget up to 16 GiB. The prior 8 GiB
       # clamp silently capped catalog entries that ask for more (e.g. the
       # large-context resident class at cacheMemoryMb = 16384), making the

--- a/modules/mlx/model-server-cmd.nix
+++ b/modules/mlx/model-server-cmd.nix
@@ -70,13 +70,7 @@ rec {
           cfg // overrides
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
-      effectiveMlxLmMaxTokens =
-        if c.maxTokens != null then
-          c.maxTokens
-        else if c.maxRequestTokens != null then
-          c.maxRequestTokens
-        else
-          8192;
+      effectiveMlxLmMaxTokens = if c.maxTokens == null then 8192 else c.maxTokens;
       # Honor the configured prompt-cache budget up to 16 GiB. The prior 8 GiB
       # clamp silently capped catalog entries that ask for more (e.g. the
       # large-context resident class at cacheMemoryMb = 16384), making the


### PR DESCRIPTION
Declares the Qwen3.6 resident profile's configured 64k context window and covers it in catalog evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog metadata and CI assertions only; no runtime serving-path or auth changes.
> 
> **Overview**
> Adds an explicit **65536-token** `contextWindowTokens` declaration on the stock **qwen36-35b** catalog entry (`mlx-community/Qwen3.6-35B-A3B-4bit`), aligning the compiled `modelContextWindows` surface with the resident profile’s existing **65536** `maxRequestTokens` caps.
> 
> The **mlx-catalog** regression check now asserts that window for the stock Qwen3.6 model id. The catalog fixture enables **qwen36-35b** as **swap** (not resident) so that value is compiled without exceeding the fixture’s resident weight budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0ad1d38dbd85a39fd9d169e92e89aca60ea2f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->