### PR TITLE
feat: gate experimental MTP profiles

### DIFF
--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -28,6 +28,23 @@ in
     }
     {
       assertion = lib.all (
+        modelId:
+        let
+          profile = cfg.modelMtpProfiles.${modelId};
+          backend = cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+        in
+        !profile.enable
+        || (
+          backend == "vllm-mlx"
+          && lib.elem "vllm-mlx" cfg.enabledBackends
+          && (cfg.modelConcurrencyLimits.${modelId} or cfg.proxy.concurrencyLimit) == 1
+          && !config.programs.mlx.clusterMode.enable
+        )
+      ) (lib.attrNames cfg.modelMtpProfiles);
+      message = "An enabled programs.mlx.modelMtpProfiles entry requires enabled vllm-mlx, a c1 model concurrency limit, and non-cluster mode. MTP evidence is experimental c1-only and must not silently enter a clustered or production-concurrent role.";
+    }
+    {
+      assertion = lib.all (
         role:
         let
           physical = config.services.aiStack.models.${role};

--- a/modules/mlx/catalog-lib.nix
+++ b/modules/mlx/catalog-lib.nix
@@ -55,13 +55,15 @@
 # An entry only offers the classes it has been validated for; requesting an
 # unoffered class fails the eval.
 #
-# KV-QUANT / MTP FLAGS: DO NOT ADD to any entry. Measured against the
+# KV-QUANT / MTP FLAGS: DO NOT ADD to normal catalog entries. Measured against the
 # deployed release mlx-lm 0.31.3 wrapper's own --help (2026-08): no
 # --kv-bits/--kv-group-size, no MTP flag exists on the release server at all.
 # The backend is official mlx-lm only (vllm-mlx disabled, enforced by
 # lib/checks/mlx-catalog.nix); #1334's KV-quant half is not actionable until
 # mlx-lm ships the flags, and its MTP half is vllm-mlx-only and stays
-# unavailable unless that backend is re-enabled. A future git-wheel
+# unavailable unless that backend is re-enabled. `modelMtpProfiles` provides a
+# separate, opt-in c1-only experimental contract when a served snapshot and
+# backend have both been verified. A future git-wheel
 # serverVariant (staged DeepSeek rollout) adds --mtp but drops
 # --harmony-tool-parser — never select it for gpt-oss.
 {

--- a/modules/mlx/model-server-cmd.nix
+++ b/modules/mlx/model-server-cmd.nix
@@ -53,6 +53,11 @@ rec {
     modelId:
     let
       backend = cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+      mtp =
+        cfg.modelMtpProfiles.${modelId} or {
+          enable = false;
+          draftBlockSize = null;
+        };
       serverPkg = mlxModelServerPkgs.${backend} or mlxModelServerPkg;
       overrides = cfg.modelFlagOverrides.${modelId} or { };
       unknown = lib.filter (k: !(lib.elem k overridableFlags)) (lib.attrNames overrides);
@@ -94,6 +99,11 @@ rec {
           (toString c.autoUnloadIdleSeconds)
         ]
         ++ lib.optionals c.enableMetrics [ "--enable-metrics" ]
+        ++ lib.optionals mtp.enable [ "--enable-mtp" ]
+        ++ lib.optionals (mtp.enable && mtp.draftBlockSize != null) [
+          "--draft-block-size"
+          (toString mtp.draftBlockSize)
+        ]
         ++ lib.optionals c.continuousBatching [ "--continuous-batching" ]
         # Applied server-side so every request carries the same logits
         # processor — a batch mixing penalized with penalty-free requests

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -200,6 +200,23 @@
       description = "Per-physical-model override of programs.mlx.proxy.concurrencyLimit (llama-swap in-flight cap), for models that must be serialized independent of the global default.";
     };
 
+    modelMtpProfiles = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            enable = lib.mkEnableOption "experimental multi-token prediction for this model";
+            draftBlockSize = lib.mkOption {
+              type = lib.types.nullOr (lib.types.ints.between 2 8);
+              default = null;
+              description = "Optional vllm-mlx MTP draft block size. Values below 2 are rejected because a one-token run is not a speculative-decoding measurement.";
+            };
+          };
+        }
+      );
+      default = { };
+      description = "Opt-in experimental MTP profiles. An enabled profile requires the vllm-mlx backend and a serialized model concurrency limit; it never changes a model's default profile.";
+    };
+
     # modelBackends — the per-model counterpart of modelServerBackend above —
     # lives in ./options-model-backends.nix (12 KB gate).
 


### PR DESCRIPTION
Recovered from an unmerged local branch during a repo-hygiene sweep. It had commits but no pull request.

Gates experimental MTP profiles behind a capability contract. Opening it so CI judges whether it still applies to current develop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vllm-mlx serve flags and adds eval assertions on backend/concurrency/cluster; impact is bounded because MTP is opt-in and gated to serialized, non-cluster vllm-mlx.
> 
> **Overview**
> Adds **`programs.mlx.modelMtpProfiles`**, an opt-in per-model switch for experimental multi-token prediction on **vllm-mlx** only. When enabled, the model-server command builder emits **`--enable-mtp`** and optional **`--draft-block-size`** (2–8).
> 
> **Evaluation-time gates** reject enabled MTP unless the model uses vllm-mlx (and that backend is in `enabledBackends`), **concurrency is 1** (per-model or global proxy limit), and **cluster mode is off**—so MTP cannot run in clustered or multi-in-flight production setups.
> 
> Catalog documentation is updated to keep MTP out of normal catalog entries and point hosts at this separate c1-only contract instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d03df02daf3e2afa7d3a7c2285633e317d24045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->