### PR TITLE
feat(catalog): assert tweaks.ttl is swap-class-only (review catch)

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -72,7 +72,8 @@ in
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
 // (import ./checks/autonomous-profile.nix { inherit pkgs; })
-// (import ./checks/mlx.nix { inherit pkgs hmConfig hmConfigCatalog; })
+// (import ./checks/mlx.nix { inherit pkgs hmConfig; })
+// (import ./checks/mlx-catalog.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -43,6 +43,27 @@ let
   # Second evaluation with fabric REST API LaunchAgent enabled — used by the
   # fabric-launchd positive check (default eval has enableServer = false).
   hmConfigFabricServer = mkHmConfig [ { programs.fabric.enableServer = true; } ];
+
+  # Third evaluation exercising programs.mlx.catalog (lib/checks/mlx.nix
+  # mlx-catalog): a server-like selection plus one direct host override that
+  # must beat the catalog's mkDefault.
+  hmConfigCatalog = mkHmConfig [
+    {
+      programs.mlx = {
+        catalog = {
+          qwen36-optiq.class = "resident";
+          qwen3-coder-30b.class = "resident";
+          gpt-oss-120b.class = "swap";
+          qwen3-next-80b = {
+            class = "swap";
+            tweaks.ttl = 600;
+          };
+        };
+        # Direct host setting on a catalog-managed key must win over the catalog.
+        modelFlagOverrides."mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit".cacheMemoryMb = 8192;
+      };
+    }
+  ];
 in
 (import ./checks/lint.nix { inherit pkgs src; })
 // (import ./checks/ai-stack.nix { inherit pkgs testLocalModelId; })
@@ -51,7 +72,7 @@ in
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
 // (import ./checks/autonomous-profile.nix { inherit pkgs; })
-// (import ./checks/mlx.nix { inherit pkgs hmConfig; })
+// (import ./checks/mlx.nix { inherit pkgs hmConfig hmConfigCatalog; })
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks/lint.nix
+++ b/lib/checks/lint.nix
@@ -50,13 +50,16 @@
   # Every consumer references a capability role, never a hardcoded id — so a
   # model swap touches only the registry. Allowed: the "mlx-community/<...>"
   # placeholder in option examples and the "test-model" id in the check harness.
-  # lib/checks/* is excluded since it names the pattern itself.
+  # lib/checks/* is excluded since it names the pattern itself, and
+  # modules/mlx/catalog-data.nix is excluded because it IS the physical-id
+  # SSOT (the validated model catalog every other reference resolves through).
   no-hardcoded-model-id = pkgs.runCommand "check-no-hardcoded-model-id" { } ''
     cd ${src}
     bad=$(grep -rnoE 'mlx-community/[A-Za-z0-9][^[:space:]"]*' \
       --include='*.nix' --include='*.sh' --include='*.md' \
       --exclude-dir=.git --exclude-dir=result --exclude-dir=.direnv . \
       | grep -vE 'lib/checks' \
+      | grep -vE 'modules/mlx/catalog-data\.nix' \
       | grep -vE 'mlx-community/test-model' || true)
     if [ -n "$bad" ]; then
       echo "ERROR: hardcoded physical MLX model id(s) found — use an ai-stack capability role instead:" >&2

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -1,0 +1,48 @@
+# Catalog compile regression tests (programs.mlx.catalog -> per-model surfaces)
+{ pkgs, hmConfigCatalog }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+in
+{
+  # Catalog compile regression (programs.mlx.catalog -> per-model surfaces).
+  # Uses hmConfigCatalog (lib/checks.nix): optiq+coder resident, gpt-oss+80B
+  # swap (80B with a ttl tweak), plus a direct host override on optiq's
+  # cacheMemoryMb that must beat the catalog's mkDefault.
+  mlx-catalog =
+    let
+      c = hmConfigCatalog.config.programs.mlx;
+      optiq = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
+      coder = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+      next80 = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
+      optiqFlags = c.modelFlagOverrides.${optiq};
+      optiqArgs = builtins.concatStringsSep " " c.modelExtraArgs.${optiq};
+    in
+    assert
+      optiqFlags.cacheMemoryMb == 8192
+      || throw "catalog: direct host override (8192) must beat the catalog default 16384, got ${toString optiqFlags.cacheMemoryMb}";
+    assert
+      optiqFlags.pagedCacheBlockSize == 256 && optiqFlags.maxNumSeqs == 8
+      || throw "catalog: optiq resident profile (block 256 / maxNumSeqs 8) not compiled";
+    assert
+      builtins.match ".*--tool-call-parser hermes.*--reasoning-parser qwen3.*" optiqArgs != null
+      || throw "catalog: optiq family parser args not compiled into modelExtraArgs: ${optiqArgs}";
+    assert
+      c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
+      || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
+    assert
+      c.modelFlagOverrides.${gptOss}.pagedKvCache == false
+      && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false
+      || throw "catalog: gpt-oss swap profile must disable paged KV + prefix caching";
+    assert
+      c.models.${gptOss}.ttl == 900
+      || throw "catalog: gpt-oss swap ttl must default to 900, got ${toString c.models.${gptOss}.ttl}";
+    assert
+      c.models.${next80}.ttl == 600 && c.modelFlagOverrides.${next80}.autoUnloadIdleSeconds == 600
+      || throw "catalog: 80B ttl tweak (600) must reach both llama-swap ttl and worker idle unload";
+    assert
+      builtins.match ".*enable_thinking.*" (builtins.concatStringsSep " " c.models.${next80}.extraArgs)
+      == null
+      || throw "catalog: 80B (always-thinking variant) must not carry an enable_thinking kwarg";
+    helpers.mkMarker "check-mlx-catalog" "MLX catalog: resident/swap compile, bounded tweak, ttl fan-out, and host-override precedence verified";
+}

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -1,9 +1,5 @@
 # MLX module regression tests and LaunchAgent validation
