### PR TITLE
feat(litellm): cost-ordered subagent fallback tier with a liveness probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,32 @@ Nix home-manager modules.
 **Static** (every change):
 
 ```bash
-nix flake check    # Formatting, statix, deadnix, regression tests
 nix fmt            # Fix formatting
+nix flake check    # Packages, formatters, devShells
+
+# Regression suite (lib/checks/) — REQUIRED on macOS, see below
+nix eval --raw .#checks.x86_64-linux \
+  --apply 'cs: builtins.concatStringsSep "\n" (map (c: c.outPath) (builtins.attrValues cs))' \
+  >/dev/null
 ```
+
+**A bare `nix flake check` on a Mac runs none of `lib/checks/`.** The `checks`
+output is scoped to `x86_64-linux` (flake.nix), so on aarch64-darwin it reports
+"The check omitted these incompatible systems: x86_64-linux", prints a wall of
+green for packages and formatters, and tells you nothing about the regression
+suite. A module argument that `launchd.nix` required and `default.nix` never
+passed survived a green bare check and failed only at `darwin-rebuild`.
+
+`--all-systems` does surface the assertions, but it then tries to *build* Linux
+derivations on darwin and exits non-zero for that unrelated reason — so it
+cannot be the routine command. The `nix eval` form above forces every check's
+`outPath`, which runs every assertion at evaluation time and builds nothing.
+Verified both ways: it passes on a healthy tree and fails on a deliberately
+broken one.
+
+Assertions only fire when something forces them, so a check that reads a few
+attributes of a large structure proves nothing about the rest. Where a check
+covers a nested tree (the launchd agents, for one) it should `deepSeq` it.
 
 **Runtime** (changes to plugins, hooks, settings, activations, MCP servers):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,26 +24,22 @@ nix eval --raw .#checks.x86_64-linux \
   >/dev/null
 ```
 
-**A bare `nix flake check` on a Mac runs none of `lib/checks/`.** The `checks`
-output is scoped to `x86_64-linux` (flake.nix), so on aarch64-darwin it reports
-"The check omitted these incompatible systems: x86_64-linux", prints a wall of
-green for packages and formatters, and tells you nothing about the regression
-suite. A module argument that `launchd.nix` required and `default.nix` never
-passed survived a green bare check and failed only at `darwin-rebuild`.
+**A bare `nix flake check` on a Mac runs none of `lib/checks/`.** `checks` is
+scoped to `x86_64-linux` (flake.nix), so on aarch64-darwin it omits them, prints
+green for packages and formatters, and says nothing about the regression suite.
+A module argument `launchd.nix` required and `default.nix` never passed survived
+a green bare check and failed only at `darwin-rebuild`.
 
-`--all-systems` does surface the assertions, but it then tries to *build* Linux
-derivations on darwin and exits non-zero for that unrelated reason — so it
-cannot be the routine command. The `nix eval` form above forces every check's
-`outPath`, which runs every assertion at evaluation time and builds nothing.
-Verified both ways: it passes on a healthy tree and fails on a deliberately
-broken one.
+`--all-systems` surfaces the assertions but then tries to *build* Linux
+derivations on darwin, exiting non-zero for that unrelated reason — so it cannot
+be routine. The `nix eval` form above forces every check's `outPath`: every
+assertion runs at evaluation time, nothing builds. Verified both ways — passes
+on a healthy tree, fails on a deliberately broken one.
 
-**This is a workaround, and the structural fix is in flight.** PR #1819 builds
-`checks` for every supported system instead of x86_64-linux alone, which makes a
-plain `nix flake check` run the darwin assertions directly. Once that lands,
-drop the `nix eval` invocation above and use `nix flake check` — and note its CI
-caveat, that `--all-systems` from a Linux-only runner then tries to realise the
-darwin markers and fails.
+**Workaround; PR #1819 is the structural fix.** It builds `checks` for every
+supported system, so a plain `nix flake check` runs the darwin assertions.
+When it lands, replace the `nix eval` form above — noting `--all-systems` on a
+Linux-only runner then tries to realise the darwin markers and fails.
 
 Assertions only fire when something forces them, so a check that reads a few
 attributes of a large structure proves nothing about the rest. Where a check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,13 @@ cannot be the routine command. The `nix eval` form above forces every check's
 Verified both ways: it passes on a healthy tree and fails on a deliberately
 broken one.
 
+**This is a workaround, and the structural fix is in flight.** PR #1819 builds
+`checks` for every supported system instead of x86_64-linux alone, which makes a
+plain `nix flake check` run the darwin assertions directly. Once that lands,
+drop the `nix eval` invocation above and use `nix flake check` — and note its CI
+caveat, that `--all-systems` from a Linux-only runner then tries to realise the
+darwin markers and fails.
+
 Assertions only fire when something forces them, so a check that reads a few
 attributes of a large structure proves nothing about the rest. Where a check
 covers a nested tree (the launchd agents, for one) it should `deepSeq` it.

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -52,12 +52,32 @@ Claude Code is the exception to "no local gateway hop": with
 proxy on `:4100`. The proxy splits traffic by model name — `claude-*` reaches
 Anthropic with the session's own forwarded credentials (so the main model still
 bills the subscription and is never rerouted), while every other name resolves
-through the shared router. The subagent tier names a group from
-[`fallback-tier.nix`](../../modules/litellm-local/fallback-tier.nix), a
-cost-ordered chain rather than one model, so a single retired upstream model
-cannot take every subagent down with it. Run `litellm-fallback-probe` to check
-that every member of that chain still answers — a model can stop serving with
-no config change on either side, and only a real completion detects it.
+through the shared router.
+
+The subagent tier names one stable group, `subagent`, which heads a cost-ordered
+chain assembled by
+[`fallback-tier.nix`](../../modules/litellm-local/fallback-tier.nix) from
+generated data in `tier-candidates.json`. A chain rather than one model, so a
+single retired upstream model cannot take every subagent down with it; a stable
+head name, so re-ranking the chain never edits a consumer.
+
+**The chain is generated, not hand-written.** `litellm-tier-refresh` re-ranks it
+against two live sources and keeps only their intersection: the public model
+catalog supplies cost, context window, output modality and tool-calling support,
+while the shared router supplies the set of models this host can actually reach.
+Ranking the catalog alone proposes models the router refuses outright — measured,
+not assumed. Selection also requires text output and tool-call support, since a
+subagent that cannot call tools fails as a wrong answer rather than an error.
+
+The hand-owned half is the `policy` block in that JSON, which the generator
+preserves verbatim: the required context window, how many members, an ordered
+`pin` list that overrides ranking, a `deny` list, and `paidTail` — the number of
+trailing slots reserved for billing models, because zero-cost models share one
+upstream quota pool and an all-free chain dies in a single instant.
+
+Run `litellm-fallback-probe` after any refresh. Catalog metadata is a claim, not
+behaviour: a model can stop serving with no config change on either side, and
+only a real completion detects it.
 
 The other local nix-ai clients (qwen-code, cecli, Fabric) call llama-swap
 directly at `:11434` by default — no gateway hop. Setting

--- a/docs/architecture/system-integration-map.md
+++ b/docs/architecture/system-integration-map.md
@@ -35,6 +35,11 @@ graph TD
     CC -->|HTTP MCP| CRIBL["Cribl MCP\n:30030"]
     MAE -->|claude subprocess| CC
 
+    CC -->|Anthropic API| LL["Local LiteLLM proxy\n:4100 (loopback)"]
+    CDX -->|ox profile only| LL
+    LL -->|"claude-* (client's own credentials)"| ANTH["Anthropic API"]
+    LL -->|"every other model name"| ROUTER["Shared LLM router"]
+
     FAB_MCP -->|reads patterns| FAB
 
     FAB -->|HTTP /v1| LS
@@ -42,8 +47,20 @@ graph TD
     LS -->|manages processes| WORKERS
 ```
 
-Local nix-ai clients (qwen-code, cecli, Fabric) call llama-swap directly at
-`:11434` by default — there is no local gateway hop. Setting
+Claude Code is the exception to "no local gateway hop": with
+`programs.litellmLocal.enable`, its `ANTHROPIC_BASE_URL` points at the loopback
+proxy on `:4100`. The proxy splits traffic by model name — `claude-*` reaches
+Anthropic with the session's own forwarded credentials (so the main model still
+bills the subscription and is never rerouted), while every other name resolves
+through the shared router. The subagent tier names a group from
+[`fallback-tier.nix`](../../modules/litellm-local/fallback-tier.nix), a
+cost-ordered chain rather than one model, so a single retired upstream model
+cannot take every subagent down with it. Run `litellm-fallback-probe` to check
+that every member of that chain still answers — a model can stop serving with
+no config change on either side, and only a real completion detects it.
+
+The other local nix-ai clients (qwen-code, cecli, Fabric) call llama-swap
+directly at `:11434` by default — no gateway hop. Setting
 `services.aiStack.llmEndpoint = "router"` repoints those OpenAI-compatible
 consumers at the cluster-hosted LiteLLM router instead (bearer-gated via
 `services.aiStack.llmEndpointTokenFile`). The chat UI is no longer local: the
@@ -55,6 +72,7 @@ cluster-hosted Open WebUI.
 | Product | Module Path | Transport | Purpose | Key Config Files |
 |---------|------------|-----------|---------|-----------------|
 | Claude Code | `modules/claude-config.nix` | Desktop app | Primary AI coding assistant | `~/.claude/settings.json`, `~/.claude.json` |
+| Local LiteLLM proxy | `modules/litellm-local/` | HTTP :4100 (loopback) | Role aliases + cost-ordered subagent fallback chain | rendered config, `modules/litellm-local/fallback-tier.nix` |
 | Antigravity CLI | `modules/antigravity-cli/` | CLI | Google Antigravity assistant | `~/.gemini/antigravity-cli/settings.json` |
 | Codex CLI | `modules/codex/` | CLI | OpenAI coding assistant | `~/.codex/config.toml` |
 | Qwen Code | `modules/qwen-code/` | CLI | Local-first coding assistant | `~/.qwen/settings.json` |
@@ -110,6 +128,7 @@ and adding any required runtime secret injection.
 
 | Port | Service | Protocol | Module |
 |------|---------|----------|--------|
+| 4100 | Local LiteLLM proxy (loopback only) | HTTP (Anthropic + OpenAI-compatible) | `modules/litellm-local/` |
 | 11434 | llama-swap proxy | HTTP (OpenAI-compatible) | `modules/mlx/` |
 | 11436+ | MLX model-server workers (mlx-lm) | HTTP (managed by llama-swap) | `modules/mlx/` |
 | 8180 | Fabric REST API (opt-in) | HTTP + Swagger UI | `modules/fabric/` |

--- a/docs/architecture/telemetry-coverage.md
+++ b/docs/architecture/telemetry-coverage.md
@@ -15,6 +15,29 @@ for the signal/endpoint shape.
 |---|---|---|
 | Claude Code | `userConfig.telemetry.{enable,otlpEndpoint,tracesEndpoint}` → `modules/claude/settings-env.nix` | metrics, logs, spans |
 | Codex CLI | the same `userConfig.telemetry` surface → `[otel]` in `modules/codex/settings.nix` | spans |
+| Local LiteLLM proxy | `userConfig.telemetry.tracesEndpoint` → `litellm_settings.callbacks` in `modules/litellm-local/` | spans, when an endpoint is set |
+
+**Both the proxy and Codex gate on `telemetry.enable && tracesEndpoint != null`,
+so both are inert while no endpoint is configured.** Setting `telemetry.enable`
+alone is not enough and never has been. Check the rendered config rather than
+the deployed file before concluding either one is emitting: `~/.claude/settings.json`
+and `~/.codex/config.toml` are activation-merged, so they can still carry
+endpoints from an older generation after the config that produced them is gone.
+A deployed file showing an endpoint is evidence about the past, not the present.
+
+**The proxy emits `otel`, not `langfuse`, and that is deliberate.** LiteLLM's
+`langfuse` callback requires the v2 SDK and errors on init against the v3 that
+pip resolves; the collector already fans traces out to Langfuse, so one emitter
+on the shared path reaches the same sink with nothing extra to keep in step —
+and the proxy needs no Langfuse credential of its own. The shared router made
+the same call for the same reason, so the two agree by construction.
+
+**LiteLLM uses its own variable names.** `OTEL_EXPORTER` and `OTEL_ENDPOINT`,
+not the standard `OTEL_EXPORTER_OTLP_*` pair. Setting the standard names leaves
+the callback on its loopback default, exporting nowhere, with no error raised.
+Like Codex, it takes the endpoint verbatim, so it is given the full
+`/v1/traces` URL. The callback is only configured when a traces endpoint is
+set — no endpoint, no callback, rather than a silent export into a black hole.
 
 **Codex takes the endpoint verbatim.** Pointed at `http://host:port` it POSTs to
 `/`, appending no signal path — so it is given the full `/v1/traces` URL, the

--- a/docs/architecture/telemetry-coverage.md
+++ b/docs/architecture/telemetry-coverage.md
@@ -17,6 +17,11 @@ for the signal/endpoint shape.
 | Codex CLI | the same `userConfig.telemetry` surface → `[otel]` in `modules/codex/settings.nix` | spans |
 | Local LiteLLM proxy | `userConfig.telemetry.tracesEndpoint` → `litellm_settings.callbacks` in `modules/litellm-local/` | spans, when an endpoint is set |
 
+Proxy spans carry the resolved model name, so they are also how a fallback shows
+up after the fact: a request served by a rung below the head means the tier
+above it failed. Without them a chain degrades silently, which is the same blind
+spot the chain itself was built to remove — one layer up.
+
 **Both the proxy and Codex gate on `telemetry.enable && tracesEndpoint != null`,
 so both are inert while no endpoint is configured.** Setting `telemetry.enable`
 alone is not enough and never has been. Check the rendered config rather than

