### PR TITLE
chore(claude): drop the langfuse marketplace and plugin entries

### DIFF
--- a/modules/claude/marketplaces.nix
+++ b/modules/claude/marketplaces.nix
@@ -121,12 +121,4 @@ base
     };
     flakeInput = marketplaceInputs.managing-dependencies;
   };
-  # langfuse-skills is a single-plugin marketplace rooted at ./.
-  "langfuse-skills" = {
-    source = {
-      type = "github";
-      url = "langfuse/skills";
-    };
-    flakeInput = marketplaceInputs.langfuse-skills;
-  };
 }

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -92,13 +92,6 @@ _:
     "hf-mcp@huggingface-skills" = false;
 
     # ========================================================================
-    # langfuse-skills — langfuse/skills
-    # ========================================================================
-    # Langfuse tracing, prompt management, and evaluation. Flows to every
-    # harness via agent-skills auto-discovery (~/.codex/skills/langfuse).
-    "langfuse@langfuse-skills" = true;
-
-    # ========================================================================
     # karpathy-skills — forrestchang/andrej-karpathy-skills (113639★)
     # ========================================================================
     # Single skill: karpathy-guidelines. Behavioral rules for LLM coding:


### PR DESCRIPTION
The `langfuse-skills` marketplace never registered and the plugin never
installed — neither appears in the on-disk marketplace cache or plugin
records, while sibling marketplaces do.

The skill itself is unaffected: it reaches every harness through agent-skills
auto-discovery, which walks the flake inputs directly rather than this
registry. The flake input, the `observability` skill group, and the
`lib/checks/agent-skills.nix` discovery assertion are all unchanged.

## Verification

- `nix fmt` — clean, 0 files changed
- `nix flake check` — pass
- forced regression suite (`nix eval` over `checks.x86_64-linux`) — exit 0,
  including the langfuse discovery assertion

No rebuild: the removed entries were never loaded, so the change cannot alter
runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only deletes unused Claude marketplace/plugin metadata; no changes to flake inputs, agent-skills discovery, or runtime-loaded plugins.
> 
> **Overview**
> Removes **dead Claude Code wiring** for Langfuse: the `langfuse-skills` block in `marketplaces.nix` and the enabled `langfuse@langfuse-skills` entry (plus its comment) in tier 5 specialty plugins.
> 
> Those registry paths never showed up in the on-disk marketplace cache or installed plugins, so this is **cleanup only**. Langfuse skill delivery is unchanged—the flake input, the `observability` group in agent-skills, and the `lib/checks/agent-skills.nix` discovery assertion still pin and verify the skill via auto-discovery rather than this marketplace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1dc2bb0334ec0ae9594da70595bf3510b8094c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->