### PR TITLE
test(catalog): track resident block 512 in the mlx-catalog check

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -22,8 +22,8 @@ in
       optiqFlags.cacheMemoryMb == 8192
       || throw "catalog: direct host override (8192) must beat the catalog default 16384, got ${toString optiqFlags.cacheMemoryMb}";
     assert
-      optiqFlags.pagedCacheBlockSize == 256 && optiqFlags.maxNumSeqs == 8
-      || throw "catalog: optiq resident profile (block 256 / maxNumSeqs 8) not compiled";
+      optiqFlags.pagedCacheBlockSize == 512 && optiqFlags.maxNumSeqs == 8
+      || throw "catalog: optiq resident profile (block 512 / maxNumSeqs 8) not compiled";
     assert
       builtins.match ".*--tool-call-parser hermes.*--reasoning-parser qwen3.*" optiqArgs != null
       || throw "catalog: optiq family parser args not compiled into modelExtraArgs: ${optiqArgs}";

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -31,12 +31,20 @@ let
     "--timeout"
     "3600"
   ];
-  # 256-token paged-cache blocks (default 64): long sessions shattered the KV
+  # Paged-cache block sizing (engine default 64): long sessions shatter the KV
   # into enough per-block Metal buffers to trip MLX's buffer-count limit
-  # ("Resource limit (499000) exceeded", not a byte OOM). Validated with a
-  # 113K-token request 2026-07-09 (nix-darwin#1609).
+  # ("Resource limit (499000) exceeded", not a byte OOM; nix-darwin#1609).
+  # Residents run 512: 256 (validated 113K single-stream) still tripped once
+  # under 2x ~50K-token concurrency + a 16K-token generation on 2026-07-09
+  # even with the MLX_BUFFER_CACHE_LIMIT cap — 512 halves the per-token block
+  # count again (worst case ~98K buffers at maxNumSeqs 8 x 65K window, deep
+  # under the ceiling). Swap tier stays 256: its 32K request cap keeps block
+  # counts low, and 512 is unvalidated there.
   block256 = {
     pagedCacheBlockSize = 256;
+  };
+  block512 = {
+    pagedCacheBlockSize = 512;
   };
   # Swap tier: on-demand, idle-unloaded, small caps.
   swapFlags = {
@@ -64,7 +72,7 @@ in
       # HIGH KV budget for 40-58K-token contexts; maxNumSeqs 8 = one
       # continuous batch. 65536 replaces the 32768 cap that fed the
       # truncation/retry death-loop.
-      resident.flags = block256 // {
+      resident.flags = block512 // {
         cacheMemoryMb = 16384;
         maxNumSeqs = 8;
         maxRequestTokens = 65536;
@@ -88,7 +96,7 @@ in
     ++ agentTimeout;
     classes = {
       # The global maxRequestTokens default is too low for agentic multi-turn.
-      resident.flags = block256 // {
+      resident.flags = block512 // {
         maxRequestTokens = 32768;
       };
       swap.flags = block256 // swapFlags;


### PR DESCRIPTION
`feat/resident-block-512`, 2 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validated serving flags for resident agent models (KV paging behavior under load); swap paths are unchanged but resident concurrency/memory tradeoffs differ from the prior 256-block profile.
> 
> **Overview**
> **Resident** MLX catalog profiles for OptiQ and Qwen3-Coder now use **`pagedCacheBlockSize` 512** instead of 256, via a new `block512` preset; **swap** tiers still use 256.
> 
> Comments document why: 256 was enough for a single ~113K stream but still hit MLX’s Metal buffer-count limit under concurrent ~50K contexts plus generation; 512 roughly halves block count for high `maxNumSeqs` / long windows. The **`mlx-catalog`** compile check now asserts OptiQ resident **block 512 / maxNumSeqs 8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c91eac8a01e328d3ab7b7413308e1ff211a11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->