### PR TITLE
fix(codex): pass MCP launch environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 #
 # CANONICAL METHOD: direct injection — no secret on disk.
 #   Inject credentials into each CLI run so nothing is ever written to a file:
-#     doppler run -p ai-ci-automation -c prd -- <command>
+#     doppler run -p "$AI_DOPPLER_PROJECT" -c "$AI_DOPPLER_CONFIG" -- <command>
 #     aws-vault exec <profile> -- <command>
 #     security find-generic-password -s <svc> -a <acct> -w <keychain-db>  # inline
 #   The real injection runbook is AGENTS.local.md (gitignored, local).
@@ -28,7 +28,7 @@
 # ───────────────────────────── MCP servers ─────────────────────────────
 
 # [required] huggingface MCP + `hf` CLI — HuggingFace Hub access.
-# source: Keychain automation.keychain-db, or Doppler ai-ci-automation/prd.
+# source: Keychain automation.keychain-db, or the configured Doppler project.
 HF_TOKEN=hf___REPLACE_ME__
 
 # [required] github MCP — GitHub API access. (github MCP ships disabled.)
@@ -49,6 +49,13 @@ BAO_ADDR=https://bao.example.com
 AI_READONLY_ROLE_ID=__REPLACE_ME__ai_readonly_role_id
 # [required] ai-readonly AppRole secret_id.  source: Keychain or Doppler.
 AI_READONLY_SECRET_ID=__REPLACE_ME__ai_readonly_secret_id
+
+# zammad MCP is enabled. doppler-mcp needs these non-secret selectors to load
+# ZAMMAD_URL and ZAMMAD_HTTP_TOKEN at launch.
+# [required-if-zammad-enabled] Doppler project. source: Keychain automation.keychain-db.
+AI_DOPPLER_PROJECT=__REPLACE_ME__doppler_project
+# [optional] Doppler config; defaults to the local deployment configuration.
+AI_DOPPLER_CONFIG=__REPLACE_ME__doppler_config
 
 # vikunja MCP ships DISABLED (task management, docs-starlight#141). When enabled,
 # the server FAILS to start without both VIKUNJA_URL and VIKUNJA_API_TOKEN.
@@ -79,8 +86,8 @@ CLOUDFLARE_API_TOKEN=cf___REPLACE_ME__
 
 # ──────────────── AI provider keys (Doppler fallback paths) ────────────────
 # All [optional] — local MLX is the default. Used by the d-claude / cecli / qwen
-# fallback paths. source: Doppler ai-ci-automation/prd. Don't hand-set these —
-# run `doppler run -p ai-ci-automation -c prd -- <cmd>`.
+# fallback paths. source: the configured Doppler project. Don't hand-set these —
+# run `doppler run -p "$AI_DOPPLER_PROJECT" -c "$AI_DOPPLER_CONFIG" -- <cmd>`.
 ANTHROPIC_API_KEY=sk-ant___REPLACE_ME__
 GEMINI_API_KEY=__REPLACE_ME__gemini
 OPENAI_API_KEY=sk___REPLACE_ME__openai
@@ -88,7 +95,7 @@ OPENROUTER_API_KEY=sk-or___REPLACE_ME__
 DASHSCOPE_API_KEY=sk___REPLACE_ME__dashscope
 
 # ───────────────────────── Observability / tooling ─────────────────────────
-# [optional] Galileo AI observability.  source: Doppler ai-ci-automation/prd.
+# [optional] Galileo AI observability. Source: the configured Doppler project.
 GALILEO_API_KEY=__REPLACE_ME__galileo
 # [optional] per-session trace toggle (set by the `galileo-on` shell function).
 GALILEO_TRACE=0

--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -25,6 +25,42 @@ let
   rendererMismatches = builtins.filter (name: rendererNames.${name} != cfg.enabledServerNames) (
     builtins.attrNames rendererNames
   );