-{
-  pkgs,
-  hmConfig,
-  hmConfigCatalog,
-}:
+{ pkgs, hmConfig }:
 let
   helpers = import ./helpers.nix { inherit pkgs; };
   mlxCfg = hmConfig.config.programs.mlx;
@@ -322,46 +318,4 @@ in
         builtins.toJSON (map (tc: tc.bannedFlag) undetected)
       }";
     helpers.mkMarker "check-mlx-launchd-negative" "MLX LaunchAgent negative: ${toString (builtins.length testCases)} banned flag patterns verified detectable";
-
-  # Catalog compile regression (programs.mlx.catalog -> per-model surfaces).
-  # Uses hmConfigCatalog (lib/checks.nix): optiq+coder resident, gpt-oss+80B
-  # swap (80B with a ttl tweak), plus a direct host override on optiq's
-  # cacheMemoryMb that must beat the catalog's mkDefault.
-  mlx-catalog =
-    let
-      c = hmConfigCatalog.config.programs.mlx;
-      optiq = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
-      coder = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
-      gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8";
-      next80 = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
-      optiqFlags = c.modelFlagOverrides.${optiq};
-      optiqArgs = builtins.concatStringsSep " " c.modelExtraArgs.${optiq};
-    in
-    assert
-      optiqFlags.cacheMemoryMb == 8192
-      || throw "catalog: direct host override (8192) must beat the catalog default 16384, got ${toString optiqFlags.cacheMemoryMb}";
-    assert
-      optiqFlags.pagedCacheBlockSize == 256 && optiqFlags.maxNumSeqs == 8
-      || throw "catalog: optiq resident profile (block 256 / maxNumSeqs 8) not compiled";
-    assert
-      builtins.match ".*--tool-call-parser hermes.*--reasoning-parser qwen3.*" optiqArgs != null
-      || throw "catalog: optiq family parser args not compiled into modelExtraArgs: ${optiqArgs}";
-    assert
-      c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
-      || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
-    assert
-      c.modelFlagOverrides.${gptOss}.pagedKvCache == false
-      && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false
-      || throw "catalog: gpt-oss swap profile must disable paged KV + prefix caching";
-    assert
-      c.models.${gptOss}.ttl == 900
-      || throw "catalog: gpt-oss swap ttl must default to 900, got ${toString c.models.${gptOss}.ttl}";
-    assert
-      c.models.${next80}.ttl == 600 && c.modelFlagOverrides.${next80}.autoUnloadIdleSeconds == 600
-      || throw "catalog: 80B ttl tweak (600) must reach both llama-swap ttl and worker idle unload";
-    assert
-      builtins.match ".*enable_thinking.*" (builtins.concatStringsSep " " c.models.${next80}.extraArgs)
-      == null
-      || throw "catalog: 80B (always-thinking variant) must not carry an enable_thinking kwarg";
-    helpers.mkMarker "check-mlx-catalog" "MLX catalog: resident/swap compile, bounded tweak, ttl fan-out, and host-override precedence verified";
 }