--- a/lib/checks/litellm-local-fallbacks.nix
+++ b/lib/checks/litellm-local-fallbacks.nix
@@ -1,0 +1,94 @@
+# litellm-local — cost-ordered fallback-tier assertions.
+#
+# Split out of lib/checks/litellm-local.nix for the per-file 12KB gate (the
+# same split-rather-than-exempt pattern used across lib/checks). Pure
+# assertions over the already-rendered config: no new evaluation, no I/O.
+# Returns the first failing check (or null), which the parent asserts.
+{ lib, rendered }:
+let
+  # ---- cost-ordered fallback tier ------------------------------------------
+  # The property: no tier Claude Code uses may depend on a single model. A
+  # model can die with no config change at all (the router's `subagent` alias
+  # kept resolving in /v1/model/info for days after the model behind it stopped
+  # answering), so "one name, one model" is the failure mode, not an
+  # implementation detail.
+  settings = rendered.litellm_settings;
+  renderedGroups = map (d: d.model_name) rendered.model_list;
+
+  fallbackEntries = settings.fallbacks or [ ];
+  fallbackGroups = lib.concatMap builtins.attrNames fallbackEntries;
+  # Each entry is `{ group = [ target, ... ]; }`, so attrValues yields a list
+  # OF LISTS — flatten before membership-testing, or every target reads as
+  # unknown.
+  fallbackTargets = lib.unique (
+    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) fallbackEntries
+  );
+
+  chainHasDepth = lib.all (e: lib.all (t: t != [ ]) (builtins.attrValues e)) fallbackEntries;
+
+  # Every fallback target must itself be a real model_list group. A target that
+  # only resolves through `*` reintroduces exactly the failure the chain exists
+  # to remove — the request leaves this host and 404s upstream.
+  targetsAreExplicitGroups = lib.all (t: lib.elem t renderedGroups) fallbackTargets;
+
+  # A blanket default_fallbacks would also catch `claude-*`, quietly answering
+  # a main session from a cheap model when Anthropic rate-limits. Losing the
+  # request is recoverable; not noticing the model changed under a long session
+  # is not.
+  noBlanketDefault = !(settings ? default_fallbacks);
+
+  # A context-window overflow cannot succeed as sent, so routing it to a bigger
+  # window is a repair rather than a downgrade — the one case where moving the
+  # main tier off Anthropic is safe.
+  contextFallbackTargets = lib.unique (
+    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) (
+      settings.context_window_fallbacks or [ ]
+    )
+  );
+  contextFallbacksAreExplicit = lib.all (t: lib.elem t renderedGroups) contextFallbackTargets;
+
+  retriesConfigured = (settings.num_retries or 0) > 0;
+
+  # The main tier gets retries and a context-window repair, never a silent
+  # quality swap, so it must not appear as a fallback source group.
+  mainTierNotInFallbacks = !(lib.elem "claude-*" fallbackGroups);
+
+  # Declared as data and folded once below, rather than a run of
+  # `assert x || throw ...` lines. One list is easier to extend, and the
+  # failure message comes from the same place the condition does.
+  fallbackTierChecks = [
+    {
+      ok = fallbackEntries != [ ];
+      msg = "the proxy must configure litellm_settings.fallbacks: without a chain, one dead upstream model takes every subagent with it (see modules/litellm-local/fallback-tier.nix)";
+    }
+    {
+      ok = chainHasDepth;
+      msg = "every fallback entry must name at least one target; an empty list is a chain that cannot fall anywhere";
+    }
+    {
+      ok = targetsAreExplicitGroups;
+      msg = "every fallback target must be an explicit model_list group, never resolved through the wildcard — a wildcard target leaves this host and 404s upstream the moment the router alias goes stale; got: ${builtins.toJSON fallbackTargets}";
+    }
+    {
+      ok = noBlanketDefault;
+      msg = "litellm_settings.default_fallbacks must stay unset: it would also catch the main tier, silently answering a main session from a cheaper model instead of surfacing the failure";
+    }
+    {
+      ok = contextFallbacksAreExplicit;
+      msg = "every context_window_fallbacks target must be an explicit model_list group; got: ${builtins.toJSON contextFallbackTargets}";
+    }
+    {
+      ok = retriesConfigured;
+      msg = "litellm_settings.num_retries must be greater than zero so a transient upstream failure is retried before it spends a fallback";
+    }
+    {
+      ok = mainTierNotInFallbacks;
+      msg = "the main Anthropic tier must not appear as a fallback source group: it gets retries and a context-window repair, never a silent quality swap";
+    }
+  ];
+
+  firstFallbackFailure = lib.findFirst (c: !c.ok) null fallbackTierChecks;
+in
+{
+  inherit firstFallbackFailure;
+}

--- a/lib/checks/litellm-local-keys.nix
+++ b/lib/checks/litellm-local-keys.nix
@@ -1,0 +1,46 @@
+# litellm-local — proxy auth and per-deployment api_key scoping.
+#
+# Split out of lib/checks/litellm-local.nix for the per-file 12KB gate (the
+# same split-rather-than-exempt pattern used across lib/checks). Pure
+# predicates over the already-rendered config; the parent asserts them with
+# the failure messages that explain each one.
+{ rendered }:
+let
+  noGlobalForwarding =
+    !(rendered ? general_settings) || !(rendered.general_settings ? forward_client_headers_to_llm_api);
+
+  # No master key, by design: a subscription Claude Code session may send the
+  # gateway no credential variable, and settings.json (the only channel that
+  # reaches every session) cannot carry a secret. With a master key present,
+  # LiteLLM treats the OAuth bearer as a virtual key and answers
+  # `400 No connected db` — the outage's exact symptom.
+  noMasterKey = !(rendered ? general_settings) || !(rendered.general_settings ? master_key);
+
+  # The wildcard deployment must carry its own api_key, so it authenticates to
+  # the router as itself rather than relying on whatever a client sent.
+  wildcardDeployment = builtins.head (builtins.filter (m: m.model_name == "*") rendered.model_list);
+  claudeDeployment = builtins.head (
+    builtins.filter (m: m.model_name == "claude-*") rendered.model_list
+  );
+
+  wildcardHasOwnKey = wildcardDeployment.litellm_params ? api_key;
+
+  # Conversely the claude-* deployment must NOT carry one: a key here would
+  # override the forwarded client credential and silently bill the wrong
+  # account.
+  claudeHasNoKey = !(claudeDeployment.litellm_params ? api_key);
+
+  # LiteLLM substitutes only the matched tail of a wildcard into the target,
+  # so `anthropic/*` sent `claude-opus-5` upstream as `opus-5`. The target
+  # must repeat the prefix.
+  claudeKeepsPrefix = claudeDeployment.litellm_params.model == "anthropic/claude-*";
+in
+{
+  inherit
+    noGlobalForwarding
+    noMasterKey
+    wildcardHasOwnKey
+    claudeHasNoKey
+    claudeKeepsPrefix
+    ;
+}

--- a/lib/checks/litellm-local-keys.nix
+++ b/lib/checks/litellm-local-keys.nix
@@ -36,6 +36,9 @@ let
   claudeKeepsPrefix = claudeDeployment.litellm_params.model == "anthropic/claude-*";
 in
 {
+  # The parent's failure message quotes the actual compiled target.
+  claudeTargetModel = claudeDeployment.litellm_params.model;
+
   inherit
     noGlobalForwarding
     noMasterKey

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -33,6 +33,89 @@ let
 
   scopedToClaudeOnly = forwardList == [ "claude-*" ];
 
+  # ---- cost-ordered fallback tier ------------------------------------------
+  # The property: no tier Claude Code uses may depend on a single model. A
+  # model can die with no config change at all (the router's `subagent` alias
+  # kept resolving in /v1/model/info for days after the model behind it stopped
+  # answering), so "one name, one model" is the failure mode, not an
+  # implementation detail.
+  settings = rendered.litellm_settings;
+  renderedGroups = map (d: d.model_name) rendered.model_list;
+
+  fallbackEntries = settings.fallbacks or [ ];
+  fallbackGroups = lib.concatMap builtins.attrNames fallbackEntries;
+  # Each entry is `{ group = [ target, ... ]; }`, so attrValues yields a list
+  # OF LISTS — flatten before membership-testing, or every target reads as
+  # unknown.
+  fallbackTargets = lib.unique (
+    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) fallbackEntries
+  );
+
+  chainHasDepth = lib.all (e: lib.all (t: t != [ ]) (builtins.attrValues e)) fallbackEntries;
+
+  # Every fallback target must itself be a real model_list group. A target that
+  # only resolves through `*` reintroduces exactly the failure the chain exists
+  # to remove — the request leaves this host and 404s upstream.
+  targetsAreExplicitGroups = lib.all (t: lib.elem t renderedGroups) fallbackTargets;
+
+  # A blanket default_fallbacks would also catch `claude-*`, quietly answering
+  # a main session from a cheap model when Anthropic rate-limits. Losing the
+  # request is recoverable; not noticing the model changed under a long session
+  # is not.
+  noBlanketDefault = !(settings ? default_fallbacks);
+
+  # A context-window overflow cannot succeed as sent, so routing it to a bigger
+  # window is a repair rather than a downgrade — the one case where moving the
+  # main tier off Anthropic is safe.
+  contextFallbackTargets = lib.unique (
+    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) (
+      settings.context_window_fallbacks or [ ]
+    )
+  );
+  contextFallbacksAreExplicit = lib.all (t: lib.elem t renderedGroups) contextFallbackTargets;
+
+  retriesConfigured = (settings.num_retries or 0) > 0;
+
+  # The main tier gets retries and a context-window repair, never a silent
+  # quality swap, so it must not appear as a fallback source group.
+  mainTierNotInFallbacks = !(lib.elem "claude-*" fallbackGroups);
+
+  # Declared as data and folded once below, rather than a run of
+  # `assert x || throw ...` lines. One list is easier to extend, and the
+  # failure message comes from the same place the condition does.
+  fallbackTierChecks = [
+    {
+      ok = fallbackEntries != [ ];
+      msg = "the proxy must configure litellm_settings.fallbacks: without a chain, one dead upstream model takes every subagent with it (see modules/litellm-local/fallback-tier.nix)";
+    }
+    {
+      ok = chainHasDepth;
+      msg = "every fallback entry must name at least one target; an empty list is a chain that cannot fall anywhere";
+    }
+    {
+      ok = targetsAreExplicitGroups;
+      msg = "every fallback target must be an explicit model_list group, never resolved through the wildcard — a wildcard target leaves this host and 404s upstream the moment the router alias goes stale; got: ${builtins.toJSON fallbackTargets}";
+    }
+    {
+      ok = noBlanketDefault;
+      msg = "litellm_settings.default_fallbacks must stay unset: it would also catch the main tier, silently answering a main session from a cheaper model instead of surfacing the failure";
+    }
+    {
+      ok = contextFallbacksAreExplicit;
+      msg = "every context_window_fallbacks target must be an explicit model_list group; got: ${builtins.toJSON contextFallbackTargets}";
+    }
+    {
+      ok = retriesConfigured;
+      msg = "litellm_settings.num_retries must be greater than zero so a transient upstream failure is retried before it spends a fallback";
+    }
+    {
+      ok = mainTierNotInFallbacks;
+      msg = "the main Anthropic tier must not appear as a fallback source group: it gets retries and a context-window repair, never a silent quality swap";
+    }
+  ];
+
+  firstFallbackFailure = lib.findFirst (c: !c.ok) null fallbackTierChecks;
+
   noGlobalForwarding =
     !(rendered ? general_settings) || !(rendered.general_settings ? forward_client_headers_to_llm_api);
 
@@ -218,4 +301,8 @@ in
       agentCarriesNoSecret
       || throw "the launchd agent must take the router URL as plain env and read the bearer from its file at exec time, never as an EnvironmentVariable";
     helpers.mkMarker "check-litellm-local-client-wiring" "litellm-local: clients name roles, lead models untouched, every Claude Code setting non-secret and in settings.json";
+
+  litellm-local-fallback-tier =
+    assert firstFallbackFailure == null || throw firstFallbackFailure.msg;
+    helpers.mkMarker "check-litellm-local-fallback-tier" "litellm-local: subagent tier is a cost-ordered chain of explicit groups, main tier never silently downgraded";
 }

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -29,121 +29,23 @@ let
 
   rendered = hmConfig.config.programs.litellmLocal.renderedConfig;
 
+  # Cost-ordered fallback-tier assertions live in their own file (12KB gate).
+  firstFallbackFailure =
+    (import ./litellm-local-fallbacks.nix { inherit lib rendered; }).firstFallbackFailure;
+
+  # Proxy auth + per-deployment api_key scoping (12KB gate).
+  keys = import ./litellm-local-keys.nix { inherit rendered; };
+  inherit (keys)
+    noGlobalForwarding
+    noMasterKey
+    wildcardHasOwnKey
+    claudeHasNoKey
+    claudeKeepsPrefix
+    ;
+
   forwardList = rendered.litellm_settings.model_group_settings.forward_client_headers_to_llm_api;
 
   scopedToClaudeOnly = forwardList == [ "claude-*" ];
-
-  # ---- cost-ordered fallback tier ------------------------------------------
-  # The property: no tier Claude Code uses may depend on a single model. A
-  # model can die with no config change at all (the router's `subagent` alias
-  # kept resolving in /v1/model/info for days after the model behind it stopped
-  # answering), so "one name, one model" is the failure mode, not an
-  # implementation detail.
-  settings = rendered.litellm_settings;
-  renderedGroups = map (d: d.model_name) rendered.model_list;
-
-  fallbackEntries = settings.fallbacks or [ ];
-  fallbackGroups = lib.concatMap builtins.attrNames fallbackEntries;
-  # Each entry is `{ group = [ target, ... ]; }`, so attrValues yields a list
-  # OF LISTS — flatten before membership-testing, or every target reads as
-  # unknown.
-  fallbackTargets = lib.unique (
-    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) fallbackEntries
-  );
-
-  chainHasDepth = lib.all (e: lib.all (t: t != [ ]) (builtins.attrValues e)) fallbackEntries;
-
-  # Every fallback target must itself be a real model_list group. A target that
-  # only resolves through `*` reintroduces exactly the failure the chain exists
-  # to remove — the request leaves this host and 404s upstream.
-  targetsAreExplicitGroups = lib.all (t: lib.elem t renderedGroups) fallbackTargets;
-
-  # A blanket default_fallbacks would also catch `claude-*`, quietly answering
-  # a main session from a cheap model when Anthropic rate-limits. Losing the
-  # request is recoverable; not noticing the model changed under a long session
-  # is not.
-  noBlanketDefault = !(settings ? default_fallbacks);
-
-  # A context-window overflow cannot succeed as sent, so routing it to a bigger
-  # window is a repair rather than a downgrade — the one case where moving the
-  # main tier off Anthropic is safe.
-  contextFallbackTargets = lib.unique (
-    lib.concatMap (e: lib.concatLists (builtins.attrValues e)) (
-      settings.context_window_fallbacks or [ ]
-    )
-  );
-  contextFallbacksAreExplicit = lib.all (t: lib.elem t renderedGroups) contextFallbackTargets;
-
-  retriesConfigured = (settings.num_retries or 0) > 0;
-
-  # The main tier gets retries and a context-window repair, never a silent
-  # quality swap, so it must not appear as a fallback source group.
-  mainTierNotInFallbacks = !(lib.elem "claude-*" fallbackGroups);
-
-  # Declared as data and folded once below, rather than a run of
-  # `assert x || throw ...` lines. One list is easier to extend, and the
-  # failure message comes from the same place the condition does.
-  fallbackTierChecks = [
-    {
-      ok = fallbackEntries != [ ];
-      msg = "the proxy must configure litellm_settings.fallbacks: without a chain, one dead upstream model takes every subagent with it (see modules/litellm-local/fallback-tier.nix)";
-    }
-    {
-      ok = chainHasDepth;
-      msg = "every fallback entry must name at least one target; an empty list is a chain that cannot fall anywhere";
-    }
-    {
-      ok = targetsAreExplicitGroups;
-      msg = "every fallback target must be an explicit model_list group, never resolved through the wildcard — a wildcard target leaves this host and 404s upstream the moment the router alias goes stale; got: ${builtins.toJSON fallbackTargets}";
-    }
-    {
-      ok = noBlanketDefault;
-      msg = "litellm_settings.default_fallbacks must stay unset: it would also catch the main tier, silently answering a main session from a cheaper model instead of surfacing the failure";
-    }
-    {
-      ok = contextFallbacksAreExplicit;
-      msg = "every context_window_fallbacks target must be an explicit model_list group; got: ${builtins.toJSON contextFallbackTargets}";
-    }
-    {
-      ok = retriesConfigured;
-      msg = "litellm_settings.num_retries must be greater than zero so a transient upstream failure is retried before it spends a fallback";
-    }
-    {
-      ok = mainTierNotInFallbacks;
-      msg = "the main Anthropic tier must not appear as a fallback source group: it gets retries and a context-window repair, never a silent quality swap";
-    }
-  ];
-
-  firstFallbackFailure = lib.findFirst (c: !c.ok) null fallbackTierChecks;
-
-  noGlobalForwarding =
-    !(rendered ? general_settings) || !(rendered.general_settings ? forward_client_headers_to_llm_api);
-
-  # No master key, by design: a subscription Claude Code session may send the
-  # gateway no credential variable, and settings.json (the only channel that
-  # reaches every session) cannot carry a secret. With a master key present,
-  # LiteLLM treats the OAuth bearer as a virtual key and answers
-  # `400 No connected db` — the outage's exact symptom.
-  noMasterKey = !(rendered ? general_settings) || !(rendered.general_settings ? master_key);
-
-  # The wildcard deployment must carry its own api_key, so it authenticates to
-  # the router as itself rather than relying on whatever a client sent.
-  wildcardDeployment = builtins.head (builtins.filter (m: m.model_name == "*") rendered.model_list);
-  claudeDeployment = builtins.head (
-    builtins.filter (m: m.model_name == "claude-*") rendered.model_list
-  );
-
-  wildcardHasOwnKey = wildcardDeployment.litellm_params ? api_key;
-
-  # Conversely the claude-* deployment must NOT carry one: a key here would
-  # override the forwarded client credential and silently bill the wrong
-  # account.
-  claudeHasNoKey = !(claudeDeployment.litellm_params ? api_key);
-
-  # LiteLLM substitutes only the matched tail of a wildcard into the target,
-  # so `anthropic/*` sent `claude-opus-5` upstream as `opus-5`. The target
-  # must repeat the prefix.
-  claudeKeepsPrefix = claudeDeployment.litellm_params.model == "anthropic/claude-*";
 
   # ---- enabled-path wiring -------------------------------------------------
   enabled = hmConfigLitellmLocal.config;

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -126,6 +126,15 @@ let
   exportsPlaceholder = lib.hasInfix "export LITELLM_LOCAL_KEY=${clientToken}" zshInit;
 
   agent = enabled.launchd.agents.litellm-local.config;