+  codexLaunchContracts = {
+    splunk = {
+      env_vars = [
+        "BAO_ADDR"
+        "AI_READONLY_ROLE_ID"
+        "AI_READONLY_SECRET_ID"
+        "SPLUNK_MCP_OPENBAO_PATH"
+      ];
+      startup_timeout_sec = 300;
+      tool_timeout_sec = 300;
+    };
+    vikunja = {
+      env_vars = [
+        "AI_DOPPLER_PROJECT"
+        "AI_DOPPLER_CONFIG"
+      ];
+      startup_timeout_sec = 300;
+      tool_timeout_sec = 300;
+    };
+    zammad = {
+      env_vars = [
+        "AI_DOPPLER_PROJECT"
+        "AI_DOPPLER_CONFIG"
+      ];
+      startup_timeout_sec = 300;
+      tool_timeout_sec = 300;
+    };
+  };
+  codexLaunchContractMismatches = builtins.filter (
+    name:
+    builtins.any (key: cfg.servers.${name}.${key} != codexLaunchContracts.${name}.${key}) [
+      "env_vars"
+      "startup_timeout_sec"
+      "tool_timeout_sec"
+    ]
+  ) (builtins.attrNames codexLaunchContracts);
 in
 {
   shared-mcp-global-profile =
@@ -44,6 +80,14 @@ in
       cfg.servers.splunk.command == "splunk-mcp-connect" && cfg.servers.splunk.args == [ ]
       || throw "Splunk MCP must launch directly through splunk-mcp-connect: ${builtins.toJSON cfg.servers.splunk}";
     helpers.mkMarker "check-splunk-mcp-canonical-launcher" "Splunk MCP uses the OpenBao launcher without Doppler wiring";
+
+  codex-mcp-launch-contract =
+    assert
+      codexLaunchContractMismatches == [ ]
+      || throw "Codex MCP launch contract mismatch: ${builtins.toJSON codexLaunchContractMismatches}; actual=${
+        builtins.toJSON (builtins.map (name: cfg.servers.${name}) (builtins.attrNames codexLaunchContracts))
+      }";
+    helpers.mkMarker "check-codex-mcp-launch-contract" "Codex MCP servers have explicit environment allowlists and 300-second startup/tool timeouts";
 
   splunk-mcp-openbao-wrapper =
     pkgs.runCommand "check-splunk-mcp-openbao-wrapper"

--- a/modules/mcp/README.md
+++ b/modules/mcp/README.md
@@ -105,13 +105,20 @@ secrets manager per command:
   at launch (see [Adding New Servers](#adding-new-servers)). `AI_DOPPLER_PROJECT`
   arrives ambiently (see `modules/ai-aliases.zsh`); no project name is committed
   to this repo. Non-secret config (log levels, flags) belongs in the Nix-managed
-  `env` attribute, not Doppler.
+  `env` attribute, not Doppler. Codex additionally requires a per-server
+  `env_vars` allowlist: catalog entries must forward `AI_DOPPLER_PROJECT` and
+  `AI_DOPPLER_CONFIG` to every `doppler-mcp` server. Use the same 300-second
+  startup and tool timeouts as the known-good client wrappers for package-backed
+  servers.
 - Splunk uses `splunk-mcp-connect`. At each launch it takes `BAO_ADDR`, an AppRole
   secret-zero (`AI_READONLY_ROLE_ID`, `AI_READONLY_SECRET_ID`), and the KV path
   (`SPLUNK_MCP_OPENBAO_PATH`) from the ambient environment — delivered by shell
   init or `doppler run`, per the `ai-agent-access-openbao` runbook on the docs
   site — authenticates to OpenBao, and reads that path. The resulting
   `SPLUNK_MCP_URL` and `SPLUNK_MCP_TOKEN` exist only in the MCP child process.
+  Its Codex catalog entry forwards exactly those four bootstrap variables and
+  uses 300-second startup and tool timeouts; it never forwards the resulting
+  Splunk URL or token.
 - Env-var-backed servers (HF_TOKEN, GitHub PAT, UniFi, …) read from the process
   environment, injected directly (e.g. an inline Keychain read or `doppler run`).
 

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -117,6 +117,16 @@ in
   # process.
   splunk = {
     command = "splunk-mcp-connect";
+    # Codex inherits only explicitly listed ambient variables for each stdio
+    # server. Keep the AppRole bootstrap narrowly scoped to this launcher.
+    env_vars = [
+      "BAO_ADDR"
+      "AI_READONLY_ROLE_ID"
+      "AI_READONLY_SECRET_ID"
+      "SPLUNK_MCP_OPENBAO_PATH"
+    ];
+    startup_timeout_sec = 300;
+    tool_timeout_sec = 300;
   };
 
   # ================================================================
@@ -199,8 +209,8 @@ in
   # project/label CRUD, batch import, webhooks) with rate limiting + circuit
   # breakers — built for autonomous agents. Requires VIKUNJA_URL (instance API
   # base, ends in /api/v1) and VIKUNJA_API_TOKEN (a tk_ service-account token,
-  # svc-mcp-rw tier) — injected at launch by doppler-mcp from ai-ci-automation/
-  # prd, same pattern as google-workspace. Canonical token home is the secrets
+  # svc-mcp-rw tier) — injected at launch by doppler-mcp from the configured
+  # Doppler project, same pattern as google-workspace. Canonical token home is the secrets
   # engine's apps/vikunja secret (promoted from the app role's SOPS mint).
   # Ships disabled — a consumer enables it deliberately once the Doppler
   # secrets exist for that machine.
@@ -210,6 +220,13 @@ in
       "bunx"
       "@democratize-technology/vikunja-mcp@${versions.vikunjaMcp}"
     ];
+    # Codex needs the Doppler wrapper configuration forwarded explicitly.
+    env_vars = [
+      "AI_DOPPLER_PROJECT"
+      "AI_DOPPLER_CONFIG"
+    ];
+    startup_timeout_sec = 300;
+    tool_timeout_sec = 300;
     disabled = true;
   };
 
