### PR TITLE
feat(mlx): make derive.nix the single source for every serving limit via a pinned-override primitive

### DIFF
--- a/modules/mlx/catalog-data-80b-instruct.nix
+++ b/modules/mlx/catalog-data-80b-instruct.nix
@@ -47,25 +47,35 @@ in
     # (Hermes crons + fleet traffic), and the crash-loop respawn storm exhausts
     # the per-uid process table — reliability over throughput.
     concurrencyLimit = 1;
-    # resident cacheMemoryMb=8192 / swap cacheMemoryMb=4096 are LIVE
-    # literals, not derived: no (concurrency, window) pair reproduces either
-    # against this entry's kv geometry, checked at concurrency=1 against both
-    # the header's stated 65536 serving window and derive.nix's 32768
-    # fallback — the 65536 case does not even fit this entry's weight budget
-    # under forModel's committable-share math. Tracked: Vikunja #106.
+    # Both cacheMemoryMb values PINNED (derive.nix's cacheMemoryMbFor):
+    # forModel's derivation is unvalidated against a real run, and this
+    # entry has a documented metal::malloc crash history under concurrency
+    # — not a formula's call to make alone. Tracked: Vikunja #106.
     classes = {
-      resident.flags = hybridNoPaged // {
-        cacheMemoryMb = 8192;
-        maxNumSeqs = 1;
-        maxRequestTokens = 65536;
-      };
-      swap.flags =
-        swapFlags
-        // hybridNoPaged
-        // {
-          cacheMemoryMb = 4096;
-          maxNumSeqs = 1; # 40B+ single-slot policy (overrides swapFlags maxNumSeqs=2)
+      resident = {
+        cacheProvisioning.pinned = {
+          mb = 8192;
+          reason = "live working value; unvalidated formula, documented crash history under concurrency";
+          tracking = "vikunja#106";
         };
+        flags = hybridNoPaged // {
+          maxNumSeqs = 1;
+          maxRequestTokens = 65536;
+        };
+      };
+      swap = {
+        cacheProvisioning.pinned = {
+          mb = 4096;
+          reason = "live working value; unvalidated formula, documented crash history under concurrency";
+          tracking = "vikunja#106";
+        };
+        flags =
+          swapFlags
+          // hybridNoPaged
+          // {
+            maxNumSeqs = 1; # 40B+ single-slot policy (overrides swapFlags maxNumSeqs=2)
+          };
+      };
     };
   };
 }

--- a/modules/mlx/catalog-data-qwen35-9b.nix
+++ b/modules/mlx/catalog-data-qwen35-9b.nix
@@ -45,11 +45,18 @@ in
       # concurrency=1 matches the entry's own concurrencyLimit=1 above
       # (#1641 caution — do not raise either without re-testing).
       resident.cacheProvisioning.concurrency = 1;
-      # swap (the LIVE class for this entry) inherits the global null-default
-      # cacheMemoryMb, not a derive.nix output — a derived value at
-      # concurrency=1 differs materially from that default. Tracked:
-      # Vikunja #106.
-      swap.flags = swapFlags;
+      # swap (the LIVE class) PINNED at today's inherited global
+      # null-default: forModel's derivation is unvalidated against a real
+      # run, and this family has a documented Metal-buffer-leak history
+      # (#1641) under batched decode. Tracked: Vikunja #106.
+      swap = {
+        cacheProvisioning.pinned = {
+          mb = 8192;
+          reason = "matches today's inherited global null-default; unvalidated formula, #1641 buffer-leak history";
+          tracking = "vikunja#106";
+        };
+        flags = swapFlags;
+      };
     };
   };
 
@@ -98,11 +105,18 @@ in
       # concurrency=1 matches the entry's own concurrencyLimit=1 above
       # (#1641 caution — do not raise either without re-testing).
       resident.cacheProvisioning.concurrency = 1;
