### PR TITLE
fix: launch text-only MLX models through env

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -51,7 +51,10 @@ let
     {
       programs.mlx = {
         catalog = {
-          qwen35-9b-optiq.class = "resident";
+          qwen35-9b-optiq = {
+            class = "resident";
+            roles = [ "goal-judge" ];
+          };
           qwen36-optiq.class = "resident";
           qwen3-coder-30b.class = "resident";
           gpt-oss-120b.class = "swap";

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -51,6 +51,7 @@ let
     {
       programs.mlx = {
         catalog = {
+          qwen35-9b-optiq.class = "resident";
           qwen36-optiq.class = "resident";
           qwen3-coder-30b.class = "resident";
           gpt-oss-120b.class = "swap";

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -16,6 +16,7 @@ in
       gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8";
       next80 = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
       next80Instruct = "mlx-community/Qwen3-Next-80B-A3B-Instruct-4bit";
+      judge9b = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
       optiqFlags = c.modelFlagOverrides.${optiq};
       optiqArgs = builtins.concatStringsSep " " c.modelExtraArgs.${optiq};
       inst = c.modelFlagOverrides.${next80Instruct};
@@ -33,6 +34,10 @@ in
     assert
       c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
       || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
+    assert
+      c.modelFlagOverrides.${judge9b}.cacheMemoryMb == 2048
+      && c.modelFlagOverrides.${judge9b}.maxRequestTokens == 16384
+      || throw "catalog: 9B judge resident profile must remain bounded";
     assert
       c.modelFlagOverrides.${gptOss}.pagedKvCache == false
       && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -39,6 +39,13 @@ in
       && c.modelFlagOverrides.${judge9b}.maxRequestTokens == 16384
       || throw "catalog: 9B judge resident profile must remain bounded";
     assert
+      c.modelTextOnly.${judge9b}
+      &&
+        builtins.match ".*enable_thinking.*false.*" (
+          builtins.concatStringsSep " " c.modelExtraArgs.${judge9b}
+        ) != null
+      || throw "catalog: 9B judge must use the text-only loader with thinking disabled";
+    assert
       c.modelFlagOverrides.${gptOss}.pagedKvCache == false
       && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false
       || throw "catalog: gpt-oss swap profile must disable paged KV + prefix caching";

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -46,6 +46,9 @@ in
         ) != null
       || throw "catalog: 9B judge must use the text-only loader with thinking disabled";
     assert
+      hmConfigCatalog.config.services.aiStack.roleOverrides.goal-judge == judge9b
+      || throw "catalog: logical goal-judge role must resolve to the catalog-owned physical model";
+    assert
       c.modelFlagOverrides.${gptOss}.pagedKvCache == false
       && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false
       || throw "catalog: gpt-oss swap profile must disable paged KV + prefix caching";

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -24,7 +24,7 @@ in
         let
           generated = llamaSwapConfigAttrs.models.${modelId} or null;
         in
-        generated != null && lib.hasPrefix "VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
+        generated != null && lib.hasPrefix "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
       ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
       message = "modelTextOnly entries must compile into final llama-swap commands with the text-only loader environment.";
     }

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  mlxShared,
+  ...
+}:
+let
+  inherit (mlxShared) cfg llamaSwapConfigAttrs;
+in
+{
+  # Fail evaluation when coupled options or generated proxy contracts drift.
+  assertions = lib.optionals cfg.enable [
+    {
+      assertion = !cfg.enablePrefixCaching || cfg.pagedKvCache;
+      message = ''
+        programs.mlx.enablePrefixCaching requires programs.mlx.pagedKvCache to
+        also be true. vllm-mlx builds the prefix-sharing index inside the paged
+        KV cache. Set both options true or both false.
+      '';
+    }
+    {
+      assertion = lib.all (
+        modelId:
+        let
+          generated = llamaSwapConfigAttrs.models.${modelId} or null;
+        in
+        generated != null && lib.hasPrefix "VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
+      ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
+      message = "modelTextOnly entries must compile into final llama-swap commands with the text-only loader environment.";
+    }
+    {
+      assertion = lib.all (
+        role:
+        let
+          physical = config.services.aiStack.models.${role};
+          generated = llamaSwapConfigAttrs.models.${physical} or null;
+        in
+        generated != null && lib.elem role generated.aliases
+      ) (lib.attrNames config.services.aiStack.models);
+      message = "Every AI-stack logical role must compile into the aliases of its final llama-swap physical backend.";
+    }
+  ];
+}

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -14,6 +14,23 @@ let
     ;
 in
 {
+  # Small resident auxiliary model for bounded classification and judging.
+  # OptiQ keeps tool/reasoning compatibility with the Qwen family while the
+  # 4-bit footprint permits it to stay warm beside the primary 80B brain.
+  qwen35-9b-optiq = {
+    model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
+    weightGb = 7.7;
+    args = qwenMoeGeneralParser ++ agentTimeout;
+    classes = {
+      resident.flags = block256 // {
+        cacheMemoryMb = 2048;
+        maxNumSeqs = 4;
+        maxRequestTokens = 16384;
+      };
+      swap.flags = block256 // swapFlags;
+    };
+  };
+
   # Agentic tool-calling brain (2026-07-08 bench winner; verdicts in
   # HF JacobPEvans/mlx-benchmarks). Thinking ON is part of the verdict.
   qwen36-optiq = {

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -20,7 +20,19 @@ in
   qwen35-9b-optiq = {
     model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
     weightGb = 7.7;
-    args = qwenMoeGeneralParser ++ agentTimeout;
+    # This text-only quant retains multimodal metadata even though it ships no
+    # vision-tower weights. Force the text loader and disable thinking so a
+    # bounded judge verdict does not spend its response budget on reasoning.
+    textOnly = true;
+    args =
+      qwenMoeGeneralParser
+      ++ [
+        "--default-chat-template-kwargs"
+        (builtins.toJSON {
+          enable_thinking = false;
+        })
+      ]
+      ++ agentTimeout;
     classes = {
       resident.flags = block256 // {
         cacheMemoryMb = 2048;

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -241,6 +241,7 @@ in
     ./options-parsers.nix
     ./options-runtime.nix
     ./options-cluster.nix
+    ./assertions.nix
     ./packages.nix
     ./launchd.nix
     ./launchd-watchdog.nix
@@ -270,39 +271,4 @@ in
       ;
   };
 
-  # Enforce documented option dependencies. Without these, vllm-mlx silently
-  # mis-behaves when consumers flip one boolean and forget the partner.
-  assertions = lib.optionals cfg.enable [
-    {
-      assertion = !cfg.enablePrefixCaching || cfg.pagedKvCache;
-      message = ''
-        programs.mlx.enablePrefixCaching requires programs.mlx.pagedKvCache to
-        also be true. vllm-mlx 0.2.9 builds the prefix-sharing index inside
-        the paged KV cache; turning prefix caching on without paged KV cache
-        either fails to start or silently drops the prefix-share path.
-        Either set both to true (the defaults) or both to false.
-      '';
-    }
-    {
-      assertion = lib.all (
-        modelId:
-        let
-          generated = llamaSwapConfigAttrs.models.${modelId} or null;
-        in
-        generated != null && lib.hasPrefix "VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
-      ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
-      message = "programs.mlx.modelTextOnly entries must compile into final llama-swap model commands with the text-only loader environment.";
-    }
-    {
-      assertion = lib.all (
-        role:
-        let
-          physical = config.services.aiStack.models.${role};
-          generated = llamaSwapConfigAttrs.models.${physical} or null;
-        in
-        generated != null && lib.elem role generated.aliases
-      ) (lib.attrNames config.services.aiStack.models);
-      message = "Every AI-stack logical role must compile into the aliases of its final llama-swap physical backend.";
-    }
-  ];
 }

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -283,5 +283,26 @@ in
         Either set both to true (the defaults) or both to false.
       '';
     }
+    {
+      assertion = lib.all (
+        modelId:
+        let
+          generated = llamaSwapConfigAttrs.models.${modelId} or null;
+        in
+        generated != null && lib.hasPrefix "VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
+      ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
+      message = "programs.mlx.modelTextOnly entries must compile into final llama-swap model commands with the text-only loader environment.";
+    }
+    {
+      assertion = lib.all (
+        role:
+        let
+          physical = config.services.aiStack.models.${role};
+          generated = llamaSwapConfigAttrs.models.${physical} or null;
+        in
+        generated != null && lib.elem role generated.aliases
+      ) (lib.attrNames config.services.aiStack.models);
+      message = "Every AI-stack logical role must compile into the aliases of its final llama-swap physical backend.";
+    }
   ];
 }

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -180,6 +180,10 @@ in
         name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault (entryFor name).args)
       ) argsViaExtraArgs;
 
+      modelTextOnly = lib.mapAttrs' (
+        name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault true)
+      ) (lib.filterAttrs (name: _sel: (entryFor name).textOnly or false) enabled);
+
       modelFlagOverrides = lib.mapAttrs' (
         name: sel:
         lib.nameValuePair (entryFor name).model (lib.mapAttrs (_: lib.mkDefault) (flagsFor name sel))

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -12,8 +12,8 @@
 #   entry args         -> modelExtraArgs.<physical id>        (mkDefault)
 #   class flag profile -> modelFlagOverrides.<physical id>    (mkDefault per key)
 #   class == "swap"    -> models.<physical id> (llama-swap swap-tier entry)
