### PR TITLE
fix(mlx): stop grafting other models' ids onto the single resident

### DIFF
--- a/lib/checks/mlx-single-model.nix
+++ b/lib/checks/mlx-single-model.nix
@@ -1,11 +1,33 @@
 # programs.mlx.singleModel unit test — split from mlx.nix (12KB gate).
+#
+# The property under test is EXACT-NAME RESOLUTION: a request naming a model
+# is served by that model's weights or it errors. Collapsing the catalog to
+# one resident must never make another model's physical id resolve to the
+# resident, because llama-swap answers 200 and echoes the *requested* name, so
+# the substitution is invisible to every caller and every log downstream of
+# it. That defect published one model's benchmark numbers under three other
+# models' names (#1431).
+#
+# Deliberate role aliases ("default", "goal-judge") stay legal — they name a
+# capability, not a checkpoint. What is banned is a *different model's
+# physical id*, or a disabled model's own alias, resolving to the survivor.
 { pkgs }:
 let
   helpers = import ./helpers.nix { inherit pkgs; };
+  inherit (pkgs.lib) assertMsg;
 
-  # programs.mlx.singleModel: one resident model, everything else disabled
-  # (not deleted), every other model's own id aliased onto the resident.
-  topology = import ../../modules/mlx/llama-swap-topology.nix { inherit (pkgs) lib; } {
+  compile = import ../../modules/mlx/llama-swap-topology.nix { inherit (pkgs) lib; };
+
+  # One fixture registry, reused by every mode below so the checks compare
+  # like with like. `judge` carries a role alias of its own precisely so the
+  # "a disabled model's alias must not leak either" case is covered.
+  fixtureModels = {
+    brain.aliases = [ "default" ];
+    sidekick.aliases = [ "coding" ];
+    judge.aliases = [ "goal-judge" ];
+  };
+
+  fixtureArgs = {
     residentModels = {
       brain.aliases = [ "default" ];
     };
@@ -13,68 +35,78 @@ let
       sidekick.aliases = [ "coding" ];
       judge.aliases = [ "goal-judge" ];
     };
-    allModels = {
-      brain.aliases = [ "default" ];
-      sidekick.aliases = [ "coding" ];
-      judge.aliases = [ "goal-judge" ];
-    };
+    allModels = fixtureModels;
     groupSwap = false;
-    singleModel = "brain";
   };
-  sortedAliases = builtins.sort builtins.lessThan topology.models.brain.aliases;
+
+  # programs.mlx.singleModel: one resident model, everything else disabled
+  # (not deleted) and NOT reachable under any name.
+  topology = compile (fixtureArgs // { singleModel = "brain"; });
 
   # alwaysAvailableModels escape: `sidekick` stays servable beside the single
   # resident, `judge` is still disabled, and the resident is pinned persistent.
-  escape = import ../../modules/mlx/llama-swap-topology.nix { inherit (pkgs) lib; } {
-    residentModels = {
-      brain.aliases = [ "default" ];
-    };
-    swapModels = {
-      sidekick.aliases = [ "coding" ];
-      judge.aliases = [ "goal-judge" ];
-    };
-    allModels = {
-      brain.aliases = [ "default" ];
-      sidekick.aliases = [ "coding" ];
-      judge.aliases = [ "goal-judge" ];
-    };
-    groupSwap = false;
-    singleModel = "brain";
-    alwaysAvailableModels = [ "sidekick" ];
-  };
+  escape = compile (
+    fixtureArgs
+    // {
+      singleModel = "brain";
+      alwaysAvailableModels = [ "sidekick" ];
+    }
+  );
+
+  sortedAliases = builtins.sort builtins.lessThan topology.models.brain.aliases;
   escapeAliases = builtins.sort builtins.lessThan escape.models.brain.aliases;
+
+  # --- the reusable substitution probe -----------------------------------
+  # Every name a caller could send that MUST NOT resolve: each disabled
+  # model's physical id, plus each disabled model's own role aliases. Derived
+  # from the compiled topology, not hand-listed, so it keeps covering new
+  # fixture entries without anyone remembering to extend it.
+  unservableNames =
+    t:
+    builtins.concatLists (
+      pkgs.lib.mapAttrsToList (id: entry: [ id ] ++ (entry.aliases or [ ])) t.disabledModels
+    );
+
+  # Every name the emitted config WILL resolve: each live model's key plus
+  # its aliases.
+  resolvableNames =
+    t:
+    builtins.concatLists (
+      pkgs.lib.mapAttrsToList (id: entry: [ id ] ++ (entry.aliases or [ ])) t.models
+    );
+
+  # The whole rule in one expression: nothing unservable is resolvable.
+  leaked = t: pkgs.lib.intersectLists (unservableNames t) (resolvableNames t);
 in
 {
   mlx-single-model-mode =
-    assert
+    assert assertMsg (
       builtins.attrNames topology.models == [ "brain" ]
-      || throw "singleModel: exactly one model must stay in `models`";
-    assert topology.models.brain.ttl == 0 || throw "singleModel: the resident entry must have ttl=0";
-    assert
-      sortedAliases == [
-        "default"
-        "judge"
-        "sidekick"
-      ]
-      || throw "singleModel: aliases must include the resident's own roles plus every other model's own id";
-    assert
-      builtins.attrNames topology.disabledModels == [
-        "judge"
-        "sidekick"
-      ]
-      || throw "singleModel: every non-resident model must survive under disabledModels, not be deleted";
-    assert
+    ) "singleModel: exactly one model must stay in `models`";
+    assert assertMsg (topology.models.brain.ttl == 0) "singleModel: the resident entry must have ttl=0";
+    # The core regression. Before the fix this list was
+    # [ "default" "judge" "sidekick" ] — the two disabled models' physical ids
+    # grafted straight onto the survivor.
+    assert assertMsg (sortedAliases == [
+      "default"
+    ]) "singleModel: the resident must keep ONLY its own role aliases; no other model's physical id may be grafted on";
+    assert assertMsg (
+      leaked topology == [ ]
+    ) "singleModel: a disabled model's id/alias resolves to the resident — that is a silent substitution: ${builtins.toJSON (leaked topology)}";
+    assert assertMsg (builtins.attrNames topology.disabledModels == [
+      "judge"
+      "sidekick"
+    ]) "singleModel: every non-resident model must survive under disabledModels, not be deleted";
+    assert assertMsg (
       topology.groups == { }
-      || throw "singleModel: the live `groups` key must be empty (meaningless with one model)";
-    assert
+    ) "singleModel: the live `groups` key must be empty (meaningless with one model)";
+    assert assertMsg (
       topology.disabledGroups ? mlx-models
-      || throw "singleModel: the persistent group definition must survive under disabledGroups";
-    helpers.mkMarker "check-mlx-single-model-mode" "MLX single-model mode: one resident model, every alias routed to it, everything else disabled-not-deleted";
+    ) "singleModel: the persistent group definition must survive under disabledGroups";
+    helpers.mkMarker "check-mlx-single-model-mode"
+      "MLX single-model mode: one resident model serving only its own role aliases, every other model disabled-not-deleted and unreachable by name";
 
   mlx-single-model-escape =
-    let
-      inherit (pkgs.lib) assertMsg;
-    in
     assert assertMsg (
       builtins.sort builtins.lessThan (builtins.attrNames escape.models) == [
         "brain"
@@ -84,12 +116,18 @@ in
     assert assertMsg (
       builtins.attrNames escape.disabledModels == [ "judge" ]
     ) "escape: non-kept models must still be disabled, not deleted";
+    assert assertMsg (escapeAliases == [
+      "default"
+    ]) "escape: the resident keeps only its own role aliases (neither kept-small nor disabled ids may be grafted on)";
     assert assertMsg (
-      escapeAliases == [
-        "default"
-        "judge"
-      ]
-    ) "escape: kept small models must NOT be aliased onto the resident (only truly-disabled ids are)";
+      leaked escape == [ ]
+    ) "escape: a disabled model's id/alias resolves to a live entry — silent substitution: ${builtins.toJSON (leaked escape)}";
+    # A kept-small model is served by its OWN weights under its own name, so
+    # its own id and alias must both still resolve — the rule bans
+    # substitution, not legitimate serving.
+    assert assertMsg (
+      escape.models.sidekick.aliases == [ "coding" ]
+    ) "escape: a kept-small model keeps serving under its own name and its own role alias";
     assert assertMsg (
       (escape.models.sidekick.ttl or null) == null
     ) "escape: kept small models stay on-demand (no forced ttl=0 resident promotion)";
@@ -104,5 +142,6 @@ in
     assert assertMsg (
       !escape.groups.mlx-small-models.persistent
     ) "escape: the kept-small swap group must be non-persistent (on-demand, idle-unloaded)";
-    helpers.mkMarker "check-mlx-single-model-escape" "MLX singleModel escape: alwaysAvailableModels stay on-demand servable beside a pinned resident, unaliased, others still disabled";
+    helpers.mkMarker "check-mlx-single-model-escape"
+      "MLX singleModel escape: alwaysAvailableModels stay on-demand servable under their OWN names beside a pinned resident, others disabled and unreachable";
 }

--- a/modules/mlx/llama-swap-topology.nix
+++ b/modules/mlx/llama-swap-topology.nix
@@ -3,10 +3,11 @@
 # model-server-cmd.nix). Two modes:
 #   singleModel == null -> normal multi-model registry (models + groups).
 #   singleModel != null -> single-model mode: only that physical id is
-#     servable (ttl=0, aliased to every other model's own id so any caller
-#     naming any known model still resolves to it); everything else is kept
-#     but demoted to disabledModels/disabledGroups (llama-swap ignores those
-#     keys) — disable, never delete.
+#     servable (ttl=0, keeping its OWN role aliases and nothing else);
+#     everything else is kept but demoted to disabledModels/disabledGroups
+#     (llama-swap ignores those keys) — disable, never delete. A request
+#     naming a disabled model's id therefore 404s, naming the model it asked
+#     for, instead of being served the resident's weights.
 #     Escape hatch: alwaysAvailableModels names small physical ids that stay
 #     servable (on-demand swap tier) beside the single resident instead of
 #     being disabled — the resident is pinned persistent so a small-model
@@ -49,12 +50,19 @@ if singleModel != null then
   in
   {
     models = {
+      # EXACT-NAME RESOLUTION. The resident keeps its own deliberate role
+      # aliases ("default", "goal-judge", …) — those name a capability and
+      # have always meant "whatever currently serves this role". It must NOT
+      # inherit any *other model's physical id* as an alias.
+      #
+      # This previously grafted every disabled model's id onto this entry, so
+      # a request for e.g. a 120B returned the resident's weights with a 200
+      # and the requested name echoed back in the response. Nothing
+      # downstream could tell. It attributed one model's benchmark numbers to
+      # three others and those results were published (#1431). A model that
+      # is not loaded must 404, naming what was asked for.
       ${singleModel} = allModels.${singleModel} // {
         ttl = 0;
-        aliases = lib.unique (
-          (allModels.${singleModel}.aliases or [ ])
-          ++ (lib.filter (id: !(builtins.elem id keep)) (builtins.attrNames allModels))
-        );
       };
     }
     // smallModels;


### PR DESCRIPTION
Recovered from an unmerged local branch during a repo-hygiene sweep. It had commits but no pull request, so nothing was evaluating it.

Stops other models' ids being attached to the single resident model. Opening it so CI judges whether it still applies to current develop — related MLX resolution work has landed since it was written, and it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes single-model llama-swap name resolution (previously silent substitution, now 404 for unserved ids), which is correctness-critical for benchmarks and any caller that assumed all registry names still routed to the resident.
> 
> **Overview**
> **Fixes silent wrong-model serving in `programs.mlx.singleModel` mode** by changing how `llama-swap-topology.nix` builds the resident entry: it still forces `ttl = 0` but **no longer adds other models' physical ids (or their role aliases from disabled entries) to the survivor's `aliases`**. Requests for a disabled checkpoint should fail instead of returning the resident's weights while echoing the requested name (#1431).
> 
> The **mlx-single-model checks** are tightened to match: shared fixtures, a derived `leaked` intersection test (disabled id/alias must not appear on any live model), and expectations that the resident keeps only its own role aliases (e.g. `"default"`), including under the `alwaysAvailableModels` escape path where kept-small models still resolve under their own names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8baacdb6e4991739f21f5888e3492db7de46b0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->