--- a/lib/checks/mlx.nix
+++ b/lib/checks/mlx.nix
@@ -1,5 +1,9 @@
 # MLX module regression tests and LaunchAgent validation
-{ pkgs, hmConfig }:
+{
+  pkgs,
+  hmConfig,
+  hmConfigCatalog,
+}:
 let
   helpers = import ./helpers.nix { inherit pkgs; };
   mlxCfg = hmConfig.config.programs.mlx;
@@ -318,4 +322,46 @@ in
         builtins.toJSON (map (tc: tc.bannedFlag) undetected)
       }";
     helpers.mkMarker "check-mlx-launchd-negative" "MLX LaunchAgent negative: ${toString (builtins.length testCases)} banned flag patterns verified detectable";
+
+  # Catalog compile regression (programs.mlx.catalog -> per-model surfaces).
+  # Uses hmConfigCatalog (lib/checks.nix): optiq+coder resident, gpt-oss+80B
+  # swap (80B with a ttl tweak), plus a direct host override on optiq's
+  # cacheMemoryMb that must beat the catalog's mkDefault.
+  mlx-catalog =
+    let
+      c = hmConfigCatalog.config.programs.mlx;
+      optiq = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
+      coder = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+      gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+      next80 = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
+      optiqFlags = c.modelFlagOverrides.${optiq};
+      optiqArgs = builtins.concatStringsSep " " c.modelExtraArgs.${optiq};
+    in
+    assert
+      optiqFlags.cacheMemoryMb == 8192
+      || throw "catalog: direct host override (8192) must beat the catalog default 16384, got ${toString optiqFlags.cacheMemoryMb}";
+    assert
+      optiqFlags.pagedCacheBlockSize == 256 && optiqFlags.maxNumSeqs == 8
+      || throw "catalog: optiq resident profile (block 256 / maxNumSeqs 8) not compiled";
+    assert
+      builtins.match ".*--tool-call-parser hermes.*--reasoning-parser qwen3.*" optiqArgs != null
+      || throw "catalog: optiq family parser args not compiled into modelExtraArgs: ${optiqArgs}";
+    assert
+      c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
+      || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
+    assert
+      c.modelFlagOverrides.${gptOss}.pagedKvCache == false
+      && c.modelFlagOverrides.${gptOss}.enablePrefixCaching == false
+      || throw "catalog: gpt-oss swap profile must disable paged KV + prefix caching";
+    assert
+      c.models.${gptOss}.ttl == 900
+      || throw "catalog: gpt-oss swap ttl must default to 900, got ${toString c.models.${gptOss}.ttl}";
+    assert
+      c.models.${next80}.ttl == 600 && c.modelFlagOverrides.${next80}.autoUnloadIdleSeconds == 600
+      || throw "catalog: 80B ttl tweak (600) must reach both llama-swap ttl and worker idle unload";
+    assert
+      builtins.match ".*enable_thinking.*" (builtins.concatStringsSep " " c.models.${next80}.extraArgs)
+      == null
+      || throw "catalog: 80B (always-thinking variant) must not carry an enable_thinking kwarg";
+    helpers.mkMarker "check-mlx-catalog" "MLX catalog: resident/swap compile, bounded tweak, ttl fan-out, and host-override precedence verified";
 }

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -1,0 +1,175 @@
+# Validated MLX model catalog — pure data, shipped with the module.
+#
+# This is the single source of truth for HOW each known model is served:
+# family serve args (parser stack, chat-template kwargs) and per-class
+# validated flag profiles. Hosts only pick WHICH entries to enable, the
+# class, and a few type-bounded tweaks (programs.mlx.catalog, see
+# options-catalog.nix) — detailed serve args never belong in host config.
+#
+# Entry schema:
+#   model            physical Hugging Face id
+#   args             family serve args, applied in every class
+#   classes.<class>  validated profile: { flags = modelFlagOverrides attrs }
+#     resident — preload-capable agent brain (host preload list still decides
+#                what actually warms at boot)
+#     swap     — on-demand, idle-unloaded, small caps
+# An entry only offers the classes it has been validated for; requesting an
+# unoffered class fails the eval.
+let
+  # Qwen3.6/Next MoE lineage: XML tool format needs hermes (qwen3_coder
+  # mis-parses it → empty function.name repair storms) + qwen3 reasoning.
+  qwenMoeGeneralParser = [
+    "--tool-call-parser"
+    "hermes"
+    "--reasoning-parser"
+    "qwen3"
+  ];
+  # Guard chain: server 3600 > router 2400 > client 1800 (lifts the
+  # 300 s disconnect_guard).
+  agentTimeout = [
+    "--timeout"
+    "3600"
+  ];
+  # 256-token paged-cache blocks (default 64): long sessions shattered the KV
+  # into enough per-block Metal buffers to trip MLX's buffer-count limit
+  # ("Resource limit (499000) exceeded", not a byte OOM). Validated with a
+  # 113K-token request 2026-07-09 (nix-darwin#1609).
+  block256 = {
+    pagedCacheBlockSize = 256;
+  };
+  # Swap tier: on-demand, idle-unloaded, small caps.
+  swapFlags = {
+    autoUnloadIdleSeconds = 900;
+    maxNumSeqs = 2;
+    maxRequestTokens = 32768;
+  };
+in
+{
+  # Agentic tool-calling brain (2026-07-08 bench winner; verdicts in
+  # HF JacobPEvans/mlx-benchmarks). Thinking ON is part of the verdict.
+  qwen36-optiq = {
+    model = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
+    args =
+      qwenMoeGeneralParser
+      ++ [
+        "--default-chat-template-kwargs"
+        (builtins.toJSON {
+          enable_thinking = true;
+        })
+      ]
+      ++ agentTimeout;
+    classes = {
+      # HIGH KV budget for 40-58K-token contexts; maxNumSeqs 8 = one
+      # continuous batch. 65536 replaces the 32768 cap that fed the
+      # truncation/retry death-loop.
+      resident.flags = block256 // {
+        cacheMemoryMb = 16384;
+        maxNumSeqs = 8;
+        maxRequestTokens = 65536;
+      };
+      swap.flags =
+        block256
+        // swapFlags
+        // {
+          cacheMemoryMb = 3072;
+        };
+    };
+  };
+
+  qwen3-coder-30b = {
+    model = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+    args = [
+      "--tool-call-parser"
+      "qwen3_coder"
+    ]
+    ++ agentTimeout;
+    classes = {
+      # The global maxRequestTokens default is too low for agentic multi-turn.
+      resident.flags = block256 // {
+        maxRequestTokens = 32768;
+      };
+      swap.flags = block256 // swapFlags;
+    };
+  };
+
+  # Stock sibling of the OptiQ brain. Parser anomaly: still qwen3_coder
+  # (predates the 2026-07-08 bench); flip to the family parser only with a
+  # bench on this variant. Thinking off by default (requests can opt in).
+  qwen36-35b = {
+    model = "mlx-community/Qwen3.6-35B-A3B-4bit";
+    args = [
+      "--tool-call-parser"
+      "qwen3_coder"
+      "--reasoning-parser"
+      "qwen3"
+      "--default-chat-template-kwargs"
+      (builtins.toJSON {
+        enable_thinking = false;
+      })
+    ];
+    classes = {
+      swap.flags =
+        block256
+        // swapFlags
+        // {
+          cacheMemoryMb = 3072;
+        };
+    };
+  };
+
+  # LARGE rotation brain. Always-thinking variant (no chat-template switch).
+  # Small cache keeps the on-demand swap-in under the memory trip (derivation
+  # in mlx-benchmarks docs/RUNBOOK.md). prefixCaching off — unsupported for
+  # the qwen3_next hybrid-attention family. Paged block size stays default:
+  # 256 is unvalidated on hybrid attention.
+  qwen3-next-80b = {
+    model = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
+    args = qwenMoeGeneralParser ++ agentTimeout;
+    classes = {
+      swap.flags = swapFlags // {
+        cacheMemoryMb = 4096;
+        enablePrefixCaching = false;
+      };
+    };
+  };
+
+  # gpt-oss MUST set --reasoning-parser gpt_oss — unset, its harmony channel
+  # markers leak into streamed message.content (nix-ai#1083). Paged cache +
+  # prefix caching OFF: sliding-window attention hits [broadcast_shapes] with
+  # vllm-mlx 0.4.0's paged cache.
+  gpt-oss-120b = {
+    model = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+    args = [
+      "--tool-call-parser"
+      "harmony"
+      "--reasoning-parser"
+      "gpt_oss"
+      # Server defaults keep request-level chat_template_kwargs overrideable.
+      "--default-chat-template-kwargs"
+      (builtins.toJSON {
+        reasoning_effort = "low";
+      })
+    ];
+    classes = {
+      # 63 GB — never resident; idle unload frees it back to baseline.
+      swap.flags = {
+        pagedKvCache = false;
+        enablePrefixCaching = false;
+        autoUnloadIdleSeconds = 900;
+      };
+    };
+  };
+
+  # Standard-attention MoE workstation default; hermes tool calling
+  # (nix-ai#915).
+  qwen3-30b-2507 = {
+    model = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
+    args = [
+      "--tool-call-parser"
+      "hermes"
+    ];
+    classes = {
+      swap.flags = swapFlags;
+    };
+  };
+}

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -8,6 +8,7 @@
 #
 # Entry schema:
 #   model            physical Hugging Face id
+#   weightGb         4-bit weight footprint (co-residency budget accounting)
 #   args             family serve args, applied in every class
 #   classes.<class>  validated profile: { flags = modelFlagOverrides attrs }
 #     resident — preload-capable agent brain (host preload list still decides
@@ -49,6 +50,7 @@ in
   # HF JacobPEvans/mlx-benchmarks). Thinking ON is part of the verdict.
   qwen36-optiq = {
     model = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit";
+    weightGb = 19.5;
     args =
       qwenMoeGeneralParser
       ++ [
@@ -78,6 +80,7 @@ in
 
   qwen3-coder-30b = {
     model = "mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit";
+    weightGb = 17.1;
     args = [
       "--tool-call-parser"
       "qwen3_coder"
@@ -97,6 +100,7 @@ in
   # bench on this variant. Thinking off by default (requests can opt in).
   qwen36-35b = {
     model = "mlx-community/Qwen3.6-35B-A3B-4bit";
+    weightGb = 19.4;
     args = [
       "--tool-call-parser"
       "qwen3_coder"
@@ -124,6 +128,7 @@ in
   # 256 is unvalidated on hybrid attention.
   qwen3-next-80b = {
     model = "mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit";
+    weightGb = 42.0;
     args = qwenMoeGeneralParser ++ agentTimeout;
     classes = {
       swap.flags = swapFlags // {
@@ -139,6 +144,7 @@ in
   # vllm-mlx 0.4.0's paged cache.
   gpt-oss-120b = {
     model = "mlx-community/gpt-oss-120b-MXFP4-Q8";
+    weightGb = 63.3;
     args = [
       "--tool-call-parser"
       "harmony"
@@ -164,6 +170,7 @@ in
   # (nix-ai#915).
   qwen3-30b-2507 = {
     model = "mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit";
+    weightGb = 17.5;
     args = [
       "--tool-call-parser"
       "hermes"

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -64,6 +64,7 @@ let
     "continuousBatching"
     "enablePrefixCaching"
     "pagedKvCache"
+    "pagedCacheBlockSize"
     "maxNumSeqs"
     "chunkedPrefillTokens"
     "completionBatchSize"
@@ -105,6 +106,10 @@ let
         ++ lib.optionals c.continuousBatching [ "--continuous-batching" ]
         ++ lib.optionals c.enablePrefixCaching [ "--enable-prefix-cache" ]
         ++ lib.optionals c.pagedKvCache [ "--use-paged-cache" ]
+        ++ lib.optionals (c.pagedKvCache && c.pagedCacheBlockSize != null) [
+          "--paged-cache-block-size"
+          (toString c.pagedCacheBlockSize)
+        ]
         ++ lib.optionals (c.maxNumSeqs != null) [
           "--max-num-seqs"
           (toString c.maxNumSeqs)
@@ -269,6 +274,7 @@ in
     ./options-server.nix
     ./options-cache.nix
     ./options-batching.nix
+    ./options-catalog.nix
     ./options-filters.nix
     ./options-parsers.nix
     ./options-runtime.nix

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -95,6 +95,19 @@
       description = "Use paged KV cache (--use-paged-cache). Required for prefix sharing.";
     };
 
+    # pagedCacheBlockSize — tokens per paged-KV block (--paged-cache-block-size).
+    # The engine default (64) shatters long-session KV into enough per-block
+    # Metal buffers to trip MLX's buffer-COUNT ceiling ("[metal::malloc]
+    # Resource limit (499000) exceeded" — not a byte OOM). 256 validated with a
+    # 113K-token request 2026-07-09 (nix-darwin#1609). Null = engine default.
+    # Only meaningful with pagedKvCache; leave null for hybrid-attention
+    # families (qwen3_next) where larger blocks are unvalidated.
+    pagedCacheBlockSize = lib.mkOption {
+      type = lib.types.nullOr lib.types.ints.positive;
+      default = null;
+      description = "Tokens per paged-KV-cache block (--paged-cache-block-size). Null = engine default (64). Larger blocks reduce Metal buffer count on long contexts.";
+    };
+
     # prefillBatchSize — Batch size for prompt prefill processing (--prefill-batch-size).
     # Default: null = server picks optimal value based on available memory.
     # Previously --prefill-step-size; renamed in v0.2.6.

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -152,6 +152,17 @@ in
         '';
       }
       {
+        # ttl is lifecycle for on-demand models; residents ignore it (they
+        # follow proxy.idleTtl), so a resident ttl tweak would be a silent
+        # no-op misconfiguration.
+        assertion = lib.all (name: residents.${name}.tweaks.ttl == null) (lib.attrNames residents);
+        message = ''
+          programs.mlx.catalog: tweaks.ttl is only meaningful on class = "swap"
+          entries — resident-class models follow programs.mlx.proxy.idleTtl.
+          Remove the ttl tweak from the resident entr(y/ies) or demote them.
+        '';
+      }
+      {
         assertion = cfg.gpuMemoryUtilization == null || cfg.gpuMemoryUtilization <= 0.85;
         message = ''
           programs.mlx.gpuMemoryUtilization must stay <= 0.85 on catalog hosts —

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -1,0 +1,190 @@
+#
+# MLX Module — validated model catalog (programs.mlx.catalog)
+#
+# The catalog is the DRY boundary between nix-ai (owns HOW a model is served:
+# parser stack, chat-template kwargs, per-class flag profiles — catalog-data.nix)
+# and host config (owns WHICH entries run, in which class, plus a few
+# type-bounded tweaks). Detailed serve args in a host file are a smell; add or
+# fix them here instead.
+#
+# Compilation targets the existing per-model surfaces, so the catalog composes
+# with (and can be overridden by) direct host settings:
+#   entry args         -> modelExtraArgs.<physical id>        (mkDefault)
+#   class flag profile -> modelFlagOverrides.<physical id>    (mkDefault per key)
+#   class == "swap"    -> models.<physical id> (llama-swap swap-tier entry)
+# Role aliasing (which entry serves "tool-calling"/"coding"/"default") stays a
+# host concern via services.aiStack.models — the catalog never assigns roles.
+#
+{ config, lib, ... }:
+let
+  cfg = config.programs.mlx;
+  catalogData = import ./catalog-data.nix;
+
+  enabled = lib.filterAttrs (_: sel: sel.enable) cfg.catalog;
+
+  entryFor =
+    name:
+    catalogData.${name} or (throw ''
+      programs.mlx.catalog."${name}": unknown catalog entry.
+      Known entries: ${lib.concatStringsSep ", " (lib.attrNames catalogData)}
+    '');
+
+  profileFor =
+    name: sel:
+    let
+      entry = entryFor name;
+    in
+    entry.classes.${sel.class}.flags or (throw ''
+      programs.mlx.catalog."${name}": class "${sel.class}" is not offered by
+      this entry (offered: ${lib.concatStringsSep ", " (lib.attrNames entry.classes)}).
+      A class must be validated on real hardware before the catalog offers it.
+    '');
+
+  # Bounded host tweaks (non-null only) merge over the validated class profile.
+  # ttl is proxy/idle lifecycle, not a serve flag — pulled out separately.
+  flagsFor =
+    name: sel:
+    profileFor name sel
+    // lib.filterAttrs (k: v: k != "ttl" && v != null) sel.tweaks
+    // lib.optionalAttrs (sel.class == "swap" && sel.tweaks.ttl != null) {
+      autoUnloadIdleSeconds = sel.tweaks.ttl;
+    };
+
+  swapTtlFor =
+    name: sel:
+    if sel.tweaks.ttl != null then
+      sel.tweaks.ttl
+    else
+      (profileFor name sel).autoUnloadIdleSeconds or 900;
+
+  residents = lib.filterAttrs (_: sel: sel.class == "resident") enabled;
+  swaps = lib.filterAttrs (_: sel: sel.class == "swap") enabled;
+
+  # Physical ids already served by the role registry (services.aiStack.models).
+  # A swap-class entry that is ALSO role-registered (e.g. gpt-oss owning the
+  # "default" role but demoted from preload) must keep its single registry
+  # backend — emitting a models.<id> entry too would collide in llama-swap's
+  # model table and clobber the alias/useModelName wiring. Its args therefore
+  # travel via modelExtraArgs and its swap profile via modelFlagOverrides.
+  registryPhysicals = lib.attrValues config.services.aiStack.models;
+  isRegistry = name: lib.elem (entryFor name).model registryPhysicals;
+
+  argsViaExtraArgs = residents // lib.filterAttrs (name: _: isRegistry name) swaps;
+  swapsNonRegistry = lib.filterAttrs (name: _: !(isRegistry name)) swaps;
+
+  residentWeightGb = lib.foldl' (acc: name: acc + (entryFor name).weightGb) 0.0 (
+    lib.attrNames residents
+  );
+in
+{
+  options.programs.mlx = {
+    catalog = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule {
+          options = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              default = true;
+              description = "Whether this catalog entry is compiled into the serving config.";
+            };
+            class = lib.mkOption {
+              type = lib.types.enum [
+                "resident"
+                "swap"
+              ];
+              description = "Validated serving class: resident (preload-capable brain, big caps) or swap (on-demand, idle-unloaded, small caps). The entry must offer the class.";
+            };
+            tweaks = {
+              cacheMemoryMb = lib.mkOption {
+                type = lib.types.nullOr (lib.types.ints.between 1024 32768);
+                default = null;
+                description = "Override the class profile's KV-cache budget (MB), within safe bounds.";
+              };
+              maxNumSeqs = lib.mkOption {
+                type = lib.types.nullOr (lib.types.ints.between 1 16);
+                default = null;
+                description = "Override the class profile's continuous-batch width, within safe bounds.";
+              };
+              maxRequestTokens = lib.mkOption {
+                type = lib.types.nullOr (lib.types.ints.between 4096 131072);
+                default = null;
+                description = "Override the class profile's per-request token ceiling, within safe bounds.";
+              };
+              ttl = lib.mkOption {
+                type = lib.types.nullOr (lib.types.ints.between 300 3600);
+                default = null;
+                description = "Swap-class only: idle seconds before unload (both llama-swap ttl and worker --auto-unload-idle-seconds).";
+              };
+            };
+          };
+        }
+      );
+      default = { };
+      example = lib.literalExpression ''
+        {
+          qwen36-optiq.class = "resident";
+          qwen3-coder-30b.class = "resident";
+          gpt-oss-120b.class = "swap";
+          qwen3-next-80b = {
+            class = "swap";
+            tweaks.ttl = 600;
+          };
+        }
+      '';
+      description = "Validated-model catalog selections. Keys name entries in modules/mlx/catalog-data.nix; the catalog owns parser stacks and per-class flag profiles, the host only picks entries, classes, and bounded tweaks.";
+    };
+
+    residentWeightBudgetGb = lib.mkOption {
+      type = lib.types.numbers.between 10 120;
+      default = 70;
+      description = "Eval-time ceiling on the summed 4-bit weight footprint of resident-class catalog entries. Guards against scheduling a resident set whose weights alone crowd out KV caches and the OS working set.";
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && enabled != { }) {
+    assertions = [
+      {
+        assertion = residentWeightGb <= cfg.residentWeightBudgetGb;
+        message = ''
+          programs.mlx.catalog: resident-class weights sum to ${toString residentWeightGb} GB,
+          exceeding residentWeightBudgetGb = ${toString cfg.residentWeightBudgetGb}.
+          Demote an entry to class = "swap" or raise the budget deliberately.
+        '';
+      }
+      {
+        assertion = cfg.gpuMemoryUtilization == null || cfg.gpuMemoryUtilization <= 0.85;
+        message = ''
+          programs.mlx.gpuMemoryUtilization must stay <= 0.85 on catalog hosts —
+          above that the Metal cache-clear trip sits inside normal serving load.
+        '';
+      }
+    ];
+
+    programs.mlx = {
+      # Registry models (residents + role-registered swaps) read
+      # modelExtraArgs; non-registry swap args travel on the models.<id>
+      # entry instead. mkDefault everywhere: a direct host setting on the
+      # same physical id wins over the catalog.
+      modelExtraArgs = lib.mapAttrs' (
+        name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault (entryFor name).args)
+      ) argsViaExtraArgs;
+
+      modelFlagOverrides = lib.mapAttrs' (
+        name: sel:
+        lib.nameValuePair (entryFor name).model (lib.mapAttrs (_: lib.mkDefault) (flagsFor name sel))
+      ) enabled;
+
+      models = lib.mapAttrs' (
+        name: sel:
+        lib.nameValuePair (entryFor name).model (
+          lib.mkDefault {
+            ttl = swapTtlFor name sel;
+            # The swap-tier cmd builder raw-concatenates extraArgs, so quote
+            # each token here (JSON kwargs contain shell metacharacters).
+            extraArgs = map lib.escapeShellArg (entryFor name).args;
+          }
+        )
+      ) swapsNonRegistry;
+    };
+  };
+}


### PR DESCRIPTION
`feat/mlx-model-catalog`, 4 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local MLX models are compiled into llama-swap/vllm-mlx serving config; mistakes affect memory limits, parsers, and swap behavior, though bounded tweaks and regression checks reduce foot-guns.
> 
> **Overview**
> Adds **`programs.mlx.catalog`**: hosts choose named entries from **`catalog-data.nix`**, set **resident** vs **swap**, and apply **bounded tweaks**; the module compiles validated parser stacks and flag profiles into **`modelExtraArgs`**, **`modelFlagOverrides`**, and swap-tier **`models`**, using **`mkDefault`** so direct host settings still win. Swap **`tweaks.ttl`** fans out to llama-swap TTL and worker idle unload; role-registry models avoid duplicate llama-swap entries.
> 
> New eval-time assertions include **resident weight budget**, **`gpuMemoryUtilization` ≤ 0.85** on catalog hosts, and **`tweaks.ttl` only on swap-class** entries (resident TTL follows **`proxy.idleTtl`**).
> 
> Also wires **`pagedCacheBlockSize`** through MLX options and the vllm-mlx command builder. CI gains **`check-mlx-catalog`** plus a lint carve-out for **`catalog-data.nix`** as the physical model-id SSOT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44adcbd5b4c7c28f54f3ee64233144a235bf7b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->