### PR TITLE
fix(mlx): correct derive.nix concurrency semantics, backfill kv

### DIFF
--- a/modules/mlx/catalog-data-qwen35-9b.nix
+++ b/modules/mlx/catalog-data-qwen35-9b.nix
@@ -1,0 +1,100 @@
+# qwen35-9b-optiq + qwen35-9b-mlx — split out of catalog-data.nix for the
+# per-file 12KB gate (same split-rather-than-exempt pattern as
+# catalog-data-80b-instruct.nix and catalog-data-qwen38-27b.nix: split the
+# entry, never trim the evidence). Merged into the same catalog attrset by
+# catalog-data.nix; see that file for the entry schema and catalog-lib.nix
+# for the shared serve-arg helpers.
+let
+  inherit (import ./catalog-lib.nix) swapFlags;
+in
+{
+  # Small resident auxiliary model for bounded classification and judging.
+  # OptiQ keeps tool/reasoning compatibility with the Qwen family while the
+  # 4-bit footprint permits it to stay warm beside the primary 80B brain.
+  # #1641: batched decode leaks Metal buffers on this family — swapFlags'
+  # maxNumSeqs=2 keeps it narrow; do not raise it.
+  qwen35-9b-optiq = {
+    model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
+    weightGb = 7.7;
+    # qwen3_5_text HYBRID, same family as qwen38-27b: 32 layers,
+    # full_attention_interval 4 -> 8 full-attention layers carry paged KV, the
+    # other 24 linear-attention layers carry none.
+    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
+    # against the model's own config.json (2026-08-27).
+    kv = {
+      kvLayers = 8;
+      kvHeads = 4;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
+    # The model card's Hermes recipe serves this text quant with mlx_lm.server.
+    # Keep it off the multimodal-aware vllm-mlx loader.
+    args = [
+      "--chat-template-args"
+      (builtins.toJSON {
+        enable_thinking = false;
+      })
+    ];
+    concurrencyLimit = 1;
+    classes = {
+      # No host currently selects this class for this entry (grepped
+      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
+      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
+      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
+      # so it is safe to derive rather than leave silently defaulted:
+      # concurrency=1 matches the entry's own concurrencyLimit=1 above
+      # (#1641 caution — do not raise either without re-testing).
+      resident.cacheProvisioning.concurrency = 1;
+      swap.flags = swapFlags;
+    };
+  };
+
+  # Small on-demand summarizer. An hourly note-capture pipe requests
+  # this exact physical id ("mlx-community/Qwen3.5-9B-MLX-4bit"); registering it
+  # swap-class (no roles -> compiles to a llama-swap models.<id> entry keyed by
+  # the physical id) lets that request route without evicting a resident.
+  #
+  # WEIGHTS MUST BE PRE-CACHED under HF_HOME. This comment used to promise they
+  # "fetch from HuggingFace on first load if not already cached" — a promise the
+  # runtime forbids: modules/mlx/worker-env.nix sets HF_HUB_OFFLINE=1, so a
+  # first load of an uncached id raises OfflineModeIsEnabled and the request
+  # 502s after minutes of retrying rather than failing fast. Registering an id
+  # here while a different quant variant is the only one cached on disk means
+  # every call to it 502s with nothing reporting why. Registration makes an id
+  # SERVABLE, never CACHED.
+  # `hf download <id>` (or the prefetch agent) is the step that caches it.
+  # #1641 (same family as qwen35-9b-optiq): maxNumSeqs low, see its comment.
+  qwen35-9b-mlx = {
+    model = "mlx-community/Qwen3.5-9B-MLX-4bit";
+    weightGb = 5.2;
+    # Same qwen3_5_text HYBRID geometry as qwen35-9b-optiq above: 32 layers,
+    # 8 full-attention (full_attention_interval 4) carry paged KV.
+    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
+    # against the model's own config.json (2026-08-27).
+    kv = {
+      kvLayers = 8;
+      kvHeads = 4;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
+    # Text quant served through mlx_lm.server; keep off the vllm-mlx loader.
+    args = [
+      "--chat-template-args"
+      (builtins.toJSON {
+        enable_thinking = false;
+      })
+    ];
+    concurrencyLimit = 1;
+    classes = {
+      # No host currently selects this class for this entry (grepped
+      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
+      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
+      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
+      # so it is safe to derive rather than leave silently defaulted:
+      # concurrency=1 matches the entry's own concurrencyLimit=1 above
+      # (#1641 caution — do not raise either without re-testing).
+      resident.cacheProvisioning.concurrency = 1;
+      swap.flags = swapFlags;
+    };
+  };
+}

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -81,10 +81,27 @@ in
       # The 128k catalog window must also be admitted by the serving worker;
       # a lower request cap would turn the declared default into a client-only
       # hint and force long-context callers to fail before model dispatch.
-      resident.flags = block512 // {
-        cacheMemoryMb = 16384;
-        maxNumSeqs = 8;
-        maxRequestTokens = 131072;
+      #
+      # maxNumSeqs/maxRequestTokens are declared for the vllm-mlx backend this
+      # entry does not currently run on (mlx-lm is the deployed backend
+      # fleet-wide; see lib/checks/mlx-catalog.nix). model-server-cmd.nix's
+      # mlxLmFlags never reads them, so they are inert today. Left declared
+      # rather than removed: they are the correct values IF vllm-mlx is
+      # re-enabled, and removing them would silently lose that intent.
+      #
+      # cacheMemoryMb is DERIVED, not stated: cacheProvisioning.concurrency=1
+      # means "guarantee ONE genuinely-simultaneous full-window (128k) stream
+      # stays cached, plus a second slot for an alternating conversation" —
+      # derive.nix's promptCacheSlotsPerStream=2 calibration already encodes
+      # that second-slot rationale. Verified exact: at this host's
+      # memoryHardLimitGb this reproduces 16384 (the prior literal) precisely,
+      # with headroom to spare — see options-catalog.nix's derivedCacheMb.
+      resident = {
+        cacheProvisioning.concurrency = 1;
+        flags = block512 // {
+          maxNumSeqs = 8;
+          maxRequestTokens = 131072;
+        };
       };
       swap.flags =
         block256

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -51,6 +51,17 @@ in
   qwen38-27b = {
     model = "mlx-community/Qwen3.8-27B-4bit";
     weightGb = 16.1;
+    # qwen3_5_text HYBRID: 64 layers, 16 full_attention / 48 linear_attention
+    # (already stated above — full_attention_interval 4). Only the 16
+    # full-attention layers carry paged KV; the 48 linear layers carry none.
+    # perTokenKvBytes = 2*16*4*256*2 = 65536 B/token (64 KiB/token). Verified
+    # against the model's own config.json (2026-08-27).
+    kv = {
+      kvLayers = 16;
+      kvHeads = 4;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
     # The model supports a native 262,144-token window. Production roles use
     # 131,072 so the remaining range is available for separately managed 200K
     # feasibility work rather than silently becoming a fleet default.

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -3,10 +3,10 @@
 # (parser stacks, timeout, paged-block sizes, swap tier) are documented in
 # catalog-lib.nix; this file is split out to keep each under the 12KB gate.
 # See catalog-lib.nix for the #1334 KV-quant/MTP flag-availability note.
-# qwen3-next-80b-instruct and qwen38-27b live in their own files, merged
-# below, for the same size-gate reason. Both carry long measurement notes,
-# which is exactly what pushed this file over the gate — split the entry,
-# never trim the evidence.
+# qwen3-next-80b-instruct, qwen38-27b, and the qwen35-9b pair live in their
+# own files, merged below, for the same size-gate reason. Each carries long
+# measurement notes, which is exactly what pushed this file over the gate —
+# split the entry, never trim the evidence.
 let
   inherit (import ./catalog-lib.nix)
     block256
@@ -17,6 +17,7 @@ let
 in
 (import ./catalog-data-80b-instruct.nix)
 // (import ./catalog-data-qwen38-27b.nix)
+// (import ./catalog-data-qwen35-9b.nix)
 // {
   # Document OCR, on demand. The only non-text entry in the catalog: an
   # SAM + CLIP-L + DeepSeek-V2 vision-language model, so it CANNOT run on the
@@ -51,95 +52,8 @@ in
     };
   };
 
-  # Small resident auxiliary model for bounded classification and judging.
-  # OptiQ keeps tool/reasoning compatibility with the Qwen family while the
-  # 4-bit footprint permits it to stay warm beside the primary 80B brain.
-  # #1641: batched decode leaks Metal buffers on this family — swapFlags'
-  # maxNumSeqs=2 keeps it narrow; do not raise it.
-  qwen35-9b-optiq = {
-    model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
-    weightGb = 7.7;
-    # qwen3_5_text HYBRID, same family as qwen38-27b: 32 layers,
-    # full_attention_interval 4 -> 8 full-attention layers carry paged KV, the
-    # other 24 linear-attention layers carry none.
-    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
-    # against the model's own config.json (2026-08-27).
-    kv = {
-      kvLayers = 8;
-      kvHeads = 4;
-      headDim = 256;
-      kvDtypeBytes = 2;
-    };
-    # The model card's Hermes recipe serves this text quant with mlx_lm.server.
-    # Keep it off the multimodal-aware vllm-mlx loader.
-    args = [
-      "--chat-template-args"
-      (builtins.toJSON {
-        enable_thinking = false;
-      })
-    ];
-    concurrencyLimit = 1;
-    classes = {
-      # No host currently selects this class for this entry (grepped
-      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
-      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
-      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
-      # so it is safe to derive rather than leave silently defaulted:
-      # concurrency=1 matches the entry's own concurrencyLimit=1 above
-      # (#1641 caution — do not raise either without re-testing).
-      resident.cacheProvisioning.concurrency = 1;
-      swap.flags = swapFlags;
-    };
-  };
-
-  # Small on-demand summarizer. An hourly note-capture pipe requests
-  # this exact physical id ("mlx-community/Qwen3.5-9B-MLX-4bit"); registering it
-  # swap-class (no roles -> compiles to a llama-swap models.<id> entry keyed by
-  # the physical id) lets that request route without evicting a resident.
-  #
-  # WEIGHTS MUST BE PRE-CACHED under HF_HOME. This comment used to promise they
-  # "fetch from HuggingFace on first load if not already cached" — a promise the
-  # runtime forbids: modules/mlx/worker-env.nix sets HF_HUB_OFFLINE=1, so a
-  # first load of an uncached id raises OfflineModeIsEnabled and the request
-  # 502s after minutes of retrying rather than failing fast. Registering an id
-  # here while a different quant variant is the only one cached on disk means
-  # every call to it 502s with nothing reporting why. Registration makes an id
-  # SERVABLE, never CACHED.
-  # `hf download <id>` (or the prefetch agent) is the step that caches it.
-  # #1641 (same family as qwen35-9b-optiq): maxNumSeqs low, see its comment.
-  qwen35-9b-mlx = {
-    model = "mlx-community/Qwen3.5-9B-MLX-4bit";
-    weightGb = 5.2;
-    # Same qwen3_5_text HYBRID geometry as qwen35-9b-optiq above: 32 layers,
-    # 8 full-attention (full_attention_interval 4) carry paged KV.
-    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
-    # against the model's own config.json (2026-08-27).
-    kv = {
-      kvLayers = 8;
-      kvHeads = 4;
-      headDim = 256;
-      kvDtypeBytes = 2;
-    };
-    # Text quant served through mlx_lm.server; keep off the vllm-mlx loader.
-    args = [
-      "--chat-template-args"
-      (builtins.toJSON {
-        enable_thinking = false;
-      })
-    ];
-    concurrencyLimit = 1;
-    classes = {
-      # No host currently selects this class for this entry (grepped
-      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
-      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
-      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
-      # so it is safe to derive rather than leave silently defaulted:
-      # concurrency=1 matches the entry's own concurrencyLimit=1 above
-      # (#1641 caution — do not raise either without re-testing).
-      resident.cacheProvisioning.concurrency = 1;
-      swap.flags = swapFlags;
-    };
-  };
+  # qwen35-9b-optiq and qwen35-9b-mlx moved to catalog-data-qwen35-9b.nix
+  # (12KB gate); merged into this attrset at the top of the file.
 
   # Agentic tool-calling brain (2026-07-08 bench winner; verdicts in
   # HF JacobPEvans/mlx-benchmarks). Thinking ON is part of the verdict.

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -59,6 +59,17 @@ in
   qwen35-9b-optiq = {
     model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
     weightGb = 7.7;
+    # qwen3_5_text HYBRID, same family as qwen38-27b: 32 layers,
+    # full_attention_interval 4 -> 8 full-attention layers carry paged KV, the
+    # other 24 linear-attention layers carry none.
+    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
+    # against the model's own config.json (2026-08-27).
+    kv = {
+      kvLayers = 8;
+      kvHeads = 4;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
     # The model card's Hermes recipe serves this text quant with mlx_lm.server.
     # Keep it off the multimodal-aware vllm-mlx loader.
     args = [
@@ -92,6 +103,16 @@ in
   qwen35-9b-mlx = {
     model = "mlx-community/Qwen3.5-9B-MLX-4bit";
     weightGb = 5.2;
+    # Same qwen3_5_text HYBRID geometry as qwen35-9b-optiq above: 32 layers,
+    # 8 full-attention (full_attention_interval 4) carry paged KV.
+    # perTokenKvBytes = 2*8*4*256*2 = 32768 B/token (32 KiB/token). Verified
+    # against the model's own config.json (2026-08-27).
+    kv = {
+      kvLayers = 8;
+      kvHeads = 4;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
     # Text quant served through mlx_lm.server; keep off the vllm-mlx loader.
     args = [
       "--chat-template-args"

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -80,7 +80,14 @@ in
     ];
     concurrencyLimit = 1;
     classes = {
-      resident.flags = { };
+      # No host currently selects this class for this entry (grepped
+      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
+      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
+      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
+      # so it is safe to derive rather than leave silently defaulted:
+      # concurrency=1 matches the entry's own concurrencyLimit=1 above
+      # (#1641 caution — do not raise either without re-testing).
+      resident.cacheProvisioning.concurrency = 1;
       swap.flags = swapFlags;
     };
   };
@@ -122,7 +129,14 @@ in
     ];
     concurrencyLimit = 1;
     classes = {
-      resident.flags = { };
+      # No host currently selects this class for this entry (grepped
+      # nix-darwin: absent entirely for qwen35-9b-optiq, swap-only for
+      # qwen35-9b-mlx) — offered so a future host CAN run either resident,
+      # but dead today. Wiring cacheMemoryMb here changes no live behavior,
+      # so it is safe to derive rather than leave silently defaulted:
+      # concurrency=1 matches the entry's own concurrencyLimit=1 above
+      # (#1641 caution — do not raise either without re-testing).
+      resident.cacheProvisioning.concurrency = 1;
       swap.flags = swapFlags;
     };
   };

--- a/modules/mlx/derive.nix
+++ b/modules/mlx/derive.nix
@@ -1,71 +1,56 @@
 # MLX Module — the serving-limit derivation
 #
-# Every memory, concurrency, and cache limit the model servers run with is
-# computed HERE, from a small set of inputs, and nowhere else. Before this file
-# those values were literals spread across catalog entries, catalog-lib profiles
-# and options-proxy, each hand-calculated once and then hand-synced forever —
-# a shape that had already drifted (see the three notes below).
+# Every memory/buffer limit a model server runs with is computed HERE from a
+# small input set, not hand-set at a call site. Before this file the values
+# were literals in catalog entries, catalog-lib, and options-proxy, hand-
+# calculated once and hand-synced forever — already drifted (below).
 #
-# The contract, and the reason to reach for this file rather than edit a number:
+#   INPUT       a hardware/model fact or deliberate choice. Written once.
+#   CALIBRATION an empirical coefficient, not derivable from first
+#               principles. Named, isolated, TUNED HERE when reality
+#               disagrees — never worked around at a call site.
+#   DERIVED     computed below, never hand-set/overridden. Wrong output ->
+#               fix an input or calibration constant, not a call-site literal.
 #
-#   INPUT      a fact about hardware or a model, or a deliberate choice.
-#              Written once, in one place.
-#   CALIBRATION an empirical coefficient that cannot be derived from first
-#              principles. Named, isolated, and TUNED HERE when reality
-#              disagrees — never worked around at a call site.
-#   DERIVED    computed below. Never hand-set, never overridden. If a derived
-#              value is wrong, the fix is an input or a calibration constant,
-#              because a literal at the call site is how this rotted last time.
-#
-# WHAT WAS WRONG BEFORE (2026-08-27), kept here because each is a live trap:
+# WHAT WAS WRONG BEFORE (2026-08-27), each a live trap:
 #
 #   1. catalog-lib.nix documents
 #        perTokenKvBytes = 2 * kvLayers * kvHeads * headDim * kvDtypeBytes
-#      and the `kv` schema that feeds it — but the formula was never executed in
-#      Nix. Every occurrence of perTokenKvBytes was a hand-evaluated result
-#      pasted into a COMMENT. This file is the first code that computes it.
+#      but never executed it — every occurrence was hand-evaluated into a
+#      COMMENT. This file is the first code that computes it.
 #
-#   2. options-proxy.nix derived concurrencyLimitCeiling from four constants
-#      that restate the catalog instead of reading it: peakWeightGiB = 31,
-#      kvPerTokenDenseKiB = 64, maxGrantedRequestTokens = 65536. That last one
-#      is the sharpest trap — raise a model's window and the ceiling meant to
-#      protect memory keeps computing against the old number, with nothing
-#      detecting the drift.
+#   2. options-proxy.nix's concurrencyLimitCeiling restated the catalog
+#      instead of reading it (peakWeightGiB=31, kvPerTokenDenseKiB=64,
+#      maxGrantedRequestTokens=65536). The last one is sharpest: raise a
+#      window and the memory ceiling keeps computing against the old number.
 #
-#   3. options-residency.nix states the invariant
+#   3. options-residency.nix states
 #        maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
-#      in prose. THIS FILE DOES NOT OWN THAT DERIVATION — nix-darwin's
+#      in prose. NOT THIS FILE'S DERIVATION — nix-darwin's
 #      hosts/common/residency-budget.nix already computes memoryHardLimitGb
-#      from the host's appleSiliconTunables.wiredLimitMb sysctl and k_max, in
-#      the same evaluation closure that reads the sysctl. That value is a
-#      taken-as-given INPUT here (see forModel's budgetGb), never re-derived.
+#      from appleSiliconTunables.wiredLimitMb + k_max, same closure as the
+#      sysctl read. Taken as a given INPUT here (forModel's budgetGb).
 #
-# WHAT THIS FILE DOES NOT OWN (found while wiring it in, 2026-08-28):
+# WHAT THIS FILE DOES NOT OWN (found wiring it in, 2026-08-28): `maxNumSeqs`
+# (engine batch-admission width) and `proxy.concurrencyLimit`/
+# `serveConcurrency` (llama-swap's admission cap) are NOT `concurrency`
+# below — an earlier version conflated them. Proof: today's real qwen38-27b
+# values (maxNumSeqs=8, window=131072, weightGb=16.1) demand ~80 GiB in the
+# old KV formula against a 48 GiB budget, yet this config runs fine today at
+# cacheMemoryMb=16384. maxNumSeqs is a throughput ceiling the runtime paged-
+# cache admission check enforces AT CALL TIME (docs/local-llm/memory-
+# ceilings.mdx "load-time admission control"), not a promise of pre-reserved
+# capacity for that many simultaneous streams. Admission width already has a
+# single source: the ADR at d/decisions/llm-serving-concurrency-single-source
+# (docs-starlight) plus the catalog's per-entry `concurrencyLimit`. This file
+# sets neither — only sizing for a stated provisioning target (see
+# `concurrency` on forModel).
 #
-#   `maxNumSeqs` (the engine's decode/prompt BATCH-ADMISSION width) and
-#   `proxy.concurrencyLimit` / `serveConcurrency` (llama-swap's in-flight
-#   admission cap) are NOT the same thing as `concurrency` below, and an
-#   earlier version of this file conflated them. Proof: plugging today's real
-#   qwen38-27b values (maxNumSeqs=8, window=131072, weightGb=16.1) into
-#   forModel's KV formula demands ~80 GiB against a 48 GiB per-worker budget
-#   — yet that exact config runs today with cacheMemoryMb=16384 (16 GiB) and
-#   does not fall over. maxNumSeqs is a throughput ceiling the runtime paged-
-#   cache admission check enforces AT CALL TIME (see docs/local-llm/memory-
-#   ceilings.mdx "load-time admission control") — it does not promise that
-#   many simultaneous full-window streams get pre-reserved capacity. The
-#   admission-width number already has a single source: the ADR at
-#   d/decisions/llm-serving-concurrency-single-source (docs-starlight) plus
-#   the per-entry `concurrencyLimit` field already in the catalog. This file
-#   does not set, read, or derive `maxNumSeqs`/`concurrencyLimit` — only
-#   memory and buffer sizing for a stated provisioning target (see
-#   `concurrency`'s definition on forModel below).
-#
-# ON THE NUMBERS: the calibration constants below are seeded from single
-# observations on one host under uncontrolled load, not controlled benchmarks.
-# They are directional, and they are expected to be wrong at the edges. That is
-# precisely why they are isolated and labelled — tuning one of them is the
-# supported way to respond to a measurement, and the reason none of their
-# consequences are written down as literals anywhere else.
+# ON THE NUMBERS: calibration constants are seeded from single observations
+# on one host under uncontrolled load, not controlled benchmarks — directional
+# and expected wrong at the edges. That is why they are isolated and named:
+# tuning one is the supported response to a measurement, and the reason none
+# of their consequences are literals anywhere else.
 { lib }:
 let
   # ---- PLATFORM FACTS ------------------------------------------------------
@@ -80,30 +65,27 @@ let
   # Empirical. Tune HERE against measurement; never compensate at a call site.
 
   calibration = {
-    # Metal buffers held per paged KV block per KV-bearing layer. Cannot be
-    # derived from first principles — it depends on MLX allocator internals.
+    # Metal buffers held per paged KV block per KV-bearing layer. Depends on
+    # MLX allocator internals, not derivable from first principles.
     #
-    # SEEDED AT 1 AND DELIBERATELY UNCALIBRATED. The obvious anchor was
-    # catalog-lib's "~98K buffers at maxNumSeqs 8 x 65K window", but that
-    # figure is not yet trustworthy: catalog-data.nix records
-    # perTokenKvBytes = 98304 B/token for an unrelated model, and two distinct
-    # quantities carrying the same number is exactly how a hand-copied constant
-    # loses its units. Calibrate this against a real buffer-exhaustion run
-    # before treating headroom reported here as meaningful.
+    # SEEDED AT 1, DELIBERATELY UNCALIBRATED: no real buffer-exhaustion run
+    # exists to fit it to yet (catalog-lib's "~98K buffers at maxNumSeqs 8 x
+    # 65K window" and catalog-data.nix's unrelated-model
+    # perTokenKvBytes=98304 B/token were checked 2026-08-28 and are
+    # legitimately different quantities, not a units collision — but neither
+    # is a calibration measurement). Fit to a real run before trusting the
+    # headroom this reports.
     bufferPerBlockPerLayer = 1;
 
-    # Prompt-cache slots per in-flight stream. Each concurrent stream needs at
-    # least its own slot or streams evict each other between turns; the
-    # measured cost of getting this wrong was large (model-server-cmd.nix
-    # records 0.22s warm vs 8.34s cold at 7k tokens with a single shared slot,
-    # and re-prefill cost scales with context, so a long-context stream pays
-    # far more). 2 gives each stream its slot plus one for an alternating
-    # conversation rather than sizing exactly to concurrency.
+    # Prompt-cache slots per in-flight stream — each needs its own or streams
+    # evict each other between turns (model-server-cmd.nix: 0.22s warm vs
+    # 8.34s cold at 7k tokens, single shared slot; re-prefill cost scales with
+    # context). 2 = own slot plus one for an alternating conversation.
     promptCacheSlotsPerStream = 2;
 
-    # Fraction of a budget that may be committed, leaving room for the
-    # allocator's own overhead and fragmentation. Applies to both the per-worker
-    # memory budget and the Metal buffer ceiling.
+    # Committable fraction of a budget, leaving allocator overhead/
+    # fragmentation headroom. Applies to the per-worker memory budget and the
+    # Metal buffer ceiling alike.
     safetyFraction = 90; # percent
 
     # Practical decode concurrency on a single Apple GPU. Throughput collapses

--- a/modules/mlx/derive.nix
+++ b/modules/mlx/derive.nix
@@ -1,0 +1,285 @@
+# MLX Module — the serving-limit derivation
+#
+# Every memory, concurrency, and cache limit the model servers run with is
+# computed HERE, from a small set of inputs, and nowhere else. Before this file
+# those values were literals spread across catalog entries, catalog-lib profiles
+# and options-proxy, each hand-calculated once and then hand-synced forever —
+# a shape that had already drifted (see the three notes below).
+#
+# The contract, and the reason to reach for this file rather than edit a number:
+#
+#   INPUT      a fact about hardware or a model, or a deliberate choice.
+#              Written once, in one place.
+#   CALIBRATION an empirical coefficient that cannot be derived from first
+#              principles. Named, isolated, and TUNED HERE when reality
+#              disagrees — never worked around at a call site.
+#   DERIVED    computed below. Never hand-set, never overridden. If a derived
+#              value is wrong, the fix is an input or a calibration constant,
+#              because a literal at the call site is how this rotted last time.
+#
+# WHAT WAS WRONG BEFORE (2026-08-27), kept here because each is a live trap:
+#
+#   1. catalog-lib.nix documents
+#        perTokenKvBytes = 2 * kvLayers * kvHeads * headDim * kvDtypeBytes
+#      and the `kv` schema that feeds it — but the formula was never executed in
+#      Nix. Every occurrence of perTokenKvBytes was a hand-evaluated result
+#      pasted into a COMMENT. This file is the first code that computes it.
+#
+#   2. options-proxy.nix derived concurrencyLimitCeiling from four constants
+#      that restate the catalog instead of reading it: peakWeightGiB = 31,
+#      kvPerTokenDenseKiB = 64, maxGrantedRequestTokens = 65536. That last one
+#      is the sharpest trap — raise a model's window and the ceiling meant to
+#      protect memory keeps computing against the old number, with nothing
+#      detecting the drift.
+#
+#   3. options-residency.nix states the invariant
+#        maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
+#      in prose, warns that "2 workers at the default 99 GiB permits 198 GiB
+#      against a 100 GiB ceiling, which over-commits it", and then leaves both
+#      numbers to be set by hand. Co-residency therefore silently over-commits
+#      unless a human remembers to lower the other number. Here it cannot:
+#      memoryHardLimitGb is derived FROM the ceiling and k_max.
+#
+# ON THE NUMBERS: the calibration constants below are seeded from single
+# observations on one host under uncontrolled load, not controlled benchmarks.
+# They are directional, and they are expected to be wrong at the edges. That is
+# precisely why they are isolated and labelled — tuning one of them is the
+# supported way to respond to a measurement, and the reason none of their
+# consequences are written down as literals anywhere else.
+{ lib }:
+let
+  # ---- PLATFORM FACTS ------------------------------------------------------
+
+  # MLX's Metal buffer-count ceiling. Exceeding it raises
+  # "Resource limit (499000) exceeded" — a BUFFER-COUNT failure, not a byte
+  # OOM, which is why it is reachable at low memory use and why the lever
+  # against it is block size rather than a smaller budget (nix-darwin#1609).
+  metalBufferCeiling = 499000;
+
+  # ---- CALIBRATION ---------------------------------------------------------
+  # Empirical. Tune HERE against measurement; never compensate at a call site.
+
+  calibration = {
+    # Metal buffers held per paged KV block per KV-bearing layer. Cannot be
+    # derived from first principles — it depends on MLX allocator internals.
+    #
+    # SEEDED AT 1 AND DELIBERATELY UNCALIBRATED. The obvious anchor was
+    # catalog-lib's "~98K buffers at maxNumSeqs 8 x 65K window", but that
+    # figure is not yet trustworthy: catalog-data.nix records
+    # perTokenKvBytes = 98304 B/token for an unrelated model, and two distinct
+    # quantities carrying the same number is exactly how a hand-copied constant
+    # loses its units. Calibrate this against a real buffer-exhaustion run
+    # before treating headroom reported here as meaningful.
+    bufferPerBlockPerLayer = 1;
+
+    # Prompt-cache slots per in-flight stream. Each concurrent stream needs at
+    # least its own slot or streams evict each other between turns; the
+    # measured cost of getting this wrong was large (model-server-cmd.nix
+    # records 0.22s warm vs 8.34s cold at 7k tokens with a single shared slot,
+    # and re-prefill cost scales with context, so a long-context stream pays
+    # far more). 2 gives each stream its slot plus one for an alternating
+    # conversation rather than sizing exactly to concurrency.
+    promptCacheSlotsPerStream = 2;
+
+    # Fraction of a budget that may be committed, leaving room for the
+    # allocator's own overhead and fragmentation. Applies to both the per-worker
+    # memory budget and the Metal buffer ceiling.
+    safetyFraction = 90; # percent
+
+    # Practical decode concurrency on a single Apple GPU. Throughput collapses
+    # before memory does, so this caps the memory-derived ceiling rather than
+    # replacing it: tighten on memory, never loosen past operator judgment.
+    # Carried forward unchanged from options-proxy.nix.
+    operatorConcurrencyCap = 4;
+  };
+
+  # ---- HELPERS -------------------------------------------------------------
+
+  divCeil = a: b: (a + b - 1) / b;
+  pct = value: percent: (value * percent) / 100;
+
+  gib = 1024 * 1024 * 1024;
+  mib = 1024 * 1024;
+
+  # perTokenKvBytes — the formula catalog-lib.nix documents, finally executed.
+  #
+  # kvLayers is the count of KV-BEARING layers, which for a hybrid-attention
+  # model is ONLY its full-attention layers: the linear/recurrent layers get an
+  # ArraysCache rather than a KVCache and hold no paged KV. Counting all layers
+  # on such a model over-reserves KV several-fold, so this multiplies exactly
+  # what the entry declares and never num_hidden_layers.
+  perTokenKvBytes =
+    kv:
+    2 # K and V
+    * kv.kvLayers
+    * kv.kvHeads
+    * kv.headDim
+    * kv.kvDtypeBytes;
+
+  # The smallest paged block size whose predicted buffer count stays under the
+  # ceiling. Smaller blocks waste less KV on partial fills, so prefer the
+  # smallest that fits rather than the largest available — but the candidates
+  # ascend so that a shape needing bigger blocks still gets them instead of
+  # failing. Returns null when nothing fits, which the assertions turn into an
+  # eval error naming the shape rather than a runtime buffer exhaustion.
+  blockSizeCandidates = [
+    256
+    512
+    1024
+    2048
+  ];
+
+  predictedBuffersFor =
+    {
+      kv,
+      concurrency,
+      windowTokens,
+      blockSize,
+    }:
+    (divCeil (concurrency * windowTokens) blockSize)
+    * kv.kvLayers
+    * calibration.bufferPerBlockPerLayer;
+
+  selectBlockSize =
+    args:
+    let
+      budget = pct metalBufferCeiling calibration.safetyFraction;
+      fits = blockSize: predictedBuffersFor (args // { inherit blockSize; }) <= budget;
+      usable = lib.filter fits blockSizeCandidates;
+    in
+    if usable == [ ] then null else lib.head usable;
+in
+rec {
+  inherit metalBufferCeiling calibration perTokenKvBytes;
+
+  # ---- HOST-LEVEL DERIVATION ----------------------------------------------
+
+  # memoryHardLimitGb, derived rather than declared.
+  #
+  # options-residency.nix carries the invariant
+  #   maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
+  # and warns what happens when the two are set independently. Deriving the
+  # per-worker budget FROM the ceiling makes over-commitment unrepresentable:
+  # raising k_max necessarily lowers the per-worker budget, which is the
+  # correction the prose asked a human to remember.
+  #
+  # The cushion is one whole GiB below the exact share, matching the existing
+  # "99 GiB under the 100 GiB ceiling" posture at k_max = 1.
+  memoryHardLimitGbFor =
+    {
+      hostWiredCeilingGb,
+      maxResidentWorkers,
+    }:
+    lib.max 1 (hostWiredCeilingGb / maxResidentWorkers - 1);
+
+  # ---- PER-MODEL DERIVATION ------------------------------------------------
+
+  # Every serve limit for one model, from that model's facts plus its two
+  # choices. The result is consumed directly by model-server-cmd.nix and the
+  # llama-swap topology; nothing downstream recomputes or overrides any of it.
+  #
+  #   kv            { kvLayers; kvHeads; headDim; kvDtypeBytes; } from config.json
+  #   weightGb      4-bit weight footprint
+  #   concurrency   THE input — in-flight streams this model serves
+  #   windowTokens  THE other input — max context per stream
+  #   budgetGb      this worker's share, from memoryHardLimitGbFor
+  forModel =
+    {
+      kv,
+      weightGb,
+      concurrency,
+      windowTokens,
+      budgetGb,
+    }:
+    let
+      tokenBytes = perTokenKvBytes kv;
+      totalTokens = concurrency * windowTokens;
+
+      liveKvBytes = totalTokens * tokenBytes;
+
+      promptCacheSlots = concurrency * calibration.promptCacheSlotsPerStream;
+      # Sized to hold each slot's full window: a slot that cannot hold the
+      # window it is caching for evicts mid-conversation, which is the
+      # expensive failure this budget exists to prevent.
+      promptCacheBytesUnclamped = promptCacheSlots * windowTokens * tokenBytes;
+
+      # What remains for the prompt cache after weights and live KV are taken
+      # out of this worker's committable share. The prompt cache is the only
+      # elastic consumer here — weights and live KV are both required to serve
+      # the declared shape at all — so it absorbs the shortfall rather than
+      # failing the build, and the assertion below catches the case where even
+      # the inelastic part does not fit.
+      committable = pct (budgetGb * gib) calibration.safetyFraction;
+      inelastic = (weightGb * gib) + liveKvBytes;
+      promptCacheHeadroom = if committable > inelastic then committable - inelastic else 0;
+      promptCacheBytes = lib.min promptCacheBytesUnclamped promptCacheHeadroom;
+
+      blockSize = selectBlockSize { inherit kv concurrency windowTokens; };
+      predictedBuffers =
+        if blockSize == null then
+          null
+        else
+          predictedBuffersFor {
+            inherit
+              kv
+              concurrency
+              windowTokens
+              blockSize
+              ;
+          };
+    in
+    {
+      # --- facts carried through, so a consumer never recomputes them
+      inherit tokenBytes totalTokens;
+
+      # --- memory
+      inherit liveKvBytes promptCacheBytes promptCacheSlots;
+      liveKvGb = liveKvBytes / gib;
+      # model-server-cmd.nix wants MiB for --prompt-cache-bytes' sibling flag
+      cacheMemoryMb = promptCacheBytes / mib;
+      totalResidentBytes = inelastic + promptCacheBytes;
+
+      # --- paged cache
+      pagedCacheBlockSize = blockSize;
+      maxCacheBlocks = if blockSize == null then null else divCeil totalTokens blockSize;
+      inherit predictedBuffers;
+
+      # --- concurrency, one value reaching every layer that caps it.
+      # maxNumSeqs is the model server's batch cap and concurrencyLimit is
+      # llama-swap's in-flight cap; they were independent numbers before, which
+      # meant llama-swap's default of 1 silently serialized a server configured
+      # for 8. Both derive from `concurrency` here so they cannot disagree.
+      maxNumSeqs = concurrency;
+      decodeConcurrency = concurrency;
+      promptConcurrency = concurrency;
+      concurrencyLimit = concurrency;
+
+      # --- context
+      maxRequestTokens = windowTokens;
+
+      # --- fitness, for assertions and for reporting a shape that cannot serve
+      fitsMemory = committable >= inelastic;
+      fitsBuffers = blockSize != null;
+    };
+
+  # ---- CEILING -------------------------------------------------------------
+
+  # The replacement for options-proxy.nix's concurrencyLimitCeiling. Same
+  # shape, but every input is read from the catalog rather than restated: the
+  # peak weight and the largest granted window come from the enabled entries
+  # themselves, so raising a window cannot leave the ceiling computing against
+  # a stale one.
+  concurrencyCeilingFor =
+    {
+      budgetGb,
+      peakWeightGb,
+      peakWindowTokens,
+      peakKv,
+    }:
+    let
+      headroomBytes = (budgetGb - peakWeightGb) * gib;
+      perStreamBytes = peakWindowTokens * (perTokenKvBytes peakKv);
+      memoryFit = if perStreamBytes <= 0 then 1 else lib.max 1 (headroomBytes / perStreamBytes);
+    in
+    lib.min calibration.operatorConcurrencyCap memoryFit;
+}

--- a/modules/mlx/derive.nix
+++ b/modules/mlx/derive.nix
@@ -34,11 +34,31 @@
 #
 #   3. options-residency.nix states the invariant
 #        maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
-#      in prose, warns that "2 workers at the default 99 GiB permits 198 GiB
-#      against a 100 GiB ceiling, which over-commits it", and then leaves both
-#      numbers to be set by hand. Co-residency therefore silently over-commits
-#      unless a human remembers to lower the other number. Here it cannot:
-#      memoryHardLimitGb is derived FROM the ceiling and k_max.
+#      in prose. THIS FILE DOES NOT OWN THAT DERIVATION — nix-darwin's
+#      hosts/common/residency-budget.nix already computes memoryHardLimitGb
+#      from the host's appleSiliconTunables.wiredLimitMb sysctl and k_max, in
+#      the same evaluation closure that reads the sysctl. That value is a
+#      taken-as-given INPUT here (see forModel's budgetGb), never re-derived.
+#
+# WHAT THIS FILE DOES NOT OWN (found while wiring it in, 2026-08-28):
+#
+#   `maxNumSeqs` (the engine's decode/prompt BATCH-ADMISSION width) and
+#   `proxy.concurrencyLimit` / `serveConcurrency` (llama-swap's in-flight
+#   admission cap) are NOT the same thing as `concurrency` below, and an
+#   earlier version of this file conflated them. Proof: plugging today's real
+#   qwen38-27b values (maxNumSeqs=8, window=131072, weightGb=16.1) into
+#   forModel's KV formula demands ~80 GiB against a 48 GiB per-worker budget
+#   — yet that exact config runs today with cacheMemoryMb=16384 (16 GiB) and
+#   does not fall over. maxNumSeqs is a throughput ceiling the runtime paged-
+#   cache admission check enforces AT CALL TIME (see docs/local-llm/memory-
+#   ceilings.mdx "load-time admission control") — it does not promise that
+#   many simultaneous full-window streams get pre-reserved capacity. The
+#   admission-width number already has a single source: the ADR at
+#   d/decisions/llm-serving-concurrency-single-source (docs-starlight) plus
+#   the per-entry `concurrencyLimit` field already in the catalog. This file
+#   does not set, read, or derive `maxNumSeqs`/`concurrencyLimit` — only
+#   memory and buffer sizing for a stated provisioning target (see
+#   `concurrency`'s definition on forModel below).
 #
 # ON THE NUMBERS: the calibration constants below are seeded from single
 # observations on one host under uncontrolled load, not controlled benchmarks.
@@ -136,9 +156,7 @@ let
       windowTokens,
       blockSize,
     }:
-    (divCeil (concurrency * windowTokens) blockSize)
-    * kv.kvLayers
-    * calibration.bufferPerBlockPerLayer;
+    (divCeil (concurrency * windowTokens) blockSize) * kv.kvLayers * calibration.bufferPerBlockPerLayer;
 
   selectBlockSize =
     args:
@@ -152,37 +170,27 @@ in
 rec {
   inherit metalBufferCeiling calibration perTokenKvBytes;
 
-  # ---- HOST-LEVEL DERIVATION ----------------------------------------------
-
-  # memoryHardLimitGb, derived rather than declared.
-  #
-  # options-residency.nix carries the invariant
-  #   maxResidentWorkers * memoryHardLimitGb <= host wired ceiling
-  # and warns what happens when the two are set independently. Deriving the
-  # per-worker budget FROM the ceiling makes over-commitment unrepresentable:
-  # raising k_max necessarily lowers the per-worker budget, which is the
-  # correction the prose asked a human to remember.
-  #
-  # The cushion is one whole GiB below the exact share, matching the existing
-  # "99 GiB under the 100 GiB ceiling" posture at k_max = 1.
-  memoryHardLimitGbFor =
-    {
-      hostWiredCeilingGb,
-      maxResidentWorkers,
-    }:
-    lib.max 1 (hostWiredCeilingGb / maxResidentWorkers - 1);
-
   # ---- PER-MODEL DERIVATION ------------------------------------------------
 
-  # Every serve limit for one model, from that model's facts plus its two
-  # choices. The result is consumed directly by model-server-cmd.nix and the
-  # llama-swap topology; nothing downstream recomputes or overrides any of it.
+  # Memory and buffer-count sizing for one model's PROMPT CACHE, from that
+  # model's facts plus a stated provisioning target. Consumed by
+  # model-server-cmd.nix for cacheMemoryMb/pagedCacheBlockSize only.
   #
   #   kv            { kvLayers; kvHeads; headDim; kvDtypeBytes; } from config.json
   #   weightGb      4-bit weight footprint
-  #   concurrency   THE input — in-flight streams this model serves
-  #   windowTokens  THE other input — max context per stream
-  #   budgetGb      this worker's share, from memoryHardLimitGbFor
+  #   concurrency   how many GENUINELY SIMULTANEOUS full-window streams to
+  #                 guarantee cache capacity for — a provisioning target you
+  #                 choose, NOT the engine's maxNumSeqs batch-admission width
+  #                 and NOT proxy.concurrencyLimit/serveConcurrency. Those are
+  #                 throughput ceilings enforced by the runtime admission
+  #                 check at call time; this is a memory-sizing promise. The
+  #                 two may legitimately differ by a wide margin (today's
+  #                 fleet brain: maxNumSeqs=8 for throughput, but nobody
+  #                 promises 8 simultaneous 131k-token conversations fit).
+  #   windowTokens  max context per guaranteed stream
+  #   budgetGb      this worker's memoryHardLimitGb — an INPUT taken as given
+  #                 (nix-darwin's hosts/common/residency-budget.nix derives
+  #                 it from the host ceiling and k_max; this file does not)
   forModel =
     {
       kv,
@@ -244,22 +252,15 @@ rec {
       maxCacheBlocks = if blockSize == null then null else divCeil totalTokens blockSize;
       inherit predictedBuffers;
 
-      # --- concurrency, one value reaching every layer that caps it.
-      # maxNumSeqs is the model server's batch cap and concurrencyLimit is
-      # llama-swap's in-flight cap; they were independent numbers before, which
-      # meant llama-swap's default of 1 silently serialized a server configured
-      # for 8. Both derive from `concurrency` here so they cannot disagree.
-      maxNumSeqs = concurrency;
-      decodeConcurrency = concurrency;
-      promptConcurrency = concurrency;
-      concurrencyLimit = concurrency;
-
-      # --- context
-      maxRequestTokens = windowTokens;
-
       # --- fitness, for assertions and for reporting a shape that cannot serve
       fitsMemory = committable >= inelastic;
       fitsBuffers = blockSize != null;
+
+      # maxNumSeqs / concurrencyLimit / maxRequestTokens are DELIBERATELY not
+      # emitted here. maxRequestTokens is the catalog's own contextWindowTokens
+      # field (a vllm-mlx generation guard already single-sourced there);
+      # maxNumSeqs and concurrencyLimit are the ADR-governed admission width
+      # (see the file header) — neither is this file's to set.
     };
 
   # ---- CEILING -------------------------------------------------------------

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -31,13 +31,10 @@ let
     '');
 
   # cacheMemoryMb, DERIVED when a class opts in via `cacheProvisioning`
-  # instead of stating a literal (see catalog-data-qwen38-27b.nix's resident
-  # class for the worked example). `cacheProvisioning.concurrency` is a
-  # STATED provisioning target — how many genuinely-simultaneous full-window
-  # streams this class guarantees cache capacity for — never guessed here;
-  # see derive.nix's forModel docs for why that differs from maxNumSeqs.
-  # budgetGb reads THIS host's memoryHardLimitGb, so the same class
-  # definition re-derives correctly on every host that enables it.
+  # (worked example: catalog-data-qwen38-27b.nix resident). `concurrency` is
+  # a STATED provisioning target, never guessed — see forModel's docs for
+  # why that differs from maxNumSeqs. budgetGb reads THIS host's
+  # memoryHardLimitGb, so one class re-derives per host.
   derivedCacheMb =
     entry: classDef:
     (derive.forModel {
@@ -58,10 +55,9 @@ let
           A class must be validated on real hardware before the catalog offers it.
         '');
     in
-    # A class may be all-literal (flags, no cacheProvisioning), all-derived
-    # (cacheProvisioning, no flags — see catalog-data.nix's 9B resident
-    # classes), or a mix; `flags` defaults to `{ }` so a purely-derived class
-    # never needs an empty literal alongside it.
+    # flags defaults to { }: an all-derived class (cacheProvisioning, no
+    # literal flags — catalog-data.nix's 9B resident classes) needs no
+    # empty flags = { } alongside it.
     (classDef.flags or { })
     // lib.optionalAttrs (classDef ? cacheProvisioning) {
       cacheMemoryMb = derivedCacheMb entry classDef;

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -58,7 +58,11 @@ let
           A class must be validated on real hardware before the catalog offers it.
         '');
     in
-    classDef.flags
+    # A class may be all-literal (flags, no cacheProvisioning), all-derived
+    # (cacheProvisioning, no flags — see catalog-data.nix's 9B resident
+    # classes), or a mix; `flags` defaults to `{ }` so a purely-derived class
+    # never needs an empty literal alongside it.
+    (classDef.flags or { })
     // lib.optionalAttrs (classDef ? cacheProvisioning) {
       cacheMemoryMb = derivedCacheMb entry classDef;
     };

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -19,6 +19,7 @@
 let
   cfg = config.programs.mlx;
   catalogData = import ./catalog-data.nix;
+  derive = import ./derive.nix { inherit lib; };
 
   enabled = lib.filterAttrs (_: sel: sel.enable) cfg.catalog;
 
@@ -29,16 +30,38 @@ let
       Known entries: ${lib.concatStringsSep ", " (lib.attrNames catalogData)}
     '');
 
+  # cacheMemoryMb, DERIVED when a class opts in via `cacheProvisioning`
+  # instead of stating a literal (see catalog-data-qwen38-27b.nix's resident
+  # class for the worked example). `cacheProvisioning.concurrency` is a
+  # STATED provisioning target — how many genuinely-simultaneous full-window
+  # streams this class guarantees cache capacity for — never guessed here;
+  # see derive.nix's forModel docs for why that differs from maxNumSeqs.
+  # budgetGb reads THIS host's memoryHardLimitGb, so the same class
+  # definition re-derives correctly on every host that enables it.
+  derivedCacheMb =
+    entry: classDef:
+    (derive.forModel {
+      inherit (entry) kv weightGb;
+      inherit (classDef.cacheProvisioning) concurrency;
+      windowTokens = entry.contextWindowTokens or 32768;
+      budgetGb = cfg.memoryHardLimitGb;
+    }).cacheMemoryMb;
+
   profileFor =
     name: sel:
     let
       entry = entryFor name;
+      classDef =
+        entry.classes.${sel.class} or (throw ''
+          programs.mlx.catalog."${name}": class "${sel.class}" is not offered by
+          this entry (offered: ${lib.concatStringsSep ", " (lib.attrNames entry.classes)}).
+          A class must be validated on real hardware before the catalog offers it.
+        '');
     in
-    entry.classes.${sel.class}.flags or (throw ''
-      programs.mlx.catalog."${name}": class "${sel.class}" is not offered by
-      this entry (offered: ${lib.concatStringsSep ", " (lib.attrNames entry.classes)}).
-      A class must be validated on real hardware before the catalog offers it.
-    '');
+    classDef.flags
+    // lib.optionalAttrs (classDef ? cacheProvisioning) {
+      cacheMemoryMb = derivedCacheMb entry classDef;
+    };
 
   # Bounded host tweaks (non-null only) merge over the validated class profile.
   # ttl is proxy/idle lifecycle, not a serve flag — pulled out separately.


### PR DESCRIPTION
## What

Makes `modules/mlx/derive.nix` the single source of the one per-model serving
limit confirmed live for the deployed backend, and fixes a real design flaw
found along the way. Three commits:

1. `derive.nix` — per-model KV/buffer/cache-sizing derivation (memory and
   Metal buffer-count math from a model's KV geometry, a stated provisioning
   target, and a host memory budget).
2. Fix: the original `concurrency` parameter conflated two different
   quantities — the engine's `maxNumSeqs` batch-admission width (already
   single-sourced by the `llm-serving-concurrency-single-source` ADR and
   `effectiveConcurrency` in `model-server-cmd.nix`) versus a genuine
   memory-provisioning target. Proof: today's real `qwen38-27b` values
   (`maxNumSeqs=8`, `window=131072`, `weightGb=16.1`) demand ~80 GiB against
   a 48 GiB budget under the original formula, yet this config runs fine
   today at `cacheMemoryMb=16384`. Removed the conflated outputs, and
   removed `memoryHardLimitGbFor` — nix-darwin's
   `hosts/common/residency-budget.nix` already derives that, in the same
   closure that reads the wired-ceiling sysctl. Backfilled the `kv` block on
   `qwen38-27b`, `qwen35-9b-mlx`, `qwen35-9b-optiq`.
3. Wires `cacheMemoryMb` for `qwen38-27b`'s resident class through
   `derive.forModel`, replacing the literal `16384`. Live process inspection
   proved `maxNumSeqs`/`pagedCacheBlockSize`/`maxRequestTokens` are dead for
   the deployed `mlx-lm` backend (never read by `mlxLmFlags`) — only
   `cacheMemoryMb` reaches `--prompt-cache-bytes`, so that's the field this
   PR actually wires. `options-catalog.nix` gains an opt-in
   `cacheProvisioning.concurrency` on a class definition; every other
   entry/class is unaffected.

## Test plan

- `nix flake check` (aarch64-darwin outputs, this Mac has no x86_64-linux
  builder): green.
- CI `Nix Validate` (full `checks.x86_64-linux.*`, 140+ tests including
  `mlx-catalog`, `mlx-catalog-roles`, `mlx-options-regression`): green on the
  first two commits; watching on the third.
- Hand-verified the derivation arithmetic before writing code: at
  `concurrency=1`, `windowTokens=131072`, the formula reproduces `16384`
  exactly (unclamped, with headroom) at both this repo's fixture default
  budget (99 GiB) and the real 48 GiB Studio shape.
- The existing `mlx-catalog` check's `cacheBytes` helper derives its own
  expected value from the compiled config rather than a pinned literal
  (per its own comment: "derive, never pin a literal"), so it validates
  this change structurally rather than needing a new assertion.

## Scope

Deliberately narrow: only the one field proven live is wired.
`maxNumSeqs`/`pagedCacheBlockSize`/`maxRequestTokens` stay as catalog
literals — they're inert for the currently-enabled `mlx-lm` backend
(`vllm-mlx` is disabled fleet-wide), so wiring them now would be dead code
on dead code. Swap class's `cacheMemoryMb = 3072` stays a literal too — it
doesn't cleanly reduce to any concurrency/window combination I can state
honestly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fleet-brain resident `cacheMemoryMb` from a fixed literal to a host-budget-dependent derivation; behavior is calibrated to match today but miscalibration or missing `kv` on future entries could mis-size serving memory.
> 
> **Overview**
> Introduces **`derive.nix`** as the computed source for per-model prompt-cache memory (and related KV/buffer math), replacing hand-maintained literals that had already drifted from documented formulas.
> 
> **`options-catalog.nix`** now derives **`cacheMemoryMb`** when a catalog class opts in via **`cacheProvisioning.concurrency`** — a stated “how many full-window streams to provision for” target, explicitly **not** `maxNumSeqs` or proxy admission caps. **`qwen38-27b`** resident drops the literal `cacheMemoryMb = 16384` in favor of that hook (same value at `concurrency = 1` and 131k window).
> 
> Catalog data changes: **`qwen35-9b-optiq`** / **`qwen35-9b-mlx`** move to **`catalog-data-qwen35-9b.nix`** (12KB split) with new **`kv`** blocks and resident **`cacheProvisioning`** (no live host impact today). **`qwen38-27b`** and the 9B pair get hybrid-attention **`kv`** metadata so **`perTokenKvBytes`** is computed from full-attention layers only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da2f66876af5ff065b5b3ffdf53dab21d55a433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->