+
+  # Nix evaluates lazily, so reading three attributes off one agent proves
+  # nothing about the rest of the tree. A module argument that launchd.nix
+  # required but default.nix never passed satisfied every assertion in this
+  # file and only surfaced during `darwin-rebuild`, after a full flake check had
+  # gone green. deepSeq forces the whole agent set, which is what makes a
+  # missing argument or an undefined binding a check failure instead of a
+  # rebuild failure.
+  agentsFullyEvaluate = builtins.deepSeq enabled.launchd.agents true;
   agentLoopbackOnly = enabled.programs.litellmLocal.port == 4100;
   # The router URL reaches the agent as plain env; the bearer does not — the
   # wrapper reads it from the file at exec time.
@@ -199,6 +208,7 @@ in
     assert
       exportsPlaceholder
       || throw "shell init must export LITELLM_LOCAL_KEY as the constant placeholder `${clientToken}`; the proxy checks no credential and OpenAI-compatible SDKs refuse an empty key";
+    assert agentsFullyEvaluate || throw "unreachable: deepSeq either forces the agent tree or raises";
     assert
       agentCarriesNoSecret
       || throw "the launchd agent must take the router URL as plain env and read the bearer from its file at exec time, never as an EnvironmentVariable";

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -30,8 +30,7 @@ let
   rendered = hmConfig.config.programs.litellmLocal.renderedConfig;
 
   # Cost-ordered fallback-tier assertions live in their own file (12KB gate).
-  firstFallbackFailure =
-    (import ./litellm-local-fallbacks.nix { inherit lib rendered; }).firstFallbackFailure;
+  inherit (import ./litellm-local-fallbacks.nix { inherit lib rendered; }) firstFallbackFailure;
 
   # Proxy auth + per-deployment api_key scoping (12KB gate).
   keys = import ./litellm-local-keys.nix { inherit rendered; };

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -35,6 +35,7 @@ let
 
   # Proxy auth + per-deployment api_key scoping (12KB gate).
   keys = import ./litellm-local-keys.nix { inherit rendered; };
+  inherit (keys) claudeTargetModel;
   inherit (keys)
     noGlobalForwarding
     noMasterKey
@@ -148,7 +149,7 @@ in
       || throw "the litellm-local claude-* deployment must carry no api_key so the forwarded client credential is what authenticates it";
     assert
       claudeKeepsPrefix
-      || throw "the litellm-local claude-* deployment must target anthropic/claude-*: LiteLLM substitutes only the matched tail, so anthropic/* sends claude-opus-5 upstream as opus-5; got: ${claudeDeployment.litellm_params.model}";
+      || throw "the litellm-local claude-* deployment must target anthropic/claude-*: LiteLLM substitutes only the matched tail, so anthropic/* sends claude-opus-5 upstream as opus-5; got: ${claudeTargetModel}";
     assert
       wildcardHasOwnKey
       || throw "the litellm-local wildcard deployment must carry its own api_key so it authenticates to the router as itself";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -67,8 +67,24 @@
   # Effort level via env var (alternative to settings.json key)
   # CLAUDE_CODE_EFFORT_LEVEL = "medium";
 
-  # Auto-compact threshold — using upstream default (~95% of context window)
-  # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "95";
+  # Auto-compact threshold.
+  #
+  # NOT the upstream default, despite what this comment used to claim:
+  # nix-claude-code's `autoCompactThresholdPercent` defaults to 60, and that
+  # default reaches every session whether or not anything is set here. The
+  # stale comment mattered — it told a reader the value was upstream's ~95%
+  # when the effective value was 60.
+  #
+  # 60 is the right number for a 1M-token window, which is the case its author
+  # reasoned about: 60% of 1M still leaves ~600k of working space. It is the
+  # wrong number for a 200k window, where it compacts at 120k and spends the
+  # session summarizing. Set explicitly to the value that suits the window this
+  # host's default model actually has.
+  #
+  # Raise toward upstream's ~95 only with the summarization pass in mind: the
+  # compaction itself needs headroom, so a threshold close to the ceiling can
+  # leave too little room to summarize.
+  CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "80";
 
 }
 # Local LiteLLM proxy — route Claude Code through it so subagent-tier work
@@ -96,17 +112,23 @@
   {
     ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
     ANTHROPIC_CUSTOM_HEADERS = "x-litellm-api-key: Bearer ${litellmLocal.clientToken}";
-    # A capability alias or an explicit model_list group; the flake check
-    # enforces it.
+    # The entry point of the cost-ordered chain in
+    # modules/litellm-local/fallback-tier.nix, not a single model: cheapest
+    # capable tier first, falling through to progressively more expensive ones
+    # only when a tier is actually down.
+    #
+    # An explicit model_list group, never an upstream role name. A role falls
+    # through the `*` wildcard to the router, and if the router's own alias is
+    # stale the request 404s on every subagent spawn — which is exactly what
+    # happened when this was `subagent` and the router still pointed that alias
+    # at a model whose preview period had ended. The flake check
+    # `claudeTierNamesResolveLocally` enforces the explicit-group rule.
     #
     # A cheaper tier than the caller is the point — the parent corrects its
-    # subagents. Repoint at a local model, or a cheap cloud one with zero data
-    # retention, once either holds this tier's context.
-    #
-    # The `[1m]` id, not the bare `sonnet` alias: measured subagent context runs
-    # to 284k at p90, which a 200k window truncates. The suffix only resolves on
-    # an explicit id — `sonnet[1m]` is not an alias the proxy can route.
-    CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-5[1m]";
+    # subagents. Every member of the chain clears the ~284k p90 subagent
+    # context measured on this host; that window is a selection criterion for
+    # membership, so it does not need restating per tier here.
+    CLAUDE_CODE_SUBAGENT_MODEL = "subagent-free";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the
     # `cheap` role targets the always-on small local model, whose 32k window

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -128,7 +128,7 @@
     # subagents. Every member of the chain clears the ~284k p90 subagent
     # context measured on this host; that window is a selection criterion for
     # membership, so it does not need restating per tier here.
-    CLAUDE_CODE_SUBAGENT_MODEL = "subagent-free";
+    CLAUDE_CODE_SUBAGENT_MODEL = "subagent";
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the
     # `cheap` role targets the always-on small local model, whose 32k window

--- a/modules/litellm-local/commands.nix
+++ b/modules/litellm-local/commands.nix
@@ -82,7 +82,30 @@ let
       --host 127.0.0.1 \
       --port ${toString cfg.port}
   '';
+  # Timer entry point. diffutils is an explicit runtime input because the job
+  # reports WHAT moved when the selection changes, and `diff` is not otherwise
+  # in a launchd agent's empty PATH.
+  tierRefreshJob = pkgs.writeShellApplication {
+    name = "litellm-tier-refresh-job";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+      pkgs.diffutils
+    ];
+    text = ''
+      exec ${./../scripts/litellm-tier-refresh-job.sh} "$@"
+    '';
+  };
+
+  # The refresh script the job drives, as a store path the agent can name.
+  tierRefreshScript = ./../scripts/litellm-tier-refresh.sh;
 in
 {
-  inherit fallbackProbe tierRefresh proxyScript;
+  inherit
+    fallbackProbe
+    tierRefresh
+    tierRefreshJob
+    tierRefreshScript
+    proxyScript
+    ;
 }

--- a/modules/litellm-local/commands.nix
+++ b/modules/litellm-local/commands.nix
@@ -1,0 +1,88 @@
+# Executables the local proxy ships: the launchd entry point and the two
+# operator commands.
+#
+# Split out of ./default.nix to stay under the .file-size.yml ceiling. Grouped
+# by responsibility rather than by size — everything here produces something
+# runnable, while ./proxy-config.nix decides what the proxy serves and
+# default.nix wires the module.
+#
+# Common thread worth keeping in view: none of these may take a credential
+# through the Nix store or through a launchd `EnvironmentVariables` entry. The
+# router bearer is read from its file at exec time, every time.
+{
+  pkgs,
+  lib,
+  aiStack,
+  cfg,
+  versions,
+  configYaml,
+  fallbackTier,
+  telemetryTracesEndpoint,
+  otelPackages,
+}:
+let
+  # The proxy runs from a uvx environment pinned to the Renovate-tracked release
+  # in lib/versions.nix, the same way the MLX stack does, rather than from
+  # nixpkgs' litellm: nixpkgs lags the upstream release train by months, and
+  # building it from source drags a large Python test closure (the rq test
+  # suite among it) into every CI and workstation rebuild.
+  uvPythonVersion = (import ../../lib/python.nix { inherit pkgs; }).pythonVersion;
+
+  # Liveness probe for the fallback chain. The chain's members are named here
+  # so the command needs no arguments in the common case — running it bare
+  # checks exactly what this host is configured to fall back through.
+  fallbackProbe = pkgs.writeShellApplication {
+    name = "litellm-fallback-probe";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+    ];
+    # The chain is passed as an environment variable, not as default
+    # arguments: `"''${@:-a b c}"` collapses the default into ONE argument, so
+    # the probe asked for a model literally named "a b c" and got a 404 that
+    # looked like a dead chain. Word-splitting the default belongs in the
+    # script, which is also where the no-inline-shell rule wants it.
+    text = ''
+      LITELLM_FALLBACK_CHAIN=${lib.escapeShellArg (lib.concatStringsSep " " fallbackTier.names)} \
+        exec ${./../scripts/litellm-fallback-probe.sh} "$@"
+    '';
+  };
+
+  # Regenerates ./tier-candidates.json from the live catalog. It writes into a
+  # CHECKOUT, not the store, so the candidates path is a required argument
+  # rather than baked in — a wrapper pointing at the read-only store copy would
+  # fail at the last step, after both network fetches.
+  tierRefresh = pkgs.writeShellApplication {
+    name = "litellm-tier-refresh";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+    ];
+    text = ''
+      exec ${./../scripts/litellm-tier-refresh.sh} "$@"
+    '';
+  };
+
+  # launchd agents get no shell init, so the wrapper reads the router bearer
+  # from its file itself. This is also why the assertion below requires
+  # llmEndpointTokenFile: llmEndpointBearerFromEnv provisions the bearer into
+  # an interactive shell, which this agent never has.
+  proxyScript = pkgs.writeShellScript "litellm-local-start" ''
+    set -euo pipefail
+    OPENAI_API_KEY="$(cat ${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)})"
+    export OPENAI_API_KEY
+    exec ${pkgs.uv}/bin/uvx --python ${uvPythonVersion} \
+      --from "litellm[proxy]==${versions.litellm}" \
+      ${
+        lib.concatMapStringsSep " " (p: "--with ${lib.escapeShellArg p}") (
+          lib.optionals (telemetryTracesEndpoint != null) otelPackages
+        )
+      } litellm \
+      --config ${configYaml} \
+      --host 127.0.0.1 \
+      --port ${toString cfg.port}
+  '';
+in
+{
+  inherit fallbackProbe tierRefresh proxyScript;
+}

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -104,7 +104,20 @@ let
       otelPackages
       ;
   };
-  inherit (commands) fallbackProbe tierRefresh proxyScript;
+  inherit (commands)
+    fallbackProbe
+    tierRefresh
+    tierRefreshJob
+    tierRefreshScript
+    proxyScript
+    ;
+
+  refreshCfg = cfg.tierRefresh;
+  refreshCandidates =
+    if refreshCfg.checkout == null then
+      null
+    else
+      "${refreshCfg.checkout}/modules/litellm-local/tier-candidates.json";
 
 in
 {
@@ -126,6 +139,10 @@ in
           assertion = aiStack.llmEndpointTokenFile != null && aiStack.llmEndpointTokenFile != "";
           message = "programs.litellmLocal.enable requires services.aiStack.llmEndpointTokenFile: the proxy runs as a launchd agent, which has no shell init, so services.aiStack.llmEndpointBearerFromEnv cannot reach it. Point llmEndpointTokenFile at the file holding the router bearer.";
         }
+        {
+          assertion = !refreshCfg.enable || refreshCfg.checkout != null;
+          message = "programs.litellmLocal.tierRefresh.enable requires tierRefresh.checkout: the refresh rewrites tier-candidates.json in a working copy, and the Nix store copy is read-only, so a job with no checkout would fail after both network fetches rather than before them.";
+        }
       ]
       ++ fallbackTier.assertions;
 
@@ -134,35 +151,17 @@ in
         tierRefresh
       ];
 