-      # swap (the LIVE class for this entry) inherits the global null-default
-      # cacheMemoryMb, not a derive.nix output — a derived value at
-      # concurrency=1 differs materially from that default. Tracked:
-      # Vikunja #106.
-      swap.flags = swapFlags;
+      # swap (the LIVE class) PINNED at today's inherited global
+      # null-default: forModel's derivation is unvalidated against a real
+      # run, and this family has a documented Metal-buffer-leak history
+      # (#1641) under batched decode. Tracked: Vikunja #106.
+      swap = {
+        cacheProvisioning.pinned = {
+          mb = 8192;
+          reason = "matches today's inherited global null-default; unvalidated formula, #1641 buffer-leak history";
+          tracking = "vikunja#106";
+        };
+        flags = swapFlags;
+      };
     };
   };
 }

--- a/modules/mlx/catalog-data-qwen38-27b.nix
+++ b/modules/mlx/catalog-data-qwen38-27b.nix
@@ -103,19 +103,17 @@ in
           maxRequestTokens = 131072;
         };
       };
-      # cacheMemoryMb = 3072 is a LIVE literal, not derived: no (concurrency,
-      # window) pair under derive.nix's forModel reproduces it against this
-      # entry's kv geometry, checked at concurrency=1 against both this
-      # entry's 131072 window and derive.nix's 32768 fallback. Deriving it
-      # would silently change what this swap-tier model actually gets
-      # allocated — a real limit-value change, not a refactor. Tracked:
-      # Vikunja #106 (needs an accept-or-pin decision, not more engineering).
-      swap.flags =
-        block256
-        // swapFlags
-        // {
-          cacheMemoryMb = 3072;
+      # cacheMemoryMb PINNED (derive.nix's cacheMemoryMbFor): forModel does
+      # not reproduce 3072 for this shape, and it is unvalidated against a
+      # real run. Tracked: Vikunja #106.
+      swap = {
+        cacheProvisioning.pinned = {
+          mb = 3072;
+          reason = "live working value; forModel's derivation for this shape unvalidated against a real run";
+          tracking = "vikunja#106";
         };
+        flags = block256 // swapFlags;
+      };
     };
   };
 }

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -97,13 +97,19 @@ in
     };
     args = [ ];
     classes = {
-      # The global maxRequestTokens default is too low for agentic multi-turn.
-      # cacheMemoryMb is NOT set here — it inherits model-server-cmd.nix's
-      # global null-default, not a derive.nix output. A derived value at
-      # concurrency=1 differs materially from that default; tracked rather
-      # than silently changed: Vikunja #106.
-      resident.flags = block512 // {
-        maxRequestTokens = 32768;
+      # cacheMemoryMb PINNED at today's inherited global null-default
+      # (derive.nix's cacheMemoryMbFor) — forModel's derivation is
+      # unvalidated against a real run. Tracked: Vikunja #106.
+      resident = {
+        cacheProvisioning.pinned = {
+          mb = 8192;
+          reason = "matches today's inherited global null-default; forModel's derivation unvalidated against a real run";
+          tracking = "vikunja#106";
+        };
+        # The global maxRequestTokens default is too low for agentic multi-turn.
+        flags = block512 // {
+          maxRequestTokens = 32768;
+        };
       };
       swap.flags = block256 // swapFlags;
     };