-# Role aliasing (which entry serves "tool-calling"/"coding"/"default") stays a
-# host concern via services.aiStack.models — the catalog never assigns roles.
+#   selection roles     -> services.aiStack.roleOverrides.<role>
+# Hosts assign logical roles to catalog entries without repeating physical IDs.
 #
 { config, lib, ... }:
 let
@@ -75,6 +75,10 @@ let
   residentWeightGb = lib.foldl' (acc: name: acc + (entryFor name).weightGb) 0.0 (
     lib.attrNames residents
   );
+  catalogRoleOverrides = lib.foldl' (
+    acc: name: acc // lib.genAttrs enabled.${name}.roles (_role: (entryFor name).model)
+  ) { } (lib.attrNames enabled);
+  selectedRoles = lib.concatMap (name: enabled.${name}.roles) (lib.attrNames enabled);
 in
 {
   options.programs.mlx = {
@@ -93,6 +97,11 @@ in
                 "swap"
               ];
               description = "Validated serving class: resident (preload-capable brain, big caps) or swap (on-demand, idle-unloaded, small caps). The entry must offer the class.";
+            };
+            roles = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+              description = "Logical AI-stack roles served by this catalog entry. The catalog resolves the physical model ID.";
             };
             tweaks = {
               cacheMemoryMb = lib.mkOption {
@@ -152,6 +161,10 @@ in
         '';
       }
       {
+        assertion = lib.length selectedRoles == lib.length (lib.unique selectedRoles);
+        message = "programs.mlx.catalog: each logical role may be assigned to only one enabled catalog entry.";
+      }
+      {
         # ttl is lifecycle for on-demand models; residents ignore it (they
         # follow proxy.idleTtl), so a resident ttl tweak would be a silent
         # no-op misconfiguration.
@@ -208,5 +221,9 @@ in
         )
       ) swapsNonRegistry;
     };