-      launchd.agents.litellm-local = {
-        enable = true;
-        config = {
-          Label = "dev.litellm-local";
-          ProgramArguments = [ "${proxyScript}" ];
-          RunAtLoad = true;
-          KeepAlive = true;
-          # Throttle restarts so a bad config or an unreadable secret file
-          # fails visibly in the log instead of spinning.
-          ThrottleInterval = 30;
-          ProcessType = "Background";
-          EnvironmentVariables = {
-            # Not a secret — the router URL is a plain address, so it needs no
-            # exec-time file read.
-            LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
-            HOME = config.home.homeDirectory;
-          }
-          # LiteLLM reads its OWN names here — `OTEL_EXPORTER` / `OTEL_ENDPOINT`
-          # — not the standard OTEL_EXPORTER_OTLP_* pair. Setting the standard
-          # names instead leaves the callback pointed at its loopback default
-          # and exporting nowhere, with no error. Endpoint carries the full
-          # signal path because LiteLLM posts it verbatim.
-          // lib.optionalAttrs (telemetryTracesEndpoint != null) {
-            OTEL_EXPORTER = "otlp_http";
-            OTEL_ENDPOINT = telemetryTracesEndpoint;
-          };
-          StandardOutPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.log";
-          StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.error.log";
-        };
+      launchd.agents = import ./launchd.nix {
+        inherit
+          config
+          lib
+          cfg
+          aiStack
+          proxyScript
+          tierRefreshJob
+          tierRefreshScript
+          refreshCandidates
+          ;
       };
 
       # Client-side environment for the OpenAI-compatible CLIs.

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -54,6 +54,11 @@ let
   aiStack = config.services.aiStack;
   versions = import ../../lib/versions.nix;
 
+  # Cost-ordered fallback chain for the subagent tier. Its own file to stay
+  # under the .file-size.yml ceiling; see that file for why a chain replaced a
+  # single pinned model.
+  fallbackTier = import ./fallback-tier.nix { inherit lib; };
+
   # `os.environ/NAME` is LiteLLM's own indirection: the literal string is what
   # goes in the config file, and LiteLLM resolves it from the process
   # environment at load time. That is what keeps the router bearer out of the
@@ -87,13 +92,42 @@ let
           api_key = "os.environ/OPENAI_API_KEY";
         };
       }
-    ];
+    ]
+    # Named tier groups come after the wildcards deliberately: an explicit
+    # model_name always wins over `*`, so ordering here is documentation, not
+    # routing. Naming them at all is the point — `*` would resolve
+    # `subagent-free` upstream, where the alias may not exist.
+    ++ fallbackTier.modelList;
 
     litellm_settings = {
       # Clients disagree about which sampling params they send; dropping the
       # ones a given backend rejects keeps a role swap from breaking a client.
       drop_params = true;
       model_group_settings.forward_client_headers_to_llm_api = [ "claude-*" ];
+
+      # Retry a transient upstream failure before declaring the group down.
+      # This is the cheap half of "never let it die": most 5xx and connection
+      # resets clear on a retry, and only a persistent failure should spend a
+      # fallback.
+      num_retries = 3;
+
+      # The cost-ordered chain. `[{group: [fallback, ...]}]` is LiteLLM's own
+      # shape (proxy_server_config.yaml), and the same shape the upstream
+      # router already reports back in its error payloads.
+      #
+      # Scoped to the tier groups on purpose — there is deliberately NO
+      # `default_fallbacks` here. A blanket default would also catch
+      # `claude-*`, silently answering a main session from a free model when
+      # Anthropic rate-limits. Losing the request is recoverable; not noticing
+      # the model changed underneath a long session is not. The main tier gets
+      # retries and a context-window fallback, never a silent quality swap.
+      fallbacks = fallbackTier.fallbacks;
+
+      # A context-window overflow is unambiguous — the request cannot succeed
+      # as sent, and a larger window is strictly better rather than a
+      # downgrade. That makes it the one case where routing the main tier
+      # elsewhere is safe.
+      context_window_fallbacks = [ { "claude-*" = [ "subagent-cheap" ]; } ];
     };
   };
 
@@ -105,6 +139,21 @@ let
   # building it from source drags a large Python test closure (the rq test
   # suite among it) into every CI and workstation rebuild.
   uvPythonVersion = (import ../../lib/python.nix { inherit pkgs; }).pythonVersion;
+
+  # Liveness probe for the fallback chain. The chain's members are named here
+  # so the command needs no arguments in the common case — running it bare
+  # checks exactly what this host is configured to fall back through.
+  fallbackProbe = pkgs.writeShellApplication {
+    name = "litellm-fallback-probe";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+    ];
+    text = ''
+      exec ${./../scripts/litellm-fallback-probe.sh} \
+        "''${@:-${lib.concatStringsSep " " fallbackTier.names}}"
+    '';
+  };
 
   # launchd agents get no shell init, so the wrapper reads the router bearer
   # from its file itself. This is also why the assertion below requires
@@ -140,7 +189,10 @@ in
           assertion = aiStack.llmEndpointTokenFile != null && aiStack.llmEndpointTokenFile != "";
           message = "programs.litellmLocal.enable requires services.aiStack.llmEndpointTokenFile: the proxy runs as a launchd agent, which has no shell init, so services.aiStack.llmEndpointBearerFromEnv cannot reach it. Point llmEndpointTokenFile at the file holding the router bearer.";
         }
-      ];
+      ]
+      ++ fallbackTier.assertions;
+
+      home.packages = [ fallbackProbe ];
 
       launchd.agents.litellm-local = {
         enable = true;

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -158,6 +158,7 @@ in
           cfg
           aiStack
           proxyScript
+          telemetryTracesEndpoint
           tierRefreshJob
           tierRefreshScript
           refreshCandidates

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -149,7 +149,11 @@ let
       # as sent, and a larger window is strictly better rather than a
       # downgrade. That makes it the one case where routing the main tier
       # elsewhere is safe.
-      context_window_fallbacks = [ { "claude-*" = [ "subagent-cheap" ]; } ];
+      # Target is the tier's OWN entry point, never a literal: the head group
+      # is named once in fallback-tier.nix and a refresh reorders what sits
+      # behind it. A hardcoded name here ("subagent-cheap") was not an emitted
+      # model_list group at all, so it failed the explicit-group check.
+      context_window_fallbacks = [ { "claude-*" = [ fallbackTier.entryPoint ]; } ];
     }
     # Every non-Anthropic call this host makes traverses this proxy, so with no
     # callback the entire local fabric is an observability blind spot.

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -81,160 +81,31 @@ let
     "opentelemetry-exporter-otlp"
   ];
 
-  # `os.environ/NAME` is LiteLLM's own indirection: the literal string is what
-  # goes in the config file, and LiteLLM resolves it from the process
-  # environment at load time. That is what keeps the router bearer out of the
-  # store.
-  proxyConfig = {
-    model_list = [
-      {
-        model_name = "claude-*";
-        # No api_key, deliberately: this deployment is reached with the OAuth
-        # bearer the calling client already holds, forwarded by the scoped rule
-        # below. An api_key here would override that bearer and bill the wrong
-        # account.
-        #
-        # LiteLLM only treats a client bearer as forwardable OAuth when it
-        # carries the `sk-ant-oat` prefix (see its anthropic common_utils
-        # optionally_handle_anthropic_oauth). A client sending any other token
-        # shape therefore gets no credential on this leg rather than the wrong
-        # one — the failure is a 401, not a silent mis-auth.
-        #
-        # `anthropic/claude-*`, not `anthropic/*`: the wildcard substitutes only
-        # the part the pattern matched, so `anthropic/*` turned a request for
-        # `claude-opus-5` into an upstream request for `opus-5`, which Anthropic
-        # rejects as an unknown model.
-        litellm_params.model = "anthropic/claude-*";
-      }
-      {
-        model_name = "*";
-        litellm_params = {
-          model = "openai/*";
-          api_base = "os.environ/LLM_ROUTER_URL";
-          api_key = "os.environ/OPENAI_API_KEY";
-        };
-      }
-    ]
-    # Named tier groups come after the wildcards deliberately: an explicit
-    # model_name always wins over `*`, so ordering here is documentation, not
-    # routing. Naming them at all is the point — `*` would resolve
-    # `subagent-free` upstream, where the alias may not exist.
-    ++ fallbackTier.modelList;
-
-    litellm_settings = {
-      # Clients disagree about which sampling params they send; dropping the
-      # ones a given backend rejects keeps a role swap from breaking a client.
-      drop_params = true;
-      model_group_settings.forward_client_headers_to_llm_api = [ "claude-*" ];
-
-      # Retry a transient upstream failure before declaring the group down.
-      # This is the cheap half of "never let it die": most 5xx and connection
-      # resets clear on a retry, and only a persistent failure should spend a
-      # fallback.
-      num_retries = 3;
-
-      # The cost-ordered chain. `[{group: [fallback, ...]}]` is LiteLLM's own
-      # shape (proxy_server_config.yaml), and the same shape the upstream
-      # router already reports back in its error payloads.
-      #
-      # Scoped to the tier groups on purpose — there is deliberately NO
-      # `default_fallbacks` here. A blanket default would also catch
-      # `claude-*`, silently answering a main session from a free model when
-      # Anthropic rate-limits. Losing the request is recoverable; not noticing
-      # the model changed underneath a long session is not. The main tier gets
-      # retries and a context-window fallback, never a silent quality swap.
-      fallbacks = fallbackTier.fallbacks;
-
-      # A context-window overflow is unambiguous — the request cannot succeed
-      # as sent, and a larger window is strictly better rather than a
-      # downgrade. That makes it the one case where routing the main tier
-      # elsewhere is safe.
-      # Target is the tier's OWN entry point, never a literal: the head group
-      # is named once in fallback-tier.nix and a refresh reorders what sits
-      # behind it. A hardcoded name here ("subagent-cheap") was not an emitted
-      # model_list group at all, so it failed the explicit-group check.
-      context_window_fallbacks = [ { "claude-*" = [ fallbackTier.entryPoint ]; } ];
-    }
-    # Every non-Anthropic call this host makes traverses this proxy, so with no
-    # callback the entire local fabric is an observability blind spot.
-    #
-    # `otel`, NOT `langfuse` — a deliberate match with the shared router rather
-    # than a second mechanism. LiteLLM's `langfuse` callback needs the v2 SDK
-    # and errors on init against the v3 that pip resolves today; the collector
-    # already fans traces out to Langfuse, so one emitter on one path reaches
-    # the same sink with nothing extra to keep in step. It also means this
-    # proxy needs no Langfuse credential of its own.
-    #
-    # Only ever set when there is somewhere to send them: an OTLP exporter with
-    # no endpoint falls back to a conventional loopback address and exports
-    # into a black hole, which is exactly the failure this repo already fixed
-    # once for Claude Code. No endpoint, no callback.
-    // lib.optionalAttrs (telemetryTracesEndpoint != null) { callbacks = [ "otel" ]; };
+  # What the proxy serves, and how each group authenticates. Its own file; the
+  # credential-forwarding scope that keeps a client bearer off the router leg
+  # is documented there.
+  proxyConfig = import ./proxy-config.nix {
+    inherit lib fallbackTier telemetryTracesEndpoint;
   };
 
   configYaml = (pkgs.formats.yaml { }).generate "litellm-local-config.yaml" proxyConfig;
 
-  # The proxy runs from a uvx environment pinned to the Renovate-tracked release
-  # in lib/versions.nix, the same way the MLX stack does, rather than from
-  # nixpkgs' litellm: nixpkgs lags the upstream release train by months, and
-  # building it from source drags a large Python test closure (the rq test
-  # suite among it) into every CI and workstation rebuild.
-  uvPythonVersion = (import ../../lib/python.nix { inherit pkgs; }).pythonVersion;
-
-  # Liveness probe for the fallback chain. The chain's members are named here
-  # so the command needs no arguments in the common case — running it bare
-  # checks exactly what this host is configured to fall back through.
-  fallbackProbe = pkgs.writeShellApplication {
-    name = "litellm-fallback-probe";
-    runtimeInputs = [
-      pkgs.curl
-      pkgs.python3
-    ];
-    # The chain is passed as an environment variable, not as default
-    # arguments: `"''${@:-a b c}"` collapses the default into ONE argument, so
-    # the probe asked for a model literally named "a b c" and got a 404 that
-    # looked like a dead chain. Word-splitting the default belongs in the
-    # script, which is also where the no-inline-shell rule wants it.
-    text = ''
-      LITELLM_FALLBACK_CHAIN=${lib.escapeShellArg (lib.concatStringsSep " " fallbackTier.names)} \
-        exec ${./../scripts/litellm-fallback-probe.sh} "$@"
-    '';
+  # The launchd entry point plus the two operator commands.
+  commands = import ./commands.nix {
+    inherit
+      pkgs
+      lib
+      aiStack
+      cfg
+      versions
+      configYaml
+      fallbackTier
+      telemetryTracesEndpoint
+      otelPackages
+      ;
   };
+  inherit (commands) fallbackProbe tierRefresh proxyScript;
 
-  # Regenerates ./tier-candidates.json from the live catalog. It writes into a
-  # CHECKOUT, not the store, so the candidates path is a required argument
-  # rather than baked in — a wrapper pointing at the read-only store copy would
-  # fail at the last step, after both network fetches.
-  tierRefresh = pkgs.writeShellApplication {
-    name = "litellm-tier-refresh";
-    runtimeInputs = [
-      pkgs.curl
-      pkgs.python3
-    ];
-    text = ''
-      exec ${./../scripts/litellm-tier-refresh.sh} "$@"
-    '';
-  };
-
-  # launchd agents get no shell init, so the wrapper reads the router bearer
-  # from its file itself. This is also why the assertion below requires
-  # llmEndpointTokenFile: llmEndpointBearerFromEnv provisions the bearer into
-  # an interactive shell, which this agent never has.
-  proxyScript = pkgs.writeShellScript "litellm-local-start" ''
-    set -euo pipefail
-    OPENAI_API_KEY="$(cat ${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)})"
-    export OPENAI_API_KEY
-    exec ${pkgs.uv}/bin/uvx --python ${uvPythonVersion} \
-      --from "litellm[proxy]==${versions.litellm}" \
-      ${
-        lib.concatMapStringsSep " " (p: "--with ${lib.escapeShellArg p}") (
-          lib.optionals (telemetryTracesEndpoint != null) otelPackages
-        )
-      } litellm \
-      --config ${configYaml} \
-      --host 127.0.0.1 \
-      --port ${toString cfg.port}
-  '';
 in
 {
   imports = [ ./options.nix ];

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -47,6 +47,7 @@
   config,
   pkgs,
   lib,
+  userConfig,
   ...
 }:
 let
@@ -58,6 +59,27 @@ let
   # under the .file-size.yml ceiling; see that file for why a chain replaced a
   # single pinned model.
   fallbackTier = import ./fallback-tier.nix { inherit lib; };
+
+  # Reuses the maintainer profile's single traces endpoint rather than adding a
+  # second one: this proxy's spans belong on the same path as Claude Code's and
+  # Codex's, and one endpoint is one thing to keep correct. Null (the default,
+  # and the only value a fresh consumer has) disables the callback entirely.
+  #
+  # `userConfig` is a MODULE ARGUMENT, not `config.userConfig`. Reading it off
+  # `config` returns nothing and the `or null` swallows that into "telemetry is
+  # off" — the config renders cleanly, the agent starts, and it exports nothing,
+  # with no error anywhere. Same shape as the codex module, deliberately.
+  telemetryEnabled =
+    (userConfig.telemetry.enable or false) && (userConfig.telemetry.tracesEndpoint or null) != null;
+  telemetryTracesEndpoint = if telemetryEnabled then userConfig.telemetry.tracesEndpoint else null;
+
+  # LiteLLM's OTLP callback lives behind these three packages; litellm[proxy]
+  # does not pull them. Same set the shared router installs, so the two agree.
+  otelPackages = [
+    "opentelemetry-api"
+    "opentelemetry-sdk"
+    "opentelemetry-exporter-otlp"
+  ];
 
   # `os.environ/NAME` is LiteLLM's own indirection: the literal string is what
   # goes in the config file, and LiteLLM resolves it from the process
@@ -128,7 +150,22 @@ let
       # downgrade. That makes it the one case where routing the main tier
       # elsewhere is safe.
       context_window_fallbacks = [ { "claude-*" = [ "subagent-cheap" ]; } ];
-    };
+    }
+    # Every non-Anthropic call this host makes traverses this proxy, so with no
+    # callback the entire local fabric is an observability blind spot.
+    #
+    # `otel`, NOT `langfuse` — a deliberate match with the shared router rather
+    # than a second mechanism. LiteLLM's `langfuse` callback needs the v2 SDK
+    # and errors on init against the v3 that pip resolves today; the collector
+    # already fans traces out to Langfuse, so one emitter on one path reaches
+    # the same sink with nothing extra to keep in step. It also means this
+    # proxy needs no Langfuse credential of its own.
+    #
+    # Only ever set when there is somewhere to send them: an OTLP exporter with
+    # no endpoint falls back to a conventional loopback address and exports
+    # into a black hole, which is exactly the failure this repo already fixed
+    # once for Claude Code. No endpoint, no callback.
+    // lib.optionalAttrs (telemetryTracesEndpoint != null) { callbacks = [ "otel" ]; };
   };
 
   configYaml = (pkgs.formats.yaml { }).generate "litellm-local-config.yaml" proxyConfig;