@@ -173,16 +179,21 @@ in
     # as the Instruct sibling.
     concurrencyLimit = 1;
     classes = {
-      # cacheMemoryMb = 4096 is a LIVE literal, not derived — same finding as
-      # the Instruct sibling's swap class: no (concurrency, window) pair
-      # reproduces it. Tracked: Vikunja #106.
-      swap.flags =
-        swapFlags
-        // hybridNoPaged
-        // {
-          cacheMemoryMb = 4096;
-          maxNumSeqs = 1; # 40B+ single-slot policy (overrides swapFlags maxNumSeqs=2)
+      # cacheMemoryMb PINNED (derive.nix's cacheMemoryMbFor) — same finding
+      # as the Instruct sibling's swap class. Tracked: Vikunja #106.
+      swap = {
+        cacheProvisioning.pinned = {
+          mb = 4096;
+          reason = "live working value; unvalidated formula, documented crash history under concurrency";
+          tracking = "vikunja#106";
         };
+        flags =
+          swapFlags
+          // hybridNoPaged
+          // {
+            maxNumSeqs = 1; # 40B+ single-slot policy (overrides swapFlags maxNumSeqs=2)
+          };
+      };
     };
   };
 

--- a/modules/mlx/derive-pinning.nix
+++ b/modules/mlx/derive-pinning.nix
@@ -1,0 +1,59 @@
+# MLX Module — cacheMemoryMb resolution: derive vs pin. Split from derive.nix
+# for the 12KB gate (same split-rather-than-exempt pattern as the catalog
+# entries it serves). Adds no new derivation math — only the single entry
+# point options-catalog.nix calls instead of forModel directly.
+{ lib }:
+let
+  derive = import ./derive.nix { inherit lib; };
+in
+{
+  # ---- SINGLE ENTRY POINT FOR cacheMemoryMb --------------------------------
+  #
+  # options-catalog.nix calls ONLY this: every catalog entry with a
+  # cacheProvisioning attribute routes through one mechanism either way.
+  #
+  #   .concurrency = N   -> derive.nix's forModel computes it.
+  #   .pinned = { mb; reason; tracking; } -> the literal stands. Use when
+  #     forModel's computed value is unvalidated (bufferPerBlockPerLayer is
+  #     deliberately uncalibrated — derive.nix's header) and the literal it
+  #     would replace is empirically hardened instead (a prior production
+  #     crash, not a guess): applying an unvalidated formula's output to a
+  #     model with a real crash history is not this file's call to make
+  #     alone. forModel still runs at concurrency=1 (derive.nix's standard
+  #     comparison basis) so the pin's honest alternative is computed and
+  #     exposed as derivedCacheMemoryMb — nothing to re-derive when the pin
+  #     is later revisited.
+  cacheMemoryMbFor =
+    {
+      kv,
+      weightGb,
+      windowTokens,
+      budgetGb,
+      cacheProvisioning,
+    }:
+    if cacheProvisioning ? pinned then
+      cacheProvisioning.pinned
+      // {
+        cacheMemoryMb = cacheProvisioning.pinned.mb;
+        derivedCacheMemoryMb =
+          (derive.forModel {
+            inherit
+              kv
+              weightGb
+              windowTokens
+              budgetGb
+              ;
+            concurrency = 1;
+          }).cacheMemoryMb;
+      }
+    else
+      derive.forModel {
+        inherit
+          kv
+          weightGb
+          windowTokens
+          budgetGb
+          ;
+        inherit (cacheProvisioning) concurrency;
+      };
+}

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -19,7 +19,7 @@
 let
   cfg = config.programs.mlx;
   catalogData = import ./catalog-data.nix;
-  derive = import ./derive.nix { inherit lib; };
+  derivePinning = import ./derive-pinning.nix { inherit lib; };
 
   enabled = lib.filterAttrs (_: sel: sel.enable) cfg.catalog;
 
@@ -30,16 +30,15 @@ let
       Known entries: ${lib.concatStringsSep ", " (lib.attrNames catalogData)}
     '');
 
-  # cacheMemoryMb, DERIVED when a class opts in via `cacheProvisioning`
-  # (worked example: catalog-data-qwen38-27b.nix resident). `concurrency` is
-  # a STATED provisioning target, never guessed — see forModel's docs for
-  # why that differs from maxNumSeqs. budgetGb reads THIS host's
-  # memoryHardLimitGb, so one class re-derives per host.
+  # cacheMemoryMb, resolved when a class opts in via `cacheProvisioning` —
+  # see derive-pinning.nix's cacheMemoryMbFor for the derive-vs-pin split.
+  # budgetGb is THIS host's memoryHardLimitGb: a derived class re-derives
+  # per host; a pinned class ignores it, same as its old literal did.
   derivedCacheMb =
     entry: classDef:
-    (derive.forModel {
+    (derivePinning.cacheMemoryMbFor {
       inherit (entry) kv weightGb;
-      inherit (classDef.cacheProvisioning) concurrency;
+      inherit (classDef) cacheProvisioning;
       windowTokens = entry.contextWindowTokens or 32768;
       budgetGb = cfg.memoryHardLimitGb;
     }).cacheMemoryMb;


### PR DESCRIPTION
## Summary
- Closes the literal gap #1815 could only document: the 5 catalog spots with no honest derivation now route through the same mechanism as every derived spot, via a new `cacheProvisioning.pinned = { mb; reason; tracking; }` primitive in `derive-pinning.nix`.
- Zero runtime change — every pinned `mb` equals today's live literal or the global default it replaces (verified against `model-server-cmd.nix`'s `effectiveMlxLmCacheMb` fallback).
- A pinned entry still runs `forModel` at `concurrency = 1` and exposes the result as `derivedCacheMemoryMb`, so the honest alternative is precomputed and ready when Vikunja #106 (the accept-or-pin decision, filed in #1813's follow-up) is resolved — no re-derivation needed later.

## Changes
- `derive-pinning.nix` (new): `cacheMemoryMbFor`, the single entry point `options-catalog.nix` now calls instead of `forModel` directly. Split out rather than compressing `derive.nix`'s evidenced header prose, matching this module's established split-rather-than-exempt convention for the 12KB gate.
- `options-catalog.nix`: `derivedCacheMb` routes through `derivePinning.cacheMemoryMbFor`; removed the now-unused direct `derive` import (would have tripped deadnix).
- `catalog-data-qwen38-27b.nix`, `catalog-data-80b-instruct.nix`, `catalog-data.nix`, `catalog-data-qwen35-9b.nix`: all 5 unwired spots converted from bare literals/implicit defaults to `cacheProvisioning.pinned`.

## Test plan
- [x] `nix fmt` — formatted cleanly
- [x] `nix flake check` — passed (formatting, statix, deadnix, regression tests)
- [x] Every touched file stays under the 12KB gate (max 12266 bytes)
- [x] Confirmed each pin's `mb` matches its prior literal or `model-server-cmd.nix`'s `if c.cacheMemoryMb == null then 8192` fallback exactly — no live value changes

Assisted-by: Claude:claude-opus-5[1m]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nix-only refactor with pinned MB values matching production; mis-wiring would affect KV budgets on fleet brains, but the PR preserves each prior limit.
> 
> **Overview**
> Introduces **`cacheProvisioning.pinned`** so catalog classes that used ad-hoc `cacheMemoryMb` literals (or implicit global defaults) go through the same **`cacheProvisioning`** path as derived entries, without changing served values.
> 
> **`derive-pinning.nix`** adds **`cacheMemoryMbFor`**: **`.concurrency`** still delegates to **`derive.nix`**’s **`forModel`**; **`.pinned`** keeps the stated **`mb`** plus **`reason`** / **`tracking`** (Vikunja #106) and still computes **`derivedCacheMemoryMb`** at concurrency 1 for later accept-or-pin work. **`options-catalog.nix`** now calls this helper instead of **`forModel`** directly.
> 
> Touched catalog spots include **80B instruct** (resident/swap), **Qwen3.5 9B** swap (both entries), **Qwen38-27b** swap, **qwen3-coder-30b** resident, and **qwen3-next-80b** swap — each pin matches the prior literal or the previous null-default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a02904142e979a24ca96419b29ea229f21dd50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->