+
+    services.aiStack.roleOverrides = lib.mapAttrs (
+      _role: model: lib.mkDefault model
+    ) catalogRoleOverrides;
   };
 }

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -139,6 +139,12 @@
       description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
     };
 
+    modelTextOnly = lib.mkOption {
+      type = lib.types.attrsOf lib.types.bool;
+      default = { };
+      description = "Per-physical-model text-only loader override for model artifacts whose metadata advertises multimodal support but whose quant intentionally omits media-tower weights.";
+    };
+
     # modelConcurrencyLimits — per-physical-id override of the GLOBAL proxy
     # concurrencyLimit (the llama-swap-side in-flight cap). modelExtraArgs and
     # modelFlagOverrides tune the vllm-mlx worker; this one tunes the proxy gate

--- a/modules/mlx/vllm-cmd.nix
+++ b/modules/mlx/vllm-cmd.nix
@@ -46,7 +46,9 @@ rec {
           cfg // overrides
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
-      baseCmd = "${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
+      textOnlyEnv = lib.optionalString (cfg.modelTextOnly.${modelId} or false
+      ) "VLLM_MLX_FORCE_TEXT_ONLY=1 ";
+      baseCmd = "${textOnlyEnv}${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
         lib.optionals (c.cacheMemoryMb != null) [
           "--cache-memory-mb"

--- a/modules/mlx/vllm-cmd.nix
+++ b/modules/mlx/vllm-cmd.nix
@@ -47,7 +47,7 @@ rec {
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
       textOnlyEnv = lib.optionalString (cfg.modelTextOnly.${modelId} or false
-      ) "VLLM_MLX_FORCE_TEXT_ONLY=1 ";
+      ) "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 ";
       baseCmd = "${textOnlyEnv}${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
         lib.optionals (c.cacheMemoryMb != null) [

--- a/modules/mlx/vllm-mlx-patch.nix
+++ b/modules/mlx/vllm-mlx-patch.nix
@@ -5,10 +5,11 @@
 #   cli.py:     uvicorn.run(app, host=args.host, port=args.port, log_level="info")
 # (confirmed via `vllm-mlx serve --help` and a source read of both files —
 # no --log-level flag exists anywhere in the argparse tree). This derivation
-# patches only those two call sites to read VLLM_MLX_LOG_LEVEL (falling back
+# patches those two call sites to read VLLM_MLX_LOG_LEVEL (falling back
 # to the same upstream defaults), so programs.mlx.serverLogLevel
 # (options-runtime.nix) controls the app logger AND uvicorn's own request
-# logging. No other behavior changes.
+# logging. It also provides the catalog's opt-in text-only loader override for
+# quants whose metadata advertises media support but omits media weights.
 #
 # Patches the prebuilt wheel, not the sdist: pointing uvx's `--from` at a
 # source directory made uv try to build it in place via setuptools, which
@@ -56,6 +57,17 @@ pkgs.runCommand "vllm-mlx-wheel-patched-${vllmMlxVersion}"
       --replace-fail \
         'uvicorn.run(app, host=args.host, port=args.port, log_level="info")' \
         "$(printf '_vllm_mlx_log_level = os.environ.get("VLLM_MLX_LOG_LEVEL", "info").lower()\n    _vllm_mlx_log_level = {"warn": "warning"}.get(_vllm_mlx_log_level, _vllm_mlx_log_level)\n    uvicorn.run(app, host=args.host, port=args.port, log_level=_vllm_mlx_log_level)')"
+
+    # Some text-only quants preserve multimodal config metadata while omitting
+    # the media-tower weights. Let the per-model catalog select the LLM loader
+    # without rewriting the cached Hugging Face artifact.
+    substituteInPlace unpacked/vllm_mlx/api/utils.py \
+      --replace-fail \
+        'import logging' \
+        "$(printf 'import logging\nimport os')" \
+      --replace-fail \
+        '    config = _try_read_config_json(model_name)' \
+        "$(printf '    if os.environ.get("VLLM_MLX_FORCE_TEXT_ONLY") == "1":\n        return False\n    config = _try_read_config_json(model_name)')"
 
     # _build_engine is the lifecycle/residency construction path, taken
     # whenever --auto-unload-idle-seconds or --lazy-load-model is set. Unlike


### PR DESCRIPTION
`feat/hermes-judge-model`, 6 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how vllm-mlx loads models and how catalog selections map to AI-stack roles and llama-swap commands; miscompilation would break serving or role routing at eval or runtime.
> 
> **Overview**
> Adds a **text-only serving path** for MLX quants whose HF metadata still claims multimodal support: new `programs.mlx.modelTextOnly`, `VLLM_MLX_FORCE_TEXT_ONLY` in the patched vllm-mlx wheel, and llama-swap commands prefixed with `/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1` when enabled. Catalog entries with `textOnly = true` compile into that surface automatically.
> 
> Introduces catalog entry **`qwen35-9b-optiq`** as a small resident judge (tight KV/token caps, thinking off) and wires **`programs.mlx.catalog.*.roles`** into `services.aiStack.roleOverrides` so hosts can bind logical roles like `goal-judge` without repeating physical model IDs, with an eval-time check that each role is assigned only once.
> 
> **MLX assertions** move into `assertions.nix` and expand to verify prefix-caching coupling, text-only commands in generated llama-swap config, and that every AI-stack role appears in its backend’s aliases. Catalog regression tests cover the 9B judge profile and `goal-judge` resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e42b4cfca39d7b00feefb68268e625be8782e60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->