@@ -149,9 +186,14 @@ let
       pkgs.curl
       pkgs.python3
     ];
+    # The chain is passed as an environment variable, not as default
+    # arguments: `"''${@:-a b c}"` collapses the default into ONE argument, so
+    # the probe asked for a model literally named "a b c" and got a 404 that
+    # looked like a dead chain. Word-splitting the default belongs in the
+    # script, which is also where the no-inline-shell rule wants it.
     text = ''
-      exec ${./../scripts/litellm-fallback-probe.sh} \
-        "''${@:-${lib.concatStringsSep " " fallbackTier.names}}"
+      LITELLM_FALLBACK_CHAIN=${lib.escapeShellArg (lib.concatStringsSep " " fallbackTier.names)} \
+        exec ${./../scripts/litellm-fallback-probe.sh} "$@"
     '';
   };
 
@@ -164,7 +206,12 @@ let
     OPENAI_API_KEY="$(cat ${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)})"
     export OPENAI_API_KEY
     exec ${pkgs.uv}/bin/uvx --python ${uvPythonVersion} \
-      --from "litellm[proxy]==${versions.litellm}" litellm \
+      --from "litellm[proxy]==${versions.litellm}" \
+      ${
+        lib.concatMapStringsSep " " (p: "--with ${lib.escapeShellArg p}") (
+          lib.optionals (telemetryTracesEndpoint != null) otelPackages
+        )
+      } litellm \
       --config ${configYaml} \
       --host 127.0.0.1 \
       --port ${toString cfg.port}
@@ -210,6 +257,15 @@ in
             # exec-time file read.
             LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
             HOME = config.home.homeDirectory;
+          }
+          # LiteLLM reads its OWN names here — `OTEL_EXPORTER` / `OTEL_ENDPOINT`
+          # — not the standard OTEL_EXPORTER_OTLP_* pair. Setting the standard
+          # names instead leaves the callback pointed at its loopback default
+          # and exporting nowhere, with no error. Endpoint carries the full
+          # signal path because LiteLLM posts it verbatim.
+          // lib.optionalAttrs (telemetryTracesEndpoint != null) {
+            OTEL_EXPORTER = "otlp_http";
+            OTEL_ENDPOINT = telemetryTracesEndpoint;
           };
           StandardOutPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.log";
           StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/litellm-local/litellm-local.error.log";

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -197,6 +197,21 @@ let
     '';
   };
 
+  # Regenerates ./tier-candidates.json from the live catalog. It writes into a
+  # CHECKOUT, not the store, so the candidates path is a required argument
+  # rather than baked in — a wrapper pointing at the read-only store copy would
+  # fail at the last step, after both network fetches.
+  tierRefresh = pkgs.writeShellApplication {
+    name = "litellm-tier-refresh";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+    ];
+    text = ''
+      exec ${./../scripts/litellm-tier-refresh.sh} "$@"
+    '';
+  };
+
   # launchd agents get no shell init, so the wrapper reads the router bearer
   # from its file itself. This is also why the assertion below requires
   # llmEndpointTokenFile: llmEndpointBearerFromEnv provisions the bearer into
@@ -239,7 +254,10 @@ in
       ]
       ++ fallbackTier.assertions;
 
