### PR TITLE
docs(mlx): annotate every unwired cacheMemoryMb gap inline, tracked at Vikunja #106

### DIFF
--- a/modules/mlx/catalog-data-80b-instruct.nix
+++ b/modules/mlx/catalog-data-80b-instruct.nix
@@ -47,6 +47,12 @@ in
     # (Hermes crons + fleet traffic), and the crash-loop respawn storm exhausts
     # the per-uid process table — reliability over throughput.
     concurrencyLimit = 1;
+    # resident cacheMemoryMb=8192 / swap cacheMemoryMb=4096 are LIVE
+    # literals, not derived: no (concurrency, window) pair reproduces either
+    # against this entry's kv geometry, checked at concurrency=1 against both
+    # the header's stated 65536 serving window and derive.nix's 32768
+    # fallback — the 65536 case does not even fit this entry's weight budget
+    # under forModel's committable-share math. Tracked: Vikunja #106.
     classes = {
       resident.flags = hybridNoPaged // {
         cacheMemoryMb = 8192;

--- a/modules/mlx/catalog-data-qwen35-9b.nix
+++ b/modules/mlx/catalog-data-qwen35-9b.nix
@@ -45,6 +45,10 @@ in
       # concurrency=1 matches the entry's own concurrencyLimit=1 above
       # (#1641 caution — do not raise either without re-testing).
       resident.cacheProvisioning.concurrency = 1;
+      # swap (the LIVE class for this entry) inherits the global null-default
+      # cacheMemoryMb, not a derive.nix output — a derived value at
+      # concurrency=1 differs materially from that default. Tracked:
+      # Vikunja #106.
       swap.flags = swapFlags;
     };
   };
@@ -94,6 +98,10 @@ in
       # concurrency=1 matches the entry's own concurrencyLimit=1 above
       # (#1641 caution — do not raise either without re-testing).
       resident.cacheProvisioning.concurrency = 1;
+      # swap (the LIVE class for this entry) inherits the global null-default
+      # cacheMemoryMb, not a derive.nix output — a derived value at
+      # concurrency=1 differs materially from that default. Tracked:
+      # Vikunja #106.
       swap.flags = swapFlags;
     };
   };

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -103,6 +103,13 @@ in
           maxRequestTokens = 131072;
         };
       };
+      # cacheMemoryMb = 3072 is a LIVE literal, not derived: no (concurrency,
+      # window) pair under derive.nix's forModel reproduces it against this
+      # entry's kv geometry, checked at concurrency=1 against both this
+      # entry's 131072 window and derive.nix's 32768 fallback. Deriving it
+      # would silently change what this swap-tier model actually gets
+      # allocated — a real limit-value change, not a refactor. Tracked:
+      # Vikunja #106 (needs an accept-or-pin decision, not more engineering).
       swap.flags =
         block256
         // swapFlags

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -98,6 +98,10 @@ in
     args = [ ];
     classes = {
       # The global maxRequestTokens default is too low for agentic multi-turn.
+      # cacheMemoryMb is NOT set here — it inherits model-server-cmd.nix's
+      # global null-default, not a derive.nix output. A derived value at
+      # concurrency=1 differs materially from that default; tracked rather
+      # than silently changed: Vikunja #106.
       resident.flags = block512 // {
         maxRequestTokens = 32768;
       };
@@ -151,12 +155,27 @@ in
   qwen3-next-80b = {
     model = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
     weightGb = 42.0;
+    # qwen3_next HYBRID, identical topology to the Instruct sibling
+    # (catalog-data-80b-instruct.nix): 48 layers, full_attention_interval=4,
+    # 12 full-attention layers carry paged KV, kvHeads=2, headDim=256.
+    # perTokenKvBytes = 2*12*2*256*2 = 24576 B/token. Backfilled for
+    # completeness (Vikunja #106); NOT wired to cacheMemoryMb below — see
+    # that field's comment.
+    kv = {
+      kvLayers = 12;
+      kvHeads = 2;
+      headDim = 256;
+      kvDtypeBytes = 2;
+    };
     args = [ ];
     # 40B+ single-slot policy: proxy queues (single in-flight), engine batch
     # capped at 1 (in swap.flags). Same hybrid-attention re-prefill constraint
     # as the Instruct sibling.
     concurrencyLimit = 1;
     classes = {
+      # cacheMemoryMb = 4096 is a LIVE literal, not derived — same finding as
+      # the Instruct sibling's swap class: no (concurrency, window) pair
+      # reproduces it. Tracked: Vikunja #106.
       swap.flags =
         swapFlags
         // hybridNoPaged


### PR DESCRIPTION
## Summary
- Follow-up to #1813: makes the 5 catalog spots where derive.nix's math cannot honestly reproduce today's live cacheMemoryMb literal a first-class, inline fact — each now names *why* it's unwired and points at Vikunja #106, instead of that reasoning living only in a PR description and an external tracker.
- Backfills `kv` geometry on `qwen3-next-80b` (Thinking sibling) to match its already-documented Instruct sibling — descriptive only, not wired to any cacheMemoryMb output, changes no behavior.

## Changes
- `catalog-data-qwen38-27b.nix`: swap `cacheMemoryMb = 3072` annotated
- `catalog-data-80b-instruct.nix`: resident `8192` / swap `4096` annotated
- `catalog-data.nix`: `qwen3-coder-30b` resident's inherited default annotated; `qwen3-next-80b` (Thinking) gets `kv` backfilled + its swap literal annotated
- `catalog-data-qwen35-9b.nix`: both entries' live swap class (inherited default) annotated

No behavior change — comments and one descriptive `kv` block only.

## Test plan
- [x] `nix fmt` — 0 changed
- [x] `nix flake check` — passed clean
- [x] All 4 touched files stay well under the 12KB gate (max 10093 bytes)

Assisted-by: Claude:claude-opus-5[1m]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and descriptive metadata only; no changes to serve flags, cache sizes, or derivation logic.
> 
> **Overview**
> **Documentation-only follow-up to #1813:** inline comments now mark every catalog spot where live `cacheMemoryMb` (or the inherited null default) cannot be reproduced by `derive.nix`’s `forModel` math, with rationale and **Vikunja #106** on each entry.
> 
> Touches **80B Instruct** (resident 8192 / swap 4096), **qwen38-27b** swap 3072, **qwen3-coder-30b** resident (unset), both **qwen35-9b** live swap classes, and **qwen3-next-80b** swap 4096. **`qwen3-next-80b`** also gets a descriptive **`kv`** block aligned with the Instruct sibling; it is not wired to provisioning.
> 
> **No runtime or flag changes** — comments plus the backfilled `kv` metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9e6dfd8f5ad65bfcbfd850826b22b7576ff05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->