### PR TITLE
fix(marketplaces): inherit local directory source for fabric-patterns

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -524,11 +524,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1783622041,
-        "narHash": "sha256-oMQlhF5SggRfw4eKf5gfkUWQ3CXkFx7WDpKeDRGw9ns=",
+        "lastModified": 1783656288,
+        "narHash": "sha256-pFa39OsPc+usyaGuZuM7qa1xgWCaT3bH1Y0eUaZU+kE=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "fc63a8bfdca7842569206952660818d1471b9e93",
+        "rev": "1ab41d1a8bd001303561982504617a2b34cf2916",
         "type": "github"
       },
       "original": {

--- a/modules/claude/marketplaces.nix
+++ b/modules/claude/marketplaces.nix
@@ -69,11 +69,11 @@ base
     };
     flakeInput = jacobpevansMarketplace;
   };
-  "fabric-patterns" = {
-    source = {
-      type = "github";
-      url = "danielmiessler/fabric";
-    };
+  # Inherit the catalog source (nix-claude-code marks fabric-patterns
+  # source.type = "local" → a Claude `directory` source, so Claude reads the
+  # synthetic marketplace in place instead of re-cloning raw upstream and
+  # clobbering it). Only override flakeInput, matching browser-use/cribl above.
+  "fabric-patterns" = (base."fabric-patterns" or { }) // {
     flakeInput = fabricMarketplace;
   };
   # karpathy-skills lives in nix-ai (input + tier file).


### PR DESCRIPTION
`feature/fabric-patterns-local-source`, 1 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Claude marketplace source configuration; no auth, data, or core app logic changes.
> 
> **Overview**
> **fabric-patterns** marketplace wiring now follows the same pattern as **browser-use** and **cribl**: it merges the **nix-claude-code** catalog entry and only overrides **`flakeInput`** to the synthetic **`fabricMarketplace`**, instead of forcing a GitHub **`danielmiessler/fabric`** source.
> 
> That keeps Claude on the catalog’s **`local` / directory** source so it uses the Nix-built synthetic marketplace in place, rather than re-cloning upstream and overwriting it.
> 
> **`flake.lock`** bumps **`nix-claude-code`** to rev **`1ab41d1a8bd001303561982504617a2b34cf2916`**, which supplies the updated catalog metadata for this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f48370d0445a7f9be01723391fa4d0fc9279d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->