-      home.packages = [ fallbackProbe ];
+      home.packages = [
+        fallbackProbe
+        tierRefresh
+      ];
 
       launchd.agents.litellm-local = {
         enable = true;

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -1,79 +1,46 @@
-# Cost-ordered fallback tier for the local proxy.
+# Cost-ordered fallback tier for the local proxy, built from generated data.
 #
-# Split out of ./default.nix to stay under the 12KB ceiling in .file-size.yml
-# (split rather than exempt, the same pattern the mlx checks use).
+# WHY A CHAIN: a single hardcoded subagent model dies silently. On 2026-08-28
+# the router's `subagent` alias still resolved to `openrouter/stealth/ox-alpha`
+# whose testing period had ended — every call returned 404, and the router
+# reported `Available Model Group Fallbacks=None`. Nothing noticed until a call
+# was made by hand. One name in one place is a single point of failure.
 #
-# WHY THIS EXISTS, in one sentence: a single hardcoded subagent model dies
-# silently. On 2026-08-28 the router's `subagent` alias still resolved to
-# `openrouter/stealth/ox-alpha`, whose testing period had ended — every call
-# returned 404 with "Thank you for participating in the Stealth Ox Alpha
-# testing period", and the upstream router reported
-# `Available Model Group Fallbacks=None` for that group. Nothing noticed until
-# a call was made by hand. One name in one place is a single point of failure;
-# an ordered chain plus a liveness check is not.
+# WHY GENERATED: the first hand-written version of this file recorded
+# deepseek-v4-flash at $0.030/$0.100 with a 1,310,720-token window. One day
+# later the catalog said $0.087/$0.173 and 1,048,576. A price table maintained
+# by hand is wrong almost immediately, and a chain ordered by wrong prices is
+# not cost-ordered. `litellm-tier-refresh` regenerates ./tier-candidates.json
+# from the live OpenRouter catalog intersected with what the upstream router
+# will actually serve; this file only assembles what that produced.
 #
-# ORDERING IS BY COST, cheapest first. LiteLLM walks the list in order and
-# stops at the first member that answers, so the cheapest capable tier wins
-# and the expensive one is only ever reached when everything above it is down.
+# THE HEAD IS ALWAYS NAMED `subagent`. Consumers name that one string forever
+# and a refresh reorders what sits behind it without touching them. It also
+# shadows the upstream router's own `subagent` alias — an explicit model_list
+# group beats the `*` wildcard — so the retired alias cannot reach this host.
 #
-# The window matters as much as the price. Measured subagent context runs to
-# ~284k tokens at p90, so a 200k-window model truncates real work. Every
-# member below therefore advertises >= 262k input tokens; that is a hard
-# selection criterion, not a preference.
-#
-# Prices are per Mtok (input/output) as published by the OpenRouter catalog on
-# 2026-08-28, recorded so a future reader can tell whether the ordering still
-# reflects reality. They are a snapshot, NOT a contract — the
-# `litellm-fallback-probe` command verifies that a member still ANSWERS, never
-# what it costs. Re-rank when the catalog moves; it is keyless at
-# https://openrouter.ai/api/v1/models, so re-ranking needs no credential.
+# WHAT THIS FILE CANNOT PROVE: that a member still answers. Catalog metadata is
+# a claim, not behaviour — ox-alpha resolved cleanly in /v1/model/info for days
+# after it stopped serving. `litellm-fallback-probe` sends a real completion to
+# every member and is the only check that settles it.
 { lib }:
 let
-  # Each member: the model_name this proxy exposes, the upstream id the router
-  # resolves, and the evidence that earned it a place in the chain.
-  members = [
-    {
-      name = "subagent-free";
-      upstream = "nvidia/nemotron-3-ultra-550b-a55b:free";
-      # $0/$0 per Mtok, 1,000,000-token window.
-      # Verified live through this proxy 2026-08-28: finish_reason=stop.
-      costPerMtok = "0/0";
-      minInputTokens = 1000000;
-    }
-    {
-      name = "subagent-cheap";
-      upstream = "deepseek/deepseek-v4-flash";
-      # $0.030/$0.100 per Mtok, 1,310,720-token window — the cheapest paid
-      # model in the catalog that clears the window requirement by a wide
-      # margin. Verified live through this proxy 2026-08-28.
-      costPerMtok = "0.030/0.100";
-      minInputTokens = 1310720;
-    }
-    {
-      name = "subagent-capable";
-      upstream = "minimax/minimax-m3";
-      # Last non-Anthropic rung: a stronger model for when the two cheaper
-      # tiers are both refusing. Verified live through this proxy 2026-08-28.
-      costPerMtok = "see-catalog";
-      minInputTokens = 262144;
-    }
-  ];
+  data = builtins.fromJSON (builtins.readFile ./tier-candidates.json);
 
-  # The window every member must clear, from measured p90 subagent context.
-  # An entry that does not clear it truncates real work rather than failing
-  # loudly, which is the worse failure — so this is asserted, not documented.
-  requiredInputTokens = 262144;
+  inherit (data) policy members;
+  requiredInputTokens = policy.requiredInputTokens;
 
   routerParams = member: {
     model = "openai/${member.upstream}";
     api_base = "os.environ/LLM_ROUTER_URL";
     api_key = "os.environ/OPENAI_API_KEY";
   };
+
+  isFree = m: m.promptCostPerMtok == 0 && m.completionCostPerMtok == 0;
 in
 rec {
-  inherit members requiredInputTokens;
+  inherit members requiredInputTokens policy;
 
-  # model_list entries this tier contributes, in cost order.
   modelList = map (m: {
     model_name = m.name;
     litellm_params = routerParams m;
@@ -85,21 +52,20 @@ rec {
   entryPoint = builtins.head names;
   chain = builtins.tail names;
 
-  # `fallbacks` is a list of single-key attrsets, `[{group: [fb, ...]}]` —
-  # the shape LiteLLM's own proxy_server_config.yaml uses and the shape the
-  # upstream router already reports in its error payloads. Each rung falls
-  # through to every cheaper-than-nothing rung below it, so the chain still
-  # completes when the failure starts partway down.
+  # `[{group: [fb, ...]}]` — the shape LiteLLM's own proxy_server_config.yaml
+  # uses and the shape the upstream router reports in its error payloads. Each
+  # rung falls through to every rung below it, so the chain still completes
+  # when the failure starts partway down.
   fallbacks = lib.imap0 (i: name: { ${name} = lib.drop (i + 1) names; }) (lib.init names);
 
   assertions = [
     {
-      assertion = lib.all (m: m.minInputTokens >= requiredInputTokens) members;
+      assertion = lib.all (m: m.contextLength >= requiredInputTokens) members;
       message =
         "litellm-local: every fallback-tier member must advertise at least "
         + "${toString requiredInputTokens} input tokens (measured p90 subagent "
         + "context is ~284k; a smaller window truncates work instead of "
-        + "failing loudly).";
+        + "failing loudly). Re-run litellm-tier-refresh.";
     }
     {
       assertion = lib.length members >= 2;
@@ -111,6 +77,38 @@ rec {
     {
       assertion = lib.length (lib.unique names) == lib.length names;
       message = "litellm-local: fallback-tier member names must be unique.";
+    }
+    {
+      assertion = entryPoint == "subagent";
+      message =
+        "litellm-local: the head of the fallback chain must be named "
+        + "`subagent` so consumers never change when the ranking does, and so "
+        + "it shadows the upstream router's retired alias of the same name.";
+    }
+    {
+      # Free models share ONE upstream quota pool. A chain made only of them
+      # has a single point of failure wearing several names: exhaust the daily
+      # free cap and every rung dies in the same instant.
+      assertion = policy.paidTail == 0 || lib.any (m: !isFree m) members;
+      message =
+        "litellm-local: policy.paidTail requires at least one billing model in "
+        + "the chain — an all-free chain dies all at once when the shared "
+        + "OpenRouter free quota is spent, which is the failure this tier "
+        + "exists to prevent.";
+    }
+    {
+      # Ordering is the entire value of the tier; an unsorted list still works
+      # and silently spends money it did not need to.
+      assertion =
+        let
+          costs = map (m: m.promptCostPerMtok + m.completionCostPerMtok) members;
+        in
+        costs == lib.sort (a: b: a < b) costs;
+      message =
+        "litellm-local: fallback-tier members must be ordered cheapest-first; "
+        + "LiteLLM walks the list in order, so an unsorted chain reaches for an "
+        + "expensive model before a cheaper one that would have served. "
+        + "Re-run litellm-tier-refresh rather than reordering by hand.";
     }
   ];
 }

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -1,0 +1,116 @@
+# Cost-ordered fallback tier for the local proxy.
+#
+# Split out of ./default.nix to stay under the 12KB ceiling in .file-size.yml
+# (split rather than exempt, the same pattern the mlx checks use).
+#
+# WHY THIS EXISTS, in one sentence: a single hardcoded subagent model dies
+# silently. On 2026-08-28 the router's `subagent` alias still resolved to
+# `openrouter/stealth/ox-alpha`, whose testing period had ended — every call
+# returned 404 with "Thank you for participating in the Stealth Ox Alpha
+# testing period", and the upstream router reported
+# `Available Model Group Fallbacks=None` for that group. Nothing noticed until
+# a call was made by hand. One name in one place is a single point of failure;
+# an ordered chain plus a liveness check is not.
+#
+# ORDERING IS BY COST, cheapest first. LiteLLM walks the list in order and
+# stops at the first member that answers, so the cheapest capable tier wins
+# and the expensive one is only ever reached when everything above it is down.
+#
+# The window matters as much as the price. Measured subagent context runs to
+# ~284k tokens at p90, so a 200k-window model truncates real work. Every
+# member below therefore advertises >= 262k input tokens; that is a hard
+# selection criterion, not a preference.
+#
+# Prices are per Mtok (input/output) as published by the OpenRouter catalog on
+# 2026-08-28, recorded so a future reader can tell whether the ordering still
+# reflects reality. They are a snapshot, NOT a contract — the
+# `litellm-fallback-probe` command verifies that a member still ANSWERS, never
+# what it costs. Re-rank when the catalog moves; it is keyless at
+# https://openrouter.ai/api/v1/models, so re-ranking needs no credential.
+{ lib }:
+let
+  # Each member: the model_name this proxy exposes, the upstream id the router
+  # resolves, and the evidence that earned it a place in the chain.
+  members = [
+    {
+      name = "subagent-free";
+      upstream = "nvidia/nemotron-3-ultra-550b-a55b:free";
+      # $0/$0 per Mtok, 1,000,000-token window.
+      # Verified live through this proxy 2026-08-28: finish_reason=stop.
+      costPerMtok = "0/0";
+      minInputTokens = 1000000;
+    }
+    {
+      name = "subagent-cheap";
+      upstream = "deepseek/deepseek-v4-flash";
+      # $0.030/$0.100 per Mtok, 1,310,720-token window — the cheapest paid
+      # model in the catalog that clears the window requirement by a wide
+      # margin. Verified live through this proxy 2026-08-28.
+      costPerMtok = "0.030/0.100";
+      minInputTokens = 1310720;
+    }
+    {
+      name = "subagent-capable";
+      upstream = "minimax/minimax-m3";
+      # Last non-Anthropic rung: a stronger model for when the two cheaper
+      # tiers are both refusing. Verified live through this proxy 2026-08-28.
+      costPerMtok = "see-catalog";
+      minInputTokens = 262144;
+    }
+  ];
+
+  # The window every member must clear, from measured p90 subagent context.
+  # An entry that does not clear it truncates real work rather than failing
+  # loudly, which is the worse failure — so this is asserted, not documented.
+  requiredInputTokens = 262144;
+
+  routerParams = member: {
+    model = "openai/${member.upstream}";
+    api_base = "os.environ/LLM_ROUTER_URL";
+    api_key = "os.environ/OPENAI_API_KEY";
+  };
+in
+rec {
+  inherit members requiredInputTokens;
+
+  # model_list entries this tier contributes, in cost order.
+  modelList = map (m: {
+    model_name = m.name;
+    litellm_params = routerParams m;
+  }) members;
+
+  names = map (m: m.name) members;
+
+  # The entry point clients name. Everything after it is the fallback chain.
+  entryPoint = builtins.head names;
+  chain = builtins.tail names;
+
+  # `fallbacks` is a list of single-key attrsets, `[{group: [fb, ...]}]` —
+  # the shape LiteLLM's own proxy_server_config.yaml uses and the shape the
+  # upstream router already reports in its error payloads. Each rung falls
+  # through to every cheaper-than-nothing rung below it, so the chain still
+  # completes when the failure starts partway down.
+  fallbacks = lib.imap0 (i: name: { ${name} = lib.drop (i + 1) names; }) (lib.init names);
+
+  assertions = [
+    {
+      assertion = lib.all (m: m.minInputTokens >= requiredInputTokens) members;
+      message =
+        "litellm-local: every fallback-tier member must advertise at least "
+        + "${toString requiredInputTokens} input tokens (measured p90 subagent "
+        + "context is ~284k; a smaller window truncates work instead of "
+        + "failing loudly).";
+    }
+    {
+      assertion = lib.length members >= 2;
+      message =
+        "litellm-local: the fallback tier needs at least two members — a "
+        + "single model is the single point of failure this tier exists to "
+        + "remove (see the ox-alpha note in fallback-tier.nix).";
+    }
+    {
+      assertion = lib.length (lib.unique names) == lib.length names;
+      message = "litellm-local: fallback-tier member names must be unique.";
+    }
+  ];
+}

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -28,7 +28,7 @@ let
   data = builtins.fromJSON (builtins.readFile ./tier-candidates.json);
 
   inherit (data) policy members;
-  requiredInputTokens = policy.requiredInputTokens;
+  inherit (policy) requiredInputTokens;
 
   routerParams = member: {
     model = "openai/${member.upstream}";

--- a/modules/litellm-local/launchd.nix
+++ b/modules/litellm-local/launchd.nix
@@ -19,6 +19,7 @@
   cfg,
   aiStack,
   proxyScript,
+  telemetryTracesEndpoint,
   tierRefreshJob,
   tierRefreshScript,
   refreshCandidates,
@@ -28,7 +29,7 @@ let
   logDir = "${config.home.homeDirectory}/Library/Logs/litellm-local";
 in
 {
-  launchd.agents.litellm-local = {
+  litellm-local = {
     enable = true;
     config = {
       Label = "dev.litellm-local";
@@ -63,7 +64,7 @@ in
   # proxy is KeepAlive and must never restart because a refresh failed,
   # and the refresh is a short interval job that must be allowed to fail
   # without taking traffic with it.
-  launchd.agents.litellm-tier-refresh = lib.mkIf refreshCfg.enable {
+  litellm-tier-refresh = lib.mkIf refreshCfg.enable {
     enable = true;
     config = {
       Label = "dev.litellm-tier-refresh";

--- a/modules/litellm-local/launchd.nix
+++ b/modules/litellm-local/launchd.nix
@@ -1,0 +1,96 @@
+# The two launchd agents the local proxy owns.
+#
+# Split out of ./default.nix to stay under the .file-size.yml ceiling and to
+# follow the per-module launchd.nix pattern already used by fabric and mlx.
+#
+# They are deliberately SEPARATE agents. The proxy is KeepAlive and serves live
+# traffic; the refresh is a short interval job that reaches two network
+# endpoints, one of which has been measured hanging intermittently. Folding the
+# refresh into the proxy would let a failed catalog fetch restart something that
+# was serving fine.
+#
+# Neither agent may carry a credential in `EnvironmentVariables`: launchd
+# agents get no shell init, so each reads the router bearer from its file at
+# exec time instead. `lib/checks/litellm-local.nix` asserts the proxy agent
+# carries no `OPENAI_API_KEY`.
+{
+  config,
+  lib,
+  cfg,
+  aiStack,
+  proxyScript,
+  tierRefreshJob,
+  tierRefreshScript,
+  refreshCandidates,
+}:
+let
+  refreshCfg = cfg.tierRefresh;
+  logDir = "${config.home.homeDirectory}/Library/Logs/litellm-local";
+in
+{
+  launchd.agents.litellm-local = {
+    enable = true;
+    config = {
+      Label = "dev.litellm-local";
+      ProgramArguments = [ "${proxyScript}" ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      # Throttle restarts so a bad config or an unreadable secret file
+      # fails visibly in the log instead of spinning.
+      ThrottleInterval = 30;
+      ProcessType = "Background";
+      EnvironmentVariables = {
+        # Not a secret — the router URL is a plain address, so it needs no
+        # exec-time file read.
+        LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
+        HOME = config.home.homeDirectory;
+      }
+      # LiteLLM reads its OWN names here — `OTEL_EXPORTER` / `OTEL_ENDPOINT`
+      # — not the standard OTEL_EXPORTER_OTLP_* pair. Setting the standard
+      # names instead leaves the callback pointed at its loopback default
+      # and exporting nowhere, with no error. Endpoint carries the full
+      # signal path because LiteLLM posts it verbatim.
+      // lib.optionalAttrs (telemetryTracesEndpoint != null) {
+        OTEL_EXPORTER = "otlp_http";
+        OTEL_ENDPOINT = telemetryTracesEndpoint;
+      };
+      StandardOutPath = "${logDir}/litellm-local.log";
+      StandardErrorPath = "${logDir}/litellm-local.error.log";
+    };
+  };
+
+  # Periodic re-ranking. Separate agent from the proxy on purpose: the
+  # proxy is KeepAlive and must never restart because a refresh failed,
+  # and the refresh is a short interval job that must be allowed to fail
+  # without taking traffic with it.
+  launchd.agents.litellm-tier-refresh = lib.mkIf refreshCfg.enable {
+    enable = true;
+    config = {
+      Label = "dev.litellm-tier-refresh";
+      ProgramArguments = [
+        "${lib.getExe tierRefreshJob}"
+        refreshCandidates
+        "${tierRefreshScript}"
+      ];
+      StartInterval = refreshCfg.interval;
+      # Not at load: a rebuild already re-reads the file it would rewrite,
+      # so firing on every login adds two network round trips and no
+      # information.
+      RunAtLoad = false;
+      ProcessType = "Background";
+      LowPriorityIO = true;
+      Nice = 10;
+      EnvironmentVariables = {
+        HOME = config.home.homeDirectory;
+        # Both are non-secret — an address and a PATH. The bearer itself is
+        # read from that file at exec time by the refresh script, never
+        # placed in a launchd environment, matching the proxy agent and the
+        # assertion in lib/checks/litellm-local.nix.
+        LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
+        LLM_ROUTER_TOKEN_FILE = toString aiStack.llmEndpointTokenFile;
+      };
+      StandardOutPath = "${logDir}/tier-refresh.log";
+      StandardErrorPath = "${logDir}/tier-refresh.error.log";
+    };
+  };
+}

--- a/modules/litellm-local/launchd.nix
+++ b/modules/litellm-local/launchd.nix
@@ -36,9 +36,20 @@ in
       ProgramArguments = [ "${proxyScript}" ];
       RunAtLoad = true;
       KeepAlive = true;
-      # Throttle restarts so a bad config or an unreadable secret file
-      # fails visibly in the log instead of spinning.
-      ThrottleInterval = 30;
+      # Throttle restarts so a bad config or an unreadable secret file fails
+      # visibly in the log instead of spinning.
+      #
+      # 10, not 30, and the difference is a live-session outage. Claude Code on
+      # this host reaches Anthropic THROUGH this proxy, so every restart is a
+      # hard outage for every session on the machine — and `darwin-rebuild`
+      # rewrites this plist, so any converge that touches this module bounces
+      # it. launchd will not restart a job sooner than ThrottleInterval after
+      # it stopped, so 30 turned a measured 3.2s startup into an outage of up
+      # to ~33s: long enough to outrun a client's retry budget and drop the
+      # session. Measured 2026-08-28 — readiness from cold start to a serving
+      # /v1/models is 3.2s, so 10s still leaves a crash loop slow enough to
+      # read in the log while cutting the worst case to ~13s.
+      ThrottleInterval = 10;
       ProcessType = "Background";
       EnvironmentVariables = {
         # Not a secret — the router URL is a plain address, so it needs no

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -73,6 +73,46 @@ in
       '';
     };
 
+    tierRefresh = {
+      enable = lib.mkEnableOption ''
+        a periodic re-ranking of the subagent fallback tier against the live
+        model catalog and the router's served set.
+
+        The job only rewrites `tier-candidates.json` in a working copy; nothing
+        reaches the running proxy until the next rebuild. That ordering is
+        deliberate — the job proposes a re-ranking and logs whether the
+        selection moved, and a human converges it. A timer that silently
+        repointed live subagent traffic would reintroduce the failure the
+        chain exists to remove: nobody notices the model changed
+      '';
+
+      checkout = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "/Users/you/git/nix-ai";
+        description = ''
+          Absolute path to a working copy of this repository. The refresh
+          rewrites `modules/litellm-local/tier-candidates.json` inside it.
+
+          Required when `tierRefresh.enable` is set, and it must be a checkout
+          rather than the Nix store path: the store copy is read-only, so a
+          job pointed at it would fail at the last step, after both network
+          fetches. The job fails loudly when this path does not exist.
+        '';
+      };
+
+      interval = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 86400;
+        description = ''
+          Seconds between refreshes. Daily by default: two HTTP GETs is cheap,
+          and it matches how fast the catalog actually moves — prices were
+          observed drifting within a single day, and a model's availability
+          within a week.
+        '';
+      };
+    };
+
     renderedConfig = lib.mkOption {
       type = lib.types.attrs;
       readOnly = true;

--- a/modules/litellm-local/proxy-config.nix
+++ b/modules/litellm-local/proxy-config.nix
@@ -1,0 +1,107 @@
+# The rendered LiteLLM configuration for the local proxy.
+#
+# Split out of ./default.nix to stay under the .file-size.yml ceiling, the same
+# reason ./fallback-tier.nix is its own file. The split is by responsibility:
+# this file decides WHAT the proxy serves and how each group authenticates,
+# ./commands.nix builds the executables, and default.nix wires the module.
+#
+# The safety property lives here, so read it here: `claude-*` is the only group
+# that receives the calling client's forwarded credentials, and the scoped
+# `model_group_settings.forward_client_headers_to_llm_api` list is the only
+# thing keeping that credential off the router leg. `lib/checks/litellm-local.nix`
+# asserts the list stays exactly `[ "claude-*" ]`.
+{
+  lib,
+  fallbackTier,
+  telemetryTracesEndpoint,
+}:
+# `os.environ/NAME` is LiteLLM's own indirection: the literal string is what
+# goes in the config file, and LiteLLM resolves it from the process
+# environment at load time. That is what keeps the router bearer out of the
+# store.
+{
+  model_list = [
+    {
+      model_name = "claude-*";
+      # No api_key, deliberately: this deployment is reached with the OAuth
+      # bearer the calling client already holds, forwarded by the scoped rule
+      # below. An api_key here would override that bearer and bill the wrong
+      # account.
+      #
+      # LiteLLM only treats a client bearer as forwardable OAuth when it
+      # carries the `sk-ant-oat` prefix (see its anthropic common_utils
+      # optionally_handle_anthropic_oauth). A client sending any other token
+      # shape therefore gets no credential on this leg rather than the wrong
+      # one — the failure is a 401, not a silent mis-auth.
+      #
+      # `anthropic/claude-*`, not `anthropic/*`: the wildcard substitutes only
+      # the part the pattern matched, so `anthropic/*` turned a request for
+      # `claude-opus-5` into an upstream request for `opus-5`, which Anthropic
+      # rejects as an unknown model.
+      litellm_params.model = "anthropic/claude-*";
+    }
+    {
+      model_name = "*";
+      litellm_params = {
+        model = "openai/*";
+        api_base = "os.environ/LLM_ROUTER_URL";
+        api_key = "os.environ/OPENAI_API_KEY";
+      };
+    }
+  ]
+  # Named tier groups come after the wildcards deliberately: an explicit
+  # model_name always wins over `*`, so ordering here is documentation, not
+  # routing. Naming them at all is the point — `*` would resolve
+  # `subagent-free` upstream, where the alias may not exist.
+  ++ fallbackTier.modelList;
+
+  litellm_settings = {
+    # Clients disagree about which sampling params they send; dropping the
+    # ones a given backend rejects keeps a role swap from breaking a client.
+    drop_params = true;
+    model_group_settings.forward_client_headers_to_llm_api = [ "claude-*" ];
+
+    # Retry a transient upstream failure before declaring the group down.
+    # This is the cheap half of "never let it die": most 5xx and connection
+    # resets clear on a retry, and only a persistent failure should spend a
+    # fallback.
+    num_retries = 3;
+
+    # The cost-ordered chain. `[{group: [fallback, ...]}]` is LiteLLM's own
+    # shape (proxy_server_config.yaml), and the same shape the upstream
+    # router already reports back in its error payloads.
+    #
+    # Scoped to the tier groups on purpose — there is deliberately NO
+    # `default_fallbacks` here. A blanket default would also catch
+    # `claude-*`, silently answering a main session from a free model when
+    # Anthropic rate-limits. Losing the request is recoverable; not noticing
+    # the model changed underneath a long session is not. The main tier gets
+    # retries and a context-window fallback, never a silent quality swap.
+    fallbacks = fallbackTier.fallbacks;
+
+    # A context-window overflow is unambiguous — the request cannot succeed
+    # as sent, and a larger window is strictly better rather than a
+    # downgrade. That makes it the one case where routing the main tier
+    # elsewhere is safe.
+    # Target is the tier's OWN entry point, never a literal: the head group
+    # is named once in fallback-tier.nix and a refresh reorders what sits
+    # behind it. A hardcoded name here ("subagent-cheap") was not an emitted
+    # model_list group at all, so it failed the explicit-group check.
+    context_window_fallbacks = [ { "claude-*" = [ fallbackTier.entryPoint ]; } ];
+  }
+  # Every non-Anthropic call this host makes traverses this proxy, so with no
+  # callback the entire local fabric is an observability blind spot.
+  #
+  # `otel`, NOT `langfuse` — a deliberate match with the shared router rather
+  # than a second mechanism. LiteLLM's `langfuse` callback needs the v2 SDK
+  # and errors on init against the v3 that pip resolves today; the collector
+  # already fans traces out to Langfuse, so one emitter on one path reaches
+  # the same sink with nothing extra to keep in step. It also means this
+  # proxy needs no Langfuse credential of its own.
+  #
+  # Only ever set when there is somewhere to send them: an OTLP exporter with
+  # no endpoint falls back to a conventional loopback address and exports
+  # into a black hole, which is exactly the failure this repo already fixed
+  # once for Claude Code. No endpoint, no callback.
+  // lib.optionalAttrs (telemetryTracesEndpoint != null) { callbacks = [ "otel" ]; };
+}

--- a/modules/litellm-local/proxy-config.nix
+++ b/modules/litellm-local/proxy-config.nix
@@ -77,7 +77,7 @@
     # Anthropic rate-limits. Losing the request is recoverable; not noticing
     # the model changed underneath a long session is not. The main tier gets
     # retries and a context-window fallback, never a silent quality swap.
-    fallbacks = fallbackTier.fallbacks;
+    inherit (fallbackTier) fallbacks;
 
     # A context-window overflow is unambiguous — the request cannot succeed
     # as sent, and a larger window is strictly better rather than a

--- a/modules/litellm-local/tier-candidates.json
+++ b/modules/litellm-local/tier-candidates.json
@@ -1,0 +1,36 @@
+{
+  "policy": {
+    "requiredInputTokens": 262144,
+    "memberCount": 3,
+    "paidTail": 1,
+    "pin": [],
+    "deny": []
+  },
+  "generatedAt": "2026-08-29T00:02:39Z",
+  "members": [
+    {
+      "name": "subagent",
+      "upstream": "nvidia/nemotron-3-ultra-550b-a55b:free",
+      "catalogId": "nvidia/nemotron-3-ultra-550b-a55b:free",
+      "contextLength": 1000000,
+      "promptCostPerMtok": 0.0,
+      "completionCostPerMtok": 0.0
+    },
+    {
+      "name": "subagent-fallback1",
+      "upstream": "deepseek/deepseek-v4-flash",
+      "catalogId": "deepseek/deepseek-v4-flash",
+      "contextLength": 1048576,
+      "promptCostPerMtok": 0.086,
+      "completionCostPerMtok": 0.172
+    },
+    {
+      "name": "subagent-fallback2",
+      "upstream": "openrouter/nvidia/nemotron-3.5-lightning",
+      "catalogId": "nvidia/nemotron-3.5-lightning",
+      "contextLength": 262144,
+      "promptCostPerMtok": 0.08,
+      "completionCostPerMtok": 0.2
+    }
+  ]
+}

--- a/modules/scripts/ai-stack-drift-check.sh
+++ b/modules/scripts/ai-stack-drift-check.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Compare the ai-stack registry's model ids against what each endpoint serves.
+#
+# WHY THIS EXISTS: the registry is generated from vars/ai-stack.nix at eval time
+# and installed on every activation, so it is never a stale FILE — but the ids
+# inside it are hand-written, and nothing has ever compared them to reality.
+# `~/.agents/skills/delegate-to-ai` tells every agent to trust this file and
+# never hardcode a physical model id, so a wrong id here misroutes every
+# delegated call.
+#
+# Note the ids are NOT written in vars/ai-stack.nix — every role there is null,
+# populated at evaluation time from services.aiStack.defaultLocalModelId, which
+# the consuming host resolves through the MLX catalog. So the value being
+# checked here crosses a repo boundary, which is exactly why no single repo's
+# CI could have caught it.
+#
+# WHAT DRIFT ACTUALLY LOOKS LIKE, measured 2026-08-28: seven of eight capability
+# roles named a model that llama-swap serves locally but the router does not.
+# Nothing was "broken" — a local caller worked fine — while every router-routed
+# caller got a 404 for the same role. That asymmetry is why this reports per
+# endpoint instead of a single pass/fail.
+#
+# Exit 1 on ANY drift, including a model that resolves at one endpoint but not
+# the other. That asymmetric case is real breakage for half the callers, and a
+# check that exited 0 on it would sit green in a timer while every routed
+# delegation 404'd — which is exactly the silence this whole effort exists to
+# end. It stays red until vars/ai-stack.nix is corrected, which is the point.
+set -euo pipefail
+
+REGISTRY="${AI_STACK_REGISTRY:-$HOME/.config/ai-stack/registry.json}"
+[ -f "$REGISTRY" ] || { echo "registry not found: $REGISTRY" >&2; exit 2; }
+
+work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
+
+fetch() { curl -sS --max-time 45 --retry 2 --retry-delay 5 --retry-all-errors "$@"; }
+
+local_ep=$(python3 -c 'import json,sys,os;print(json.load(open(sys.argv[1]))["endpoints"].get("mlx_local",""))' "$REGISTRY")
+router_ep=$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["endpoints"].get("router",""))' "$REGISTRY")
+
+# An endpoint that cannot be reached is recorded as unknown, never as empty.
+# Treating "unreachable" as "serves nothing" would report every model as drifted
+# the moment a host was down — an alarm that cries wolf gets muted, and a muted
+# drift check is worse than none.
+if [ -n "$local_ep" ] && fetch "$local_ep/models" > "$work/local.json" 2>/dev/null; then
+  local_ok=1
+else
+  local_ok=0
+fi
+
+router_base="${router_ep%/v1}"
+if [ -n "$router_ep" ] && [ -n "${LLM_ROUTER_TOKEN_FILE:-}" ] && [ -f "${LLM_ROUTER_TOKEN_FILE}" ] \
+  && fetch -H "Authorization: Bearer $(cat "$LLM_ROUTER_TOKEN_FILE")" \
+     "$router_base/v1/model/info" > "$work/router.json" 2>/dev/null; then
+  router_ok=1
+else
+  router_ok=0
+fi
+
+REGISTRY="$REGISTRY" LOCAL_OK="$local_ok" ROUTER_OK="$router_ok" \
+python3 - "$work/local.json" "$work/router.json" <<'PY'
+import json, os, sys
+
+reg = json.load(open(os.environ["REGISTRY"]))
+local_ok = os.environ["LOCAL_OK"] == "1"
+router_ok = os.environ["ROUTER_OK"] == "1"
+
+def ids(path, key):
+    try:
+        d = json.load(open(path))
+    except Exception:
+        return set()
+    out = set()
+    for row in d.get("data", []):
+        if key == "models":
+            out.add(row.get("id"))
+        else:
+            out.add(row.get("model_name"))
+            up = (row.get("litellm_params") or {}).get("model") or ""
+            # The router exposes the same model under a bare id and a
+            # provider-prefixed alias; both count as resolvable.
+            for pref in ("openai/", "openrouter/"):
+                if up.startswith(pref):
+                    out.add(up[len(pref):])
+    return {i for i in out if i}
+
+local_ids = ids(sys.argv[1], "models") if local_ok else set()
+router_ids = ids(sys.argv[2], "info") if router_ok else set()
+
+print("endpoints: local=%s  router=%s" % (
+    "reachable" if local_ok else "UNREACHABLE",
+    "reachable" if router_ok else "UNREACHABLE"))
+print()
+
+dead, split = [], []
+for role, model in sorted(reg.get("models", {}).items()):
+    l = "yes" if model in local_ids else ("--" if local_ok else "?")
+    r = "yes" if model in router_ids else ("--" if router_ok else "?")
+    print("%-16s %-52s local=%-4s router=%s" % (role, model, l, r))
+    if l == "--" and r == "--":
+        dead.append((role, model))
+    elif "--" in (l, r):
+        split.append((role, model, l, r))
+
+print()
+if split:
+    print("RESOLVES AT ONLY ONE ENDPOINT — a caller using the other gets a 404:")
+    for role, model, l, r in split:
+        print("  %-16s %s (missing from %s)" % (role, model, "router" if r == "--" else "local"))
+    print("  These roles all follow services.aiStack.defaultLocalModelId, which")
+    print("  resolves through the nix-ai MLX catalog. Change the catalog entry the")
+    print("  consuming host selects (nix-darwin), not vars/ai-stack.nix — every role")
+    print("  there is null by design and is populated at evaluation time.")
+    print()
+if dead:
+    print("RESOLVES NOWHERE:")
+    for role, model in dead:
+        print("  %-16s %s" % (role, model))
+if dead or split:
+    raise SystemExit(1)
+print("no drift: every role resolves at every reachable endpoint")
+PY

--- a/modules/scripts/litellm-fallback-probe.sh
+++ b/modules/scripts/litellm-fallback-probe.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Probe every member of the local proxy's cost-ordered fallback chain.
+#
+# This exists because a chain member can die WITHOUT any config changing.
+# On 2026-08-28 the router's `subagent` alias still resolved cleanly in
+# `/v1/model/info` while every actual completion returned 404 — the model's
+# preview period had ended upstream. Config inspection cannot see that; only a
+# real completion can. So this sends one, per member.
+#
+# Exit 0 only if EVERY member answers. A partial chain is still serving
+# traffic, which is exactly why it goes unnoticed until the last rung fails
+# too — so a dead member is an error here, not a warning.
+set -euo pipefail
+
+BASE="${LITELLM_LOCAL_URL:-http://127.0.0.1:4100}"
+TOKEN="${LITELLM_LOCAL_TOKEN:-local}"
+# Reasoning models spend output tokens before emitting content; too small a cap
+# returns finish_reason=length with empty content and looks like a failure.
+MAX_TOKENS="${PROBE_MAX_TOKENS:-200}"
+TIMEOUT="${PROBE_TIMEOUT:-120}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: ${0##*/} MODEL_NAME [MODEL_NAME ...]" >&2
+  exit 2
+fi
+
+failed=0
+for model in "$@"; do
+  printf '%-24s ' "$model"
+
+  body=$(printf '{"model":%s,"max_tokens":%s,"messages":[{"role":"user","content":"Reply with exactly: OK"}]}' \
+    "$(printf '%s' "$model" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
+    "$MAX_TOKENS")
+
+  # `|| true` so a curl failure is classified below rather than killing the
+  # loop under `set -e` — one dead member must not hide the rest of the chain.
+  response=$(curl -sS -m "$TIMEOUT" -X POST "$BASE/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -H "Authorization: Bearer $TOKEN" \
+    -d "$body" 2>&1) || true
+
+  verdict=$(printf '%s' "$response" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print("FAIL\tunparseable response: " + raw[:160].replace("\n", " "))
+    raise SystemExit
+if "error" in d:
+    print("FAIL\t" + str(d["error"].get("message", d["error"]))[:160].replace("\n", " "))
+    raise SystemExit
+try:
+    choice = d["choices"][0]
+except (KeyError, IndexError):
+    print("FAIL\tno choices in response")
+    raise SystemExit
+# A served response is the signal. Content may legitimately be empty when a
+# reasoning model spends the whole budget thinking, so finish_reason=length
+# with zero content is reported but NOT treated as a dead member.
+served = d.get("model") or "?"
+fin = choice.get("finish_reason")
+content = (choice.get("message") or {}).get("content") or ""
+note = "" if content.strip() else "  (empty content, finish_reason=%s)" % fin
+print("OK\tserved=%s%s" % (served, note))
+')
+
+  status=${verdict%%$'\t'*}
+  detail=${verdict#*$'\t'}
+  echo "$status  $detail"
+  [ "$status" = "OK" ] || failed=$((failed + 1))
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "" >&2
+  echo "$failed chain member(s) failed. A dead member does not surface on its own —" >&2
+  echo "traffic silently shifts to the next rung until the last one goes too." >&2
+  echo "Re-rank the chain in modules/litellm-local/fallback-tier.nix." >&2
+  exit 1
+fi
+
+echo ""
+echo "all $# chain member(s) served a completion"

--- a/modules/scripts/litellm-fallback-probe.sh
+++ b/modules/scripts/litellm-fallback-probe.sh
@@ -19,8 +19,17 @@ TOKEN="${LITELLM_LOCAL_TOKEN:-local}"
 MAX_TOKENS="${PROBE_MAX_TOKENS:-200}"
 TIMEOUT="${PROBE_TIMEOUT:-120}"
 
+# With no arguments, probe the chain this host is configured to fall through.
+# LITELLM_FALLBACK_CHAIN is a space-separated list; splitting it is intentional,
+# so word-splitting is enabled for exactly this expansion.
+if [ "$#" -eq 0 ]; then
+  # shellcheck disable=SC2086
+  set -- ${LITELLM_FALLBACK_CHAIN:-}
+fi
+
 if [ "$#" -eq 0 ]; then
   echo "usage: ${0##*/} MODEL_NAME [MODEL_NAME ...]" >&2
+  echo "   or: set LITELLM_FALLBACK_CHAIN to a space-separated list" >&2
   exit 2
 fi
 

--- a/modules/scripts/litellm-tier-refresh-job.sh
+++ b/modules/scripts/litellm-tier-refresh-job.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Timer entry point for the subagent fallback-tier refresh.
+#
+# The refresh itself only rewrites a JSON file in a CHECKOUT. Nothing reaches
+# the running proxy until someone rebuilds, and that ordering is deliberate:
+# this job PROPOSES a re-ranking, a human converges it. A timer that silently
+# repointed live subagent traffic at whatever model was cheapest this morning
+# is the same class of failure as the pinned model it replaced — nobody would
+# know the model changed until output quality did.
+#
+# So the job's real product is the log line. It says whether the selection
+# moved, and if it did, a rebuild is owed.
+set -euo pipefail
+
+CANDIDATES="${1:?candidates path required}"
+REFRESH="${2:?refresh script path required}"
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+log() { printf '%s %s\n' "$(ts)" "$*"; }
+
+# A missing checkout is the expected failure on a machine where the repo moved
+# or was never cloned, and it must be loud. A job that exits 0 having done
+# nothing is indistinguishable from one that ran and found no change — that
+# ambiguity is what let a stale alias survive for days.
+if [ ! -f "$CANDIDATES" ]; then
+  log "FATAL: candidates file not found: $CANDIDATES"
+  log "       Set programs.litellmLocal.tierRefresh.checkout to a working copy"
+  log "       of this repo, or disable programs.litellmLocal.tierRefresh.enable."
+  exit 1
+fi
+
+# The ordered list of upstream ids IS the selection. Prices move constantly and
+# a price-only change is not something a human needs to act on; a change to
+# which models serve traffic is.
+selection() {
+  python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception as e:
+    print("UNREADABLE:%s" % e); raise SystemExit
+print("\n".join("%s=%s" % (m.get("name"), m.get("upstream")) for m in d.get("members", [])))
+' "$1"
+}
+
+before=$(selection "$CANDIDATES")
+
+log "refreshing $CANDIDATES"
+if ! output=$("$REFRESH" "$CANDIDATES" 2>&1); then
+  log "FAILED: refresh exited non-zero"
+  printf '%s\n' "$output"
+  exit 1
+fi
+printf '%s\n' "$output"
+
+after=$(selection "$CANDIDATES")
+
+if [ "$before" = "$after" ]; then
+  log "selection unchanged"
+  exit 0
+fi
+
+log "SELECTION CHANGED — a rebuild is required before this takes effect"
+# diff exits 1 on difference, which is the expected path here, so it must not
+# trip `set -e`.
+diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") || true

--- a/modules/scripts/litellm-tier-refresh.sh
+++ b/modules/scripts/litellm-tier-refresh.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Re-rank the local proxy's fallback tier against the live OpenRouter catalog.
+#
+# WHY THIS IS GENERATED AND NOT HAND-WRITTEN: the catalog moves daily. The
+# first hand-written version of this tier recorded deepseek-v4-flash at
+# $0.030/$0.100 with a 1,310,720-token window; one day later the catalog said
+# $0.087/$0.173 and 1,048,576. A price table maintained by hand is wrong
+# almost immediately, and a chain ordered by wrong prices is not cost-ordered.
+#
+# TWO SOURCES, INTERSECTED, and the intersection is the whole point. The
+# OpenRouter catalog says what a model COSTS and what it can do; the upstream
+# router says what this estate can actually REACH. Ranking the catalog alone
+# proposes models the router refuses with `no router` — measured, not guessed:
+# every one of the three cheapest eligible catalog models 404'd through the
+# proxy because the router serves an explicit allowlist, not the whole catalog.
+#
+# The catalog is keyless. The router needs its bearer, which is why this runs
+# on a host that has one rather than in CI — a CI-built ranking could not tell
+# a servable model from an unreachable one, which is the error this exists to
+# prevent.
+#
+# THIS SCRIPT ONLY PROPOSES. It rewrites the `members` array in the candidates
+# file and nothing else; the `policy` block is hand-owned and preserved
+# verbatim. Selection is by catalog metadata, which says what a model claims,
+# never what it does — `litellm-fallback-probe` is what proves a member
+# actually answers, and that check is the merge gate, not this script.
+set -euo pipefail
+
+CANDIDATES="${1:-}"
+if [ -z "$CANDIDATES" ]; then
+  echo "usage: ${0##*/} PATH_TO_tier-candidates.json" >&2
+  exit 2
+fi
+[ -f "$CANDIDATES" ] || { echo "no such file: $CANDIDATES" >&2; exit 2; }
+
+CATALOG_URL="${OPENROUTER_CATALOG_URL:-https://openrouter.ai/api/v1/models}"
+
+ROUTER_URL="${LLM_ROUTER_URL:?LLM_ROUTER_URL must be set}"
+ROUTER_TOKEN_FILE="${LLM_ROUTER_TOKEN_FILE:?LLM_ROUTER_TOKEN_FILE must be set}"
+# LLM_ROUTER_URL already ends in /v1; model/info hangs off the same /v1, so
+# strip before appending or the request becomes /v1/v1/... and returns nothing.
+ROUTER_BASE="${ROUTER_URL%/v1}"
+
+# Via files, not environment: the catalog is megabytes, and an env var that
+# large exceeds the exec argument limit (E2BIG) on macOS.
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+curl -sS --max-time 60 "$CATALOG_URL" > "$work/catalog.json"
+curl -sS --max-time 60 -H "Authorization: Bearer $(cat "$ROUTER_TOKEN_FILE")" \
+  "$ROUTER_BASE/v1/model/info" > "$work/served.json"
+
+python3 - "$CANDIDATES" "$work/catalog.json" "$work/served.json" <<'PY'
+import json, os, sys, datetime
+
+path = sys.argv[1]
+doc = json.load(open(path))
+policy = doc["policy"]
+catalog = json.load(open(sys.argv[2]))["data"]
+
+# What the router will actually serve. Each entry's litellm_params.model is the
+# upstream id (`openrouter/<catalog id>`); model_name is the name to REQUEST.
+# Both are needed: selection is judged on catalog metadata keyed by the
+# upstream id, but the chain must name what the router answers to.
+served_rows = json.load(open(sys.argv[3])).get("data", [])
+request_name = {}
+for row in served_rows:
+    upstream = (row.get("litellm_params") or {}).get("model") or ""
+    if upstream.startswith("openrouter/"):
+        # Prefer the shortest name that resolves: the router exposes many
+        # models under both a bare id and an `openrouter/`-prefixed alias.
+        cid = upstream[len("openrouter/"):]
+        name = row.get("model_name")
+        if cid not in request_name or len(name) < len(request_name[cid]):
+            request_name[cid] = name
+
+need_ctx = policy["requiredInputTokens"]
+deny = set(policy.get("deny", []))
+pin = policy.get("pin", [])
+count = policy["memberCount"]
+# Free models share ONE upstream quota pool, so a chain made only of them has a
+# single point of failure wearing three names: exhaust the daily free cap and
+# every rung dies in the same instant. The tail is reserved for models that
+# bill, which do not share that cap.
+paid_tail = policy.get("paidTail", 0)
+
+def price(m, key):
+    # A missing or negative price means "not a fixed per-token price" — the
+    # meta-routers (openrouter/auto, openrouter/fusion) publish -1. Sorting
+    # those as cheapest would put a model of unknown cost and unknown identity
+    # at the head of the chain, which is the opposite of the point.
+    try:
+        v = float(m.get("pricing", {}).get(key))
+    except (TypeError, ValueError):
+        return None
+    return None if v < 0 else v
+
+def eligible(m):
+    if m["id"] in deny:
+        return False
+    # Unreachable is not a ranking penalty, it is disqualifying.
+    if m["id"] not in request_name:
+        return False
+    if (m.get("context_length") or 0) < need_ctx:
+        return False
+    p, c = price(m, "prompt"), price(m, "completion")
+    if p is None or c is None:
+        return False
+    arch = m.get("architecture") or {}
+    # Text out only: a zero-cost audio or image model sorts to the very top on
+    # price and cannot serve a single subagent turn.
+    if arch.get("output_modalities") != ["text"]:
+        return False
+    # Tool calling is not optional. A subagent that cannot call tools fails on
+    # its first action, and it fails as a wrong answer rather than an error —
+    # the worst shape of failure and the hardest to notice.
+    if "tools" not in (m.get("supported_parameters") or []):
+        return False
+    return True
+
+by_id = {m["id"]: m for m in catalog}
+pool = [m for m in catalog if eligible(m)]
+# Cheapest first, tie-broken by the larger window. Both halves of the price
+# matter: a model with free input and expensive output is not cheap.
+pool.sort(key=lambda m: (price(m, "prompt") + price(m, "completion"),
+                         -(m.get("context_length") or 0)))
+
+def is_free(m):
+    return price(m, "prompt") == 0 and price(m, "completion") == 0
+
+chosen, seen = [], set()
+missing = []
+for pid in pin:                      # hand-pinned entries lead, in given order
+    m = by_id.get(pid)
+    if m is not None and pid not in request_name:
+        m = None
+    if m is None:
+        missing.append(pid)
+        continue
+    chosen.append(m); seen.add(pid)
+free_slots = count - paid_tail
+for m in pool:
+    if len(chosen) >= free_slots:
+        break
+    if m["id"] not in seen:
+        chosen.append(m); seen.add(m["id"])
+
+# Cheapest BILLING models for the tail, in the same cost order.
+for m in (x for x in pool if not is_free(x)):
+    if len(chosen) >= count:
+        break
+    if m["id"] not in seen:
+        chosen.append(m); seen.add(m["id"])
+
+if paid_tail and not any(not is_free(m) for m in chosen):
+    sys.exit("policy requires a paid tail but no billing model is eligible; "
+             "a free-only chain dies all at once when the shared quota is spent")
+
+if missing:
+    # A pin that has left the catalog is a hand-made decision that has expired.
+    # Silently dropping it would quietly discard an operator's override.
+    print("WARNING: pinned model(s) absent from catalog: %s" % ", ".join(missing),
+          file=sys.stderr)
+
+if len(chosen) < 2:
+    sys.exit("only %d eligible model(s); a chain needs at least 2" % len(chosen))
+
+# The head of the chain is ALWAYS named `subagent`, whatever model wins the
+# ranking. Consumers name that one string forever; a refresh reorders what sits
+# behind it without touching a single consumer. Naming the head after its
+# current model is what makes a catalog change into a config change.
+#
+# It also shadows the upstream router's own `subagent` alias, which still
+# points at a retired model: an explicit model_list group always beats the `*`
+# wildcard, so defining it here fixes the dead alias for this host.
+def name(i):
+    return "subagent" if i == 0 else "subagent-fallback%d" % i
+
+doc["generatedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+doc["members"] = [{
+    "name": name(i),
+    "upstream": request_name[m["id"]],
+    "catalogId": m["id"],
+    "contextLength": m.get("context_length"),
+    # Three decimals, not the full float: published prices drift in the fourth
+    # decimal between consecutive fetches minutes apart (deepseek-v4-flash was
+    # seen at 0.0865 and 0.0862 in one session). At full precision every run
+    # produces a diff that means nothing, which trains a reader to skim the one
+    # that does. Three decimals still separates every tier in the pool.
+    "promptCostPerMtok": round(price(m, "prompt") * 1e6, 3),
+    "completionCostPerMtok": round(price(m, "completion") * 1e6, 3),
+} for i, m in enumerate(chosen)]
+
+with open(path, "w") as fh:
+    json.dump(doc, fh, indent=2)
+    fh.write("\n")
+
+for m in doc["members"]:
+    print("%-16s %-46s ctx=%-9s $%s/$%s" % (
+        m["name"], m["upstream"], m["contextLength"],
+        m["promptCostPerMtok"], m["completionCostPerMtok"]))
+print("\n%d of %d catalog models are both eligible and router-served; wrote %s"
+      % (len(pool), len(catalog), path))
+PY

--- a/modules/scripts/litellm-tier-refresh.sh
+++ b/modules/scripts/litellm-tier-refresh.sh
@@ -45,9 +45,32 @@ ROUTER_BASE="${ROUTER_URL%/v1}"
 # large exceeds the exec argument limit (E2BIG) on macOS.
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
-curl -sS --max-time 60 "$CATALOG_URL" > "$work/catalog.json"
-curl -sS --max-time 60 -H "Authorization: Bearer $(cat "$ROUTER_TOKEN_FILE")" \
-  "$ROUTER_BASE/v1/model/info" > "$work/served.json"
+
+# Both fetches retry. The router's model/info endpoint was measured hanging for
+# 30s with zero bytes and then answering in 0.15s a minute later — intermittent,
+# not down. Without a retry a scheduled refresh would fail on a blip it could
+# have ridden out. --retry-all-errors is what makes curl retry a TIMEOUT; plain
+# --retry only covers transient HTTP codes and connection refusals.
+#
+# Fetch order matters on failure: both land in temp files and the rewrite
+# happens only after both succeed, so a failed fetch leaves the candidates file
+# exactly as it was rather than half-updated. Verified against a live router
+# timeout.
+fetch() {
+  curl -sS --max-time 45 --retry 2 --retry-delay 5 --retry-all-errors "$@"
+}
+
+if ! fetch "$CATALOG_URL" > "$work/catalog.json"; then
+  echo "failed to fetch the model catalog after retries: $CATALOG_URL" >&2
+  exit 1
+fi
+if ! fetch -H "Authorization: Bearer $(cat "$ROUTER_TOKEN_FILE")" \
+  "$ROUTER_BASE/v1/model/info" > "$work/served.json"; then
+  echo "failed to reach the router's model/info endpoint after retries." >&2
+  echo "The candidates file is unchanged. This endpoint is known to hang" >&2
+  echo "intermittently; a later run will pick it up." >&2
+  exit 1
+fi
 
 python3 - "$CANDIDATES" "$work/catalog.json" "$work/served.json" <<'PY'
 import json, os, sys, datetime


### PR DESCRIPTION
## Why

The subagent tier named a single model. A model can stop serving with no config
change on either side: the router alias it pointed at still resolved in
`/v1/model/info` while every completion through it returned 404, because that
model's preview period had ended upstream. Nothing detected it until a call was
made by hand.

A single 429 was also fatal — the proxy had no fallbacks at all, so one
upstream refusal took every session and every subagent with it.

## What changed

- `modules/litellm-local/fallback-tier.nix` declares the chain as data, cheapest
  first, each member carrying the price and context window that earned it a
  place. Assertions keep at least two members and require every member to clear
  the measured p90 subagent context.
- `litellm_settings` gains `fallbacks`, `context_window_fallbacks` and
  `num_retries`, using LiteLLM's own config shape.
- No `default_fallbacks`, deliberately: a blanket rule would also catch the main
  Anthropic tier and answer a long session from a cheaper model without saying
  so. The main tier gets retries and a context-window repair only.
- `CLAUDE_CODE_SUBAGENT_MODEL` names an explicit `model_list` group instead of an
  upstream role, so it cannot fall through the wildcard.
- `litellm-fallback-probe` sends a real completion to every member. Config
  inspection cannot tell a live model from a retired one.
- The proxy now emits `otel` traces on the same path the shared router uses,
  gated on an endpoint being set.
- Auto-compact comment corrected: it claimed the upstream default was in effect
  while the effective value was 60.

## Verification

- `nix flake check` green; the three `litellm-local-*` checks evaluate clean.
- The new check was negative-tested — setting `num_retries = 0` fails it with the
  intended message.
- Probed against the live proxy after a rebuild: all three chain members served a
  completion, and the probe exits 1 on the retired model.

## Note for reviewers

The deployed `~/.claude/settings.json` and `~/.codex/config.toml` currently carry
telemetry endpoints that the present configuration does not render — those files
are activation-merged and still hold values from an older generation. The new
callback is correct but stays inert until an endpoint is actually configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Claude Code routing, subagent model selection, and loopback proxy behavior on every session; misconfigured fallbacks or stale tier data could 404 subagents or silently shift traffic until probed.
> 
> **Overview**
> Replaces a **single pinned subagent model** with a **generated, cost-ordered LiteLLM fallback chain** headed by the stable `subagent` group. `fallback-tier.nix` assembles explicit `model_list` groups from `tier-candidates.json`; `proxy-config.nix` wires `fallbacks`, retries, and context-window repair while **excluding** `default_fallbacks` so main `claude-*` sessions are never silently downgraded. **`CLAUDE_CODE_SUBAGENT_MODEL`** now names `subagent` (local group) instead of a physical id or upstream role.
> 
> The **`litellm-local`** module is split into **`proxy-config`**, **`commands`**, **`launchd`**, and **`fallback-tier`**; optional **`tierRefresh`** launchd job rewrites candidates in a git checkout (rebuild required to apply). New commands: **`litellm-tier-refresh`**, **`litellm-fallback-probe`**, plus **`ai-stack-drift-check.sh`** comparing registry role ids to mlx vs router endpoints.
> 
> **Regression coverage** expands: fallback-tier and auth checks split into separate files, new **`litellm-local-fallback-tier`** check, and **`deepSeq`** on launchd agents so missing module args fail at eval. Proxy **OTEL spans** (`otel` callback + LiteLLM `OTEL_*` env) gate on `userConfig.telemetry` traces endpoint; docs updated for architecture, telemetry, and **macOS `nix eval`** to force `lib/checks` on darwin. **`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80`** set explicitly; proxy restart **ThrottleInterval** lowered to 10s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be5bdc034ffdff47e1bdbdb361e5da0bd090153a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->