@@ -221,11 +238,11 @@ in
   # ticket/user/organization/attachment tools plus queue resources — the
   # surface the Hermes zammad-incidents loop drives. Requires ZAMMAD_URL
   # (instance API base, ends in /api/v1) and ZAMMAD_HTTP_TOKEN (a Zammad API
-  # token) — injected at launch by doppler-mcp from ai-ci-automation/prd, same
-  # pattern as vikunja/google-workspace. Canonical token home is the secrets
+  # token) — injected at launch by doppler-mcp from the configured Doppler
+  # project, same pattern as vikunja/google-workspace. Canonical token home is the secrets
   # engine's secret/ai/mcp/zammad (ZAMMAD_MCP_URL + ZAMMAD_MCP_TOKEN fields).
-  # Ships disabled — the host opt-in + Doppler seeding follow Zammad's deploy
-  # (task #10); enabling before that would spawn a failing server.
+  # Enabled in the shared profile. Its Doppler wrapper receives only the
+  # project/config selectors from Codex; Zammad credentials stay in Doppler.
   zammad = {
     command = "doppler-mcp";
     args = [
@@ -234,6 +251,12 @@ in
       "git+https://github.com/basher83/zammad-mcp.git@v${versions.zammadMcp}"
       "mcp-zammad"
     ];
+    env_vars = [
+      "AI_DOPPLER_PROJECT"
+      "AI_DOPPLER_CONFIG"
+    ];
+    startup_timeout_sec = 300;
+    tool_timeout_sec = 300;
   };
 
   # ================================================================


### PR DESCRIPTION
Recovered from an unmerged local branch during a repo-hygiene sweep. It had commits but no pull request.

Passes the launch environment through to Codex MCP servers. Overlaps the credential change in #1819; if both are kept, the ordering between them needs a look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Codex launches credential-backed MCP servers; misconfigured allowlists would break Splunk/Zammad/Vikunja at startup, but secrets handling patterns are unchanged.
> 
> **Overview**
> Codex only forwards **ambient environment variables** that each stdio MCP server lists explicitly. This PR adds **`env_vars` allowlists** and **300s startup/tool timeouts** on **Splunk** (`splunk-mcp-connect` OpenBao bootstrap vars only), **Vikunja**, and **Zammad** (`doppler-mcp` gets `AI_DOPPLER_PROJECT` / `AI_DOPPLER_CONFIG`).
> 
> A new Nix check **`codex-mcp-launch-contract`** locks those catalog fields so they cannot drift. **`.env.example`** and **`modules/mcp/README.md`** now document the Doppler selector vars and replace hardcoded `ai-ci-automation/prd` examples with `$AI_DOPPLER_PROJECT` / `$AI_DOPPLER_CONFIG`. Zammad catalog comments are updated to reflect that it is **enabled** in the shared profile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e0cf516e8dcb1eaf0a4eea50a799383b4eb3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->