### PR TITLE
chore(deps): bump nix-claude-code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783699561,
-        "narHash": "sha256-Oc681A3Au311QturqPVhvwTCBsg8XEIITJy2iVJwyVI=",
+        "lastModified": 1783723192,
+        "narHash": "sha256-xclX8LzvWAmNWSFEisfaJWUg3f2emUJMUZ/zGlJQZMs=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "cc523447193a24bc32c623d4ece8dc0118b8c64b",
+        "rev": "d63a213af4f2c90ce3d576a2aab0c3a3ff2e4b12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`chore/bump-nix-claude-code`, 1 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a large transitive flake that owns Claude Code and marketplace configuration; impact depends on upstream changes, but scope is limited to the lockfile pin.
> 
> **Overview**
> Updates the **`nix-claude-code`** flake input in `flake.lock` from rev `cc523447…` to `d63a213a…` (new `narHash` and `lastModified` only; no other lock nodes change).
> 
> That input supplies the declarative Claude Code / Home Manager integration (marketplace catalog, plugin wiring, and related helpers), so this is a straight dependency refresh to pick up whatever landed upstream between those commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a34f6dd5b58ee59d9cd627c5a8ae28d34e37cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->