### PR TITLE
fix(mlx): serve Qwen 3.5 judge with mlx-lm

### DIFF
--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -34,17 +34,14 @@ in
     assert
       c.modelFlagOverrides.${coder}.maxRequestTokens == 32768
       || throw "catalog: coder resident maxRequestTokens 32768 not compiled";
+    assert c.modelServer.${judge9b} == "mlx-lm"
+      || throw "catalog: 9B judge must use its published mlx_lm.server deployment path";
     assert
-      c.modelFlagOverrides.${judge9b}.cacheMemoryMb == 2048
-      && c.modelFlagOverrides.${judge9b}.maxRequestTokens == 16384
-      || throw "catalog: 9B judge resident profile must remain bounded";
-    assert
-      c.modelTextOnly.${judge9b}
-      &&
-        builtins.match ".*enable_thinking.*false.*" (
-          builtins.concatStringsSep " " c.modelExtraArgs.${judge9b}
-        ) != null
-      || throw "catalog: 9B judge must use the text-only loader with thinking disabled";
+      c.modelConcurrencyLimits.${judge9b} == 1
+      && builtins.match ".*enable_thinking.*false.*" (
+        builtins.concatStringsSep " " c.modelExtraArgs.${judge9b}
+      ) != null
+      || throw "catalog: 9B judge must use bounded single-concurrency text serving";
     assert
       hmConfigCatalog.config.services.aiStack.roleOverrides.goal-judge == judge9b
       || throw "catalog: logical goal-judge role must resolve to the catalog-owned physical model";

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -24,7 +24,7 @@ in
         let
           generated = llamaSwapConfigAttrs.models.${modelId} or null;
         in
-        generated != null && lib.hasPrefix "VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
+        generated != null && lib.hasPrefix "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
       ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
       message = "modelTextOnly entries must compile into final llama-swap commands with the text-only loader environment.";
     }

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -20,16 +20,6 @@ in
     }
     {
       assertion = lib.all (
-        modelId:
-        let
-          generated = llamaSwapConfigAttrs.models.${modelId} or null;
-        in
-        generated != null && lib.hasPrefix "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 " generated.cmd
-      ) (lib.attrNames (lib.filterAttrs (_modelId: enabled: enabled) cfg.modelTextOnly));
-      message = "modelTextOnly entries must compile into final llama-swap commands with the text-only loader environment.";
-    }
-    {
-      assertion = lib.all (
         role:
         let
           physical = config.services.aiStack.models.${role};

--- a/modules/mlx/catalog-data.nix
+++ b/modules/mlx/catalog-data.nix
@@ -20,26 +20,25 @@ in
   qwen35-9b-optiq = {
     model = "mlx-community/Qwen3.5-9B-OptiQ-4bit";
     weightGb = 7.7;
-    # This text-only quant retains multimodal metadata even though it ships no
-    # vision-tower weights. Force the text loader and disable thinking so a
-    # bounded judge verdict does not spend its response budget on reasoning.
-    textOnly = true;
-    args =
-      qwenMoeGeneralParser
-      ++ [
-        "--default-chat-template-kwargs"
-        (builtins.toJSON {
-          enable_thinking = false;
-        })
-      ]
-      ++ agentTimeout;
+    # The model card's Hermes recipe serves this text quant with mlx_lm.server.
+    # Keep it off the multimodal-aware vllm-mlx loader.
+    server = "mlx-lm";
+    args = [
+      "--max-tokens"
+      "512"
+      "--chat-template-args"
+      (builtins.toJSON {
+        enable_thinking = false;
+      })
+      "--decode-concurrency"
+      "1"
+      "--prompt-concurrency"
+      "1"
+    ];
+    concurrencyLimit = 1;
     classes = {
-      resident.flags = block256 // {
-        cacheMemoryMb = 2048;
-        maxNumSeqs = 4;
-        maxRequestTokens = 16384;
-      };
-      swap.flags = block256 // swapFlags;
+      resident.flags = { };
+      swap.flags = swapFlags;
     };
   };
 

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -51,6 +51,9 @@ let
   vllmMlxPkg = pkgs.writeShellScriptBin "vllm-mlx" ''
     exec ${pkgs.uv}/bin/uvx --python ${uvPythonVersion} --from "${vllmMlxPatchedWheel}/vllm_mlx-${vllmMlxVersion}-py3-none-any.whl" --with "${mlxPin}" --with "${mlxLmPin}" --with "${transformersPin}" vllm-mlx "$@"
   '';
+  mlxLmServerPkg = pkgs.writeShellScriptBin "mlx-lm-server" ''
+    exec ${pkgs.uv}/bin/uvx --python ${uvPythonVersion} --from "${mlxLmPin}" --with "${mlxPin}" --with "${transformersPin}" mlx_lm.server "$@"
+  '';
   mlxWarmupPkg = pkgs.writeShellScriptBin "mlx-warmup" ''
     exec ${pkgs.python3}/bin/python3 ${./scripts/mlx-warmup.py} "$@"
   '';
@@ -102,7 +105,7 @@ let
   llamaSwapRuntimeConfigPath = "${config.home.homeDirectory}/.config/mlx/llama-swap.json";
 
   # Serve-command builder — split to vllm-cmd.nix (12KB file-size gate).
-  inherit (import ./vllm-cmd.nix { inherit lib cfg vllmMlxPkg; }) mkVllmCmd;
+  inherit (import ./vllm-cmd.nix { inherit lib cfg vllmMlxPkg mlxLmServerPkg; }) mkModelCmd;
 
   # Role registry (services.aiStack.models): role-name -> physical model ID.
   # Single source of truth.
@@ -143,7 +146,7 @@ let
     in
     {
       cmd =
-        mkVllmCmd physical + lib.optionalString (extraArgs != [ ]) (" " + lib.escapeShellArgs extraArgs);
+        mkModelCmd physical + lib.optionalString (extraArgs != [ ]) (" " + lib.escapeShellArgs extraArgs);
       ttl = cfg.proxy.idleTtl;
       env = workerEnv;
       checkEndpoint = "/v1/models";
@@ -167,7 +170,7 @@ let
     in
     {
       cmd =
-        mkVllmCmd name
+        mkModelCmd name
         + lib.optionalString (modelCfg.extraArgs != [ ]) (
           " " + lib.concatStringsSep " " modelCfg.extraArgs
         );

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -193,9 +193,9 @@ in
         name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault (entryFor name).args)
       ) argsViaExtraArgs;
 
-      modelTextOnly = lib.mapAttrs' (
-        name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault true)
-      ) (lib.filterAttrs (name: _sel: (entryFor name).textOnly or false) enabled);
+      modelServer = lib.mapAttrs' (
+        name: _sel: lib.nameValuePair (entryFor name).model (lib.mkDefault (entryFor name).server)
+      ) (lib.filterAttrs (name: _sel: ((entryFor name).server or "vllm-mlx") != "vllm-mlx") enabled);
 
       modelFlagOverrides = lib.mapAttrs' (
         name: sel:

--- a/modules/mlx/options-runtime.nix
+++ b/modules/mlx/options-runtime.nix
@@ -139,10 +139,13 @@
       description = "Additional vllm-mlx serve arguments per physical registry model id, appended after the global flags.";
     };
 
-    modelTextOnly = lib.mkOption {
-      type = lib.types.attrsOf lib.types.bool;
+    modelServer = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.enum [
+        "vllm-mlx"
+        "mlx-lm"
+      ]);
       default = { };
-      description = "Per-physical-model text-only loader override for model artifacts whose metadata advertises multimodal support but whose quant intentionally omits media-tower weights.";
+      description = "Per-physical-model serving implementation. Defaults to vllm-mlx; use mlx-lm when the model's published deployment recipe requires mlx_lm.server.";
     };
 
     # modelConcurrencyLimits — per-physical-id override of the GLOBAL proxy

--- a/modules/mlx/vllm-cmd.nix
+++ b/modules/mlx/vllm-cmd.nix
@@ -47,7 +47,7 @@ rec {
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
       textOnlyEnv = lib.optionalString (cfg.modelTextOnly.${modelId} or false
-      ) "VLLM_MLX_FORCE_TEXT_ONLY=1 ";
+      ) "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 ";
       baseCmd = "${textOnlyEnv}${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
         lib.optionals (c.cacheMemoryMb != null) [

--- a/modules/mlx/vllm-cmd.nix
+++ b/modules/mlx/vllm-cmd.nix
@@ -4,6 +4,7 @@
   lib,
   cfg,
   vllmMlxPkg,
+  mlxLmServerPkg,
 }:
 rec {
   # Build the vllm-mlx serve command string for a given model ID.
@@ -36,9 +37,10 @@ rec {
     "toolCallParser"
     "reasoningParser"
   ];
-  mkVllmCmd =
+  mkModelCmd =
     modelId:
     let
+      server = cfg.modelServer.${modelId} or "vllm-mlx";
       overrides = cfg.modelFlagOverrides.${modelId} or { };
       unknown = lib.filter (k: !(lib.elem k overridableFlags)) (lib.attrNames overrides);
       c =
@@ -46,9 +48,11 @@ rec {
           cfg // overrides
         else
           throw "programs.mlx.modelFlagOverrides.\"${modelId}\": not overridable serve option(s): ${lib.concatStringsSep ", " unknown}";
-      textOnlyEnv = lib.optionalString (cfg.modelTextOnly.${modelId} or false
-      ) "/usr/bin/env VLLM_MLX_FORCE_TEXT_ONLY=1 ";
-      baseCmd = "${textOnlyEnv}${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
+      baseCmd =
+        if server == "mlx-lm" then
+          "${lib.getExe mlxLmServerPkg} --model ${modelId} --port \${PORT} --host ${c.host}"
+        else
+          "${lib.getExe vllmMlxPkg} serve ${modelId} --port \${PORT} --host ${c.host}";
       flags = lib.concatStringsSep " " (
         lib.optionals (c.cacheMemoryMb != null) [
           "--cache-memory-mb"
@@ -112,6 +116,6 @@ rec {
         ]
       );
     in
-    "${baseCmd}${lib.optionalString (flags != "") " ${flags}"}";
+    "${baseCmd}${lib.optionalString (server == "vllm-mlx" && flags != "") " ${flags}"}";
 
 }


### PR DESCRIPTION
`fix/hermes-text-only-env`, 2 commit(s).

Recovered during a repo-hygiene sweep: this branch carried unmerged commits and
had never been proposed, so nothing was evaluating it. Opening it so CI decides
whether it still applies to current develop — related work has landed since, and
it may be wholly or partly superseded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how a resident judge backend is launched and how llama-swap commands are built for mlx-lm models; misconfiguration could break goal-judge serving until caught by catalog checks.
> 
> **Overview**
> Routes the **Qwen3.5-9B-OptiQ** goal-judge through **`mlx_lm.server`** instead of vllm-mlx with a text-only loader env hack. Catalog args are now mlx-lm flags (`--max-tokens`, `--chat-template-args` with `enable_thinking: false`, decode/prompt concurrency **1**), with proxy **concurrencyLimit 1** and no resident vllm KV flag profile.
> 
> Adds **`programs.mlx.modelServer`** (`vllm-mlx` | `mlx-lm`), a pinned **`mlx-lm-server`** uvx wrapper, and renames the command builder to **`mkModelCmd`**, which picks the backend per model and only appends vllm-mlx serve flags when the server is vllm-mlx.
> 
> Removes **`modelTextOnly`** and the eval assertion that text-only models must compile with `VLLM_MLX_FORCE_TEXT_ONLY=1` in llama-swap commands. Catalog regression checks for the 9B judge were updated to match the new deployment path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf92cf8243769e3446b907a23edfb817fdfd1c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->