### PR TITLE
fix(mlx): make modelMtpProfiles reachable, and prove it

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -298,6 +298,7 @@ in
 })
 // (import ./checks/mlx.nix { inherit pkgs hmConfig; })
 // (import ./checks/mlx-catalog-vlm.nix { inherit pkgs hmConfigCatalog src; })
+// (import ./checks/mlx-mtp-reachable.nix { inherit pkgs mkHmConfig; })
 // (import ./checks/mlx-single-model.nix { inherit pkgs src; })
 // (import ./checks/mlx-bash32.nix { inherit pkgs hmConfig src; })
 // (import ./checks/mlx-watchdog.nix { inherit pkgs src; })

--- a/lib/checks/mlx-catalog-vlm.nix
+++ b/lib/checks/mlx-catalog-vlm.nix
@@ -108,6 +108,11 @@ in
     ${pkgs.python3}/bin/python3 ${src}/tests/test-mlx-vlm-adapter.py && touch $out
   '';
 
+  # SCOPE: argv only. mtpCfg above is a hand-built attrset passed straight to
+  # model-server-cmd.nix, so the module system never runs and this cannot see
+  # whether any config could reach this code path. It could not, from the day
+  # the option landed until 2026-08-30. ./mlx-mtp-reachable.nix owns that half;
+  # keep them paired.
   mlx-mtp-native-contract =
     assert
       builtins.match ".*stub-mlx-vlm-native-server --model ${mtpTarget} .*" mtpCmd != null

--- a/lib/checks/mlx-mtp-reachable.nix
+++ b/lib/checks/mlx-mtp-reachable.nix
@@ -1,10 +1,10 @@
 # Reachability regression for programs.mlx.modelMtpProfiles.
 #
-# WHY ./mlx-catalog-vlm.nix does not already cover this. Its
-# mlx-mtp-native-contract check hand-builds a cfg attrset and calls
-# model-server-cmd.nix directly, so the module system — and therefore
-# modules/mlx/assertions.nix — never runs. It answers "does a profile compile
-# to the right argv?" and cannot answer "can a config ask for one?".
+# WHY ./mlx-catalog-vlm.nix does not cover this. Its mlx-mtp-native-contract
+# check hand-builds a cfg attrset and calls model-server-cmd.nix directly, so
+# the module system — and modules/mlx/assertions.nix with it — never runs. It
+# answers "does a profile compile to the right argv?" and cannot answer "can a
+# config ask for one?".
 #
 # Those came apart. From the day modelMtpProfiles landed until 2026-08-30 the
 # answers were yes and no: the backend-policy assertion required
@@ -13,8 +13,21 @@
 # so every enabled profile was rejected and the option was dead code — under a
 # green check faithfully verifying a command line nothing could request.
 #
-# So this reads config.assertions off a REAL evaluation with a profile enabled,
-# and fails if a contradiction is reintroduced anywhere in that list.
+# So this reads config.assertions off a REAL evaluation with a profile enabled.
+# What each assert pins, in order:
+#
+#   1. every assertion holds — the thing a hand-built cfg cannot say
+#   2. the backend-policy assertion, by message
+#   3. the MTP profile assertion, by message
+#   4. worker batch width is non-unit
+#   5. the proxy gate equals it
+#   6. a drafter is set
+#   7. the drafter is not the target id reused
+#
+# 4 and 5 are separate on purpose. maxNumSeqs and modelConcurrencyLimits are
+# both ints.between 1 4 and the assertion asks only that they be EQUAL, so a
+# matched pair at 2 keeps that legible as a coupling; at 1 it is
+# indistinguishable from "MTP must be serialized", which it is not.
 #
 # Assertions are located by `message`, not list index, as
 # ./mlx-cluster-sharding.nix does it: an unrelated assertion landing beside
@@ -30,18 +43,13 @@ let
 
   target = "mlx-community/Qwen3.8-27B-4bit";
 
-  # concurrency 2, deliberately: maxNumSeqs and modelConcurrencyLimits are both
-  # types.ints.between 1 4 and the assertion requires only that they be EQUAL.
-  # A matched pair at 2 keeps that legible as a coupling; at 1 it is
-  # indistinguishable from "MTP must be serialized", which it is not.
   hmConfigMtp = mkHmConfig [
     {
       programs.mlx = {
         # Stubbed as ./mlx-catalog-roles.nix stubs it: reading config.assertions
-        # forces a judge message that interpolates this option, which is
-        # types.str with no default — otherwise eval throws instead of reporting.
+        # forces a judge message interpolating this option, which is types.str
+        # with no default — otherwise eval throws instead of reporting.
         judge.model = "mlx-community/test-judge-model";
-
         defaultModelKey = "qwen38-27b";
         catalog.qwen38-27b.class = "resident";
         enabledBackends = [
@@ -53,7 +61,7 @@ let
         modelMtpProfiles.${target} = {
           enable = true;
           # Native MTP tensors from Qwen/Qwen3.8-27B in the standalone MLX
-          # drafter format mlx-vlm expects. Quantized independently of the
+          # drafter format mlx-vlm expects, quantized independently of the
           # target: this 6-bit drafter serves the 4-bit weights above.
           drafterModel = "lukaskremla/Qwen3.8-27B-MTP-6bit-MLX";
           maxNumSeqs = 2;
@@ -83,41 +91,26 @@ let
 in
 {
   mlx-mtp-reachable =
-    # THE POINT OF THE FILE. A config with an enabled MTP profile must evaluate
-    # with every assertion satisfied. This is what a hand-built cfg cannot say.
     assert
       failures == [ ]
-      || throw "mlx mtp: a configuration with an enabled modelMtpProfiles entry must satisfy every assertion, but ${toString (builtins.length failures)} failed:\n  ${failureMessages}";
-
-    # Both halves of the contradiction, pinned individually so a regression
-    # names which one came back — the aggregate above would only say "one of
-    # them", and these two have been mutually unsatisfiable before.
+      || throw "mlx mtp: a config with an enabled modelMtpProfiles entry must satisfy every assertion, but ${toString (builtins.length failures)} failed:\n  ${failureMessages}";
     assert
       assertionMatching ".*enabledBackends must not list vllm-mlx.*"
-      || throw "mlx mtp: the backend-policy assertion must admit a config that enables mlx-vlm-native for one model; if it is back to demanding enabledBackends == [ \"mlx-lm\" ] it has re-killed every MTP profile";
+      || throw "mlx mtp: the backend-policy assertion must admit a config enabling mlx-vlm-native for one model; back at enabledBackends == [ \"mlx-lm\" ] it has re-killed every MTP profile";
     assert
       assertionMatching ".*requires the native mlx-vlm backend, a drafter.*"
       || throw "mlx mtp: the MTP profile assertion must hold for a correctly-formed profile (native backend, drafter set, matched concurrency, non-cluster)";
-
-    # Concurrency is a COUPLING, not a cap at 1. maxNumSeqs and
-    # modelConcurrencyLimits are both ints.between 1 4 and the assertion asks
-    # only that they be equal; the matched pair here is 2. Pinned as two
-    # separate asserts because the 1-1 case is indistinguishable from "MTP must
-    # be serialized", and a failure should name which half moved.
     assert
       profile.maxNumSeqs == 2
       || throw "mlx mtp: the fixture must keep a non-unit worker batch width, or the coupling reads as a requirement to serialize";
     assert
       cfg.modelConcurrencyLimits.${target} == 2
       || throw "mlx mtp: the proxy gate must equal the profile's maxNumSeqs; 2 is what proves the assertion couples them rather than capping at 1";
-
-    # The drafter is a separate Hub artifact in mlx-vlm's standalone format,
-    # quantized independently of the target — a 6-bit drafter against 4-bit
-    # weights. Pinned so a future edit cannot quietly assume they must match.
-    assert profile.drafterModel != null || throw "mlx mtp: an enabled profile needs a drafter";
+    assert
+      profile.drafterModel != null
+      || throw "mlx mtp: an enabled profile requires a drafter, and a null one must not evaluate";
     assert
       profile.drafterModel != target
       || throw "mlx mtp: the drafter must be a distinct artifact from its target, not the target id reused";
-
     helpers.mkMarker "check-mlx-mtp-reachable" "mlx mtp: an enabled modelMtpProfiles entry evaluates clean at a matched concurrency of 2";
 }

--- a/lib/checks/mlx-mtp-reachable.nix
+++ b/lib/checks/mlx-mtp-reachable.nix
@@ -1,0 +1,125 @@
+# Reachability regression for programs.mlx.modelMtpProfiles.
+#
+# WHAT THIS GUARDS, and why ./mlx-catalog-vlm.nix does not already guard it.
+#
+# That file's mlx-mtp-native-contract check synthesizes a cfg attrset by hand
+# and calls model-server-cmd.nix directly. It never evaluates the module
+# system, so modules/mlx/assertions.nix never runs against it. It therefore
+# answers "does an MTP profile compile to the right argv?" and cannot answer
+# "can any configuration actually ask for one?".
+#
+# Those came apart. From the day modelMtpProfiles landed until 2026-08-30 the
+# answers were yes and no: the backend-policy assertion required
+# `enabledBackends == [ "mlx-lm" ]` (exact equality) while the MTP assertion
+# required `elem "mlx-vlm-native" cfg.enabledBackends`. No list satisfies both,
+# so every enabled profile failed one assertion or the other and the entire
+# option surface was unreachable — with a green check sitting on top of it,
+# faithfully verifying a command line nothing could request.
+#
+# This check closes that gap by reading config.assertions off a REAL evaluation
+# (lib/checks.nix `hmConfigMtp`) with a profile enabled. A contradiction
+# reintroduced anywhere in that assertion list fails here.
+#
+# Assertions are located by `message` rather than by list index, the same way
+# ./mlx-cluster-sharding.nix and ./mlx-catalog-roles.nix do it: an unrelated
+# assertion landing beside these must not silently shift which one is read.
+#
+# Takes `mkHmConfig` and builds its own fixture, unlike its siblings which
+# receive a prebuilt one: lib/checks.nix sits ~100 bytes under the 12KB
+# per-file error gate, and the repo splits rather than exempts.
+{
+  pkgs,
+  mkHmConfig,
+}:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+
+  target = "mlx-community/Qwen3.8-27B-4bit";
+
+  # concurrency 2, deliberately: maxNumSeqs and modelConcurrencyLimits are both
+  # types.ints.between 1 4 and the assertion requires only that they be EQUAL.
+  # A matched pair at 2 keeps that legible as a coupling; at 1 it is
+  # indistinguishable from "MTP must be serialized", which it is not.
+  hmConfigMtp = mkHmConfig [
+    {
+      programs.mlx = {
+        # Stubbed as ./mlx-catalog-roles.nix stubs it: reading config.assertions
+        # forces a judge message that interpolates this option, which is
+        # types.str with no default — otherwise eval throws instead of reporting.
+        judge.model = "mlx-community/test-judge-model";
+
+        defaultModelKey = "qwen38-27b";
+        catalog.qwen38-27b.class = "resident";
+        enabledBackends = [
+          "mlx-lm"
+          "mlx-vlm-native"
+        ];
+        modelBackends.${target} = "mlx-vlm-native";
+        modelConcurrencyLimits.${target} = 2;
+        modelMtpProfiles.${target} = {
+          enable = true;
+          # Native MTP tensors from Qwen/Qwen3.8-27B in the standalone MLX
+          # drafter format mlx-vlm expects. Quantized independently of the
+          # target: this 6-bit drafter serves the 4-bit weights above.
+          drafterModel = "lukaskremla/Qwen3.8-27B-MTP-6bit-MLX";
+          maxNumSeqs = 2;
+          draftBlockSize = 3;
+        };
+      };
+    }
+  ];
+
+  cfg = hmConfigMtp.config.programs.mlx;
+  profile = cfg.modelMtpProfiles.${target};
+
+  failures = builtins.filter (a: !a.assertion) hmConfigMtp.config.assertions;
+  failureMessages = builtins.concatStringsSep "\n  " (map (a: a.message) failures);
+
+  assertionMatching =
+    pattern:
+    let
+      matches = builtins.filter (
+        a: builtins.match pattern a.message != null
+      ) hmConfigMtp.config.assertions;
+    in
+    if builtins.length matches == 1 then
+      (builtins.head matches).assertion
+    else
+      throw "mlx-mtp-reachable: expected exactly one assertion matching ${pattern}, found ${toString (builtins.length matches)}";
+in
+{
+  mlx-mtp-reachable =
+    # THE POINT OF THE FILE. A config with an enabled MTP profile must evaluate
+    # with every assertion satisfied. This is what a hand-built cfg cannot say.
+    assert
+      failures == [ ]
+      || throw "mlx mtp: a configuration with an enabled modelMtpProfiles entry must satisfy every assertion, but ${toString (builtins.length failures)} failed:\n  ${failureMessages}";
+
+    # Both halves of the contradiction, pinned individually so a regression
+    # names which one came back — the aggregate above would only say "one of
+    # them", and these two have been mutually unsatisfiable before.
+    assert
+      assertionMatching ".*enabledBackends must not list vllm-mlx.*"
+      || throw "mlx mtp: the backend-policy assertion must admit a config that enables mlx-vlm-native for one model; if it is back to demanding enabledBackends == [ \"mlx-lm\" ] it has re-killed every MTP profile";
+    assert
+      assertionMatching ".*requires the native mlx-vlm backend, a drafter.*"
+      || throw "mlx mtp: the MTP profile assertion must hold for a correctly-formed profile (native backend, drafter set, matched concurrency, non-cluster)";
+
+    # Concurrency is a COUPLING, not a cap at 1. maxNumSeqs and
+    # modelConcurrencyLimits are both ints.between 1 4 and the assertion asks
+    # only that they be equal; the matched pair here is 2. Pinned because the
+    # 1-1 case is indistinguishable from "MTP must be serialized", and reading
+    # it that way is the mistake this line exists to prevent.
+    assert
+      profile.maxNumSeqs == 2 && cfg.modelConcurrencyLimits.${target} == 2
+      || throw "mlx mtp: the fixture must keep a MATCHED non-unit concurrency pair, so the coupling cannot be misread as a requirement to serialize";
+
+    # The drafter is a separate Hub artifact in mlx-vlm's standalone format and
+    # is quantized independently of the target — a 6-bit drafter against 4-bit
+    # weights. Pinned so a future edit cannot quietly assume they must match.
+    assert
+      profile.drafterModel != null && profile.drafterModel != target
+      || throw "mlx mtp: an enabled profile needs a drafter distinct from its target";
+
+    helpers.mkMarker "check-mlx-mtp-reachable" "mlx mtp: an enabled modelMtpProfiles entry evaluates clean at a matched concurrency of 2";
+}

--- a/lib/checks/mlx-mtp-reachable.nix
+++ b/lib/checks/mlx-mtp-reachable.nix
@@ -1,32 +1,26 @@
 # Reachability regression for programs.mlx.modelMtpProfiles.
 #
-# WHAT THIS GUARDS, and why ./mlx-catalog-vlm.nix does not already guard it.
-#
-# That file's mlx-mtp-native-contract check synthesizes a cfg attrset by hand
-# and calls model-server-cmd.nix directly. It never evaluates the module
-# system, so modules/mlx/assertions.nix never runs against it. It therefore
-# answers "does an MTP profile compile to the right argv?" and cannot answer
-# "can any configuration actually ask for one?".
+# WHY ./mlx-catalog-vlm.nix does not already cover this. Its
+# mlx-mtp-native-contract check hand-builds a cfg attrset and calls
+# model-server-cmd.nix directly, so the module system — and therefore
+# modules/mlx/assertions.nix — never runs. It answers "does a profile compile
+# to the right argv?" and cannot answer "can a config ask for one?".
 #
 # Those came apart. From the day modelMtpProfiles landed until 2026-08-30 the
 # answers were yes and no: the backend-policy assertion required
 # `enabledBackends == [ "mlx-lm" ]` (exact equality) while the MTP assertion
 # required `elem "mlx-vlm-native" cfg.enabledBackends`. No list satisfies both,
-# so every enabled profile failed one assertion or the other and the entire
-# option surface was unreachable — with a green check sitting on top of it,
-# faithfully verifying a command line nothing could request.
+# so every enabled profile was rejected and the option was dead code — under a
+# green check faithfully verifying a command line nothing could request.
 #
-# This check closes that gap by reading config.assertions off a REAL evaluation
-# (lib/checks.nix `hmConfigMtp`) with a profile enabled. A contradiction
-# reintroduced anywhere in that assertion list fails here.
+# So this reads config.assertions off a REAL evaluation with a profile enabled,
+# and fails if a contradiction is reintroduced anywhere in that list.
 #
-# Assertions are located by `message` rather than by list index, the same way
-# ./mlx-cluster-sharding.nix and ./mlx-catalog-roles.nix do it: an unrelated
-# assertion landing beside these must not silently shift which one is read.
-#
-# Takes `mkHmConfig` and builds its own fixture, unlike its siblings which
-# receive a prebuilt one: lib/checks.nix sits ~100 bytes under the 12KB
-# per-file error gate, and the repo splits rather than exempts.
+# Assertions are located by `message`, not list index, as
+# ./mlx-cluster-sharding.nix does it: an unrelated assertion landing beside
+# these must not shift which one is read. The fixture lives here rather than in
+# lib/checks.nix because that file sits ~100 bytes under the 12KB per-file
+# error gate, and the repo splits rather than exempts.
 {
   pkgs,
   mkHmConfig,
@@ -107,19 +101,23 @@ in
 
     # Concurrency is a COUPLING, not a cap at 1. maxNumSeqs and
     # modelConcurrencyLimits are both ints.between 1 4 and the assertion asks
-    # only that they be equal; the matched pair here is 2. Pinned because the
-    # 1-1 case is indistinguishable from "MTP must be serialized", and reading
-    # it that way is the mistake this line exists to prevent.
+    # only that they be equal; the matched pair here is 2. Pinned as two
+    # separate asserts because the 1-1 case is indistinguishable from "MTP must
+    # be serialized", and a failure should name which half moved.
     assert
-      profile.maxNumSeqs == 2 && cfg.modelConcurrencyLimits.${target} == 2
-      || throw "mlx mtp: the fixture must keep a MATCHED non-unit concurrency pair, so the coupling cannot be misread as a requirement to serialize";
+      profile.maxNumSeqs == 2
+      || throw "mlx mtp: the fixture must keep a non-unit worker batch width, or the coupling reads as a requirement to serialize";
+    assert
+      cfg.modelConcurrencyLimits.${target} == 2
+      || throw "mlx mtp: the proxy gate must equal the profile's maxNumSeqs; 2 is what proves the assertion couples them rather than capping at 1";
 
-    # The drafter is a separate Hub artifact in mlx-vlm's standalone format and
-    # is quantized independently of the target — a 6-bit drafter against 4-bit
+    # The drafter is a separate Hub artifact in mlx-vlm's standalone format,
+    # quantized independently of the target — a 6-bit drafter against 4-bit
     # weights. Pinned so a future edit cannot quietly assume they must match.
+    assert profile.drafterModel != null || throw "mlx mtp: an enabled profile needs a drafter";
     assert
-      profile.drafterModel != null && profile.drafterModel != target
-      || throw "mlx mtp: an enabled profile needs a drafter distinct from its target";
+      profile.drafterModel != target
+      || throw "mlx mtp: the drafter must be a distinct artifact from its target, not the target id reused";
 
     helpers.mkMarker "check-mlx-mtp-reachable" "mlx mtp: an enabled modelMtpProfiles entry evaluates clean at a matched concurrency of 2";
 }

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -10,9 +10,15 @@ in
 {
   # Fail evaluation when coupled options or generated proxy contracts drift.
   assertions = lib.optionals cfg.enable [
+    # A DENY of vllm-mlx, not `enabledBackends == [ "mlx-lm" ]` as it read until
+    # 2026-08-30. That exact-equality made the MTP assertion below
+    # unsatisfiable (it needs "mlx-vlm-native" IN the list), so every enabled
+    # modelMtpProfiles entry was rejected and the option was dead code. Same
+    # intent, without forbidding the per-model overrides the OCR entry already
+    # relies on. Full account in lib/checks/mlx-mtp-reachable.nix.
     {
-      assertion = cfg.modelServerBackend == "mlx-lm" && cfg.enabledBackends == [ "mlx-lm" ];
-      message = "programs.mlx must use only the enabled mlx-lm backend; vllm-mlx remains preserved but disabled.";
+      assertion = cfg.modelServerBackend == "mlx-lm" && !(lib.elem "vllm-mlx" cfg.enabledBackends);
+      message = "programs.mlx.modelServerBackend must stay mlx-lm and enabledBackends must not list vllm-mlx; vllm-mlx remains preserved but disabled.";
     }
     {
       assertion = cfg.singleModel == null || builtins.hasAttr cfg.singleModel allModels;


### PR DESCRIPTION
## The bug

`programs.mlx.modelMtpProfiles` could not be enabled in **any** configuration. Two assertions in the same list are mutually unsatisfiable:

| | |
| --- | --- |
| `assertions.nix:14` | `cfg.enabledBackends == [ "mlx-lm" ]` — exact equality |
| `assertions.nix:39` | `elem "mlx-vlm-native" cfg.enabledBackends` |

No list is both exactly `[ "mlx-lm" ]` and a list containing `"mlx-vlm-native"`. Every enabled profile therefore failed one assertion or the other. The submodule, its argv wiring in `model-server-cmd.nix` (`--draft-model`, `--draft-kind mtp`, `--draft-block-size`), and its regression check were all dead code.

### Why the existing check didn't catch it

`lib/checks/mlx-catalog-vlm.nix` builds its `cfg` by hand and calls `model-server-cmd.nix` directly, so the module system — and therefore `assertions.nix` — never runs. It answers *"does an MTP profile compile to the right argv?"* and cannot answer *"can any configuration ask for one?"*. Those came apart, and it sat green on top of a feature nothing could request.

## The change

**1. Restate the backend policy as a deny.**

```nix
assertion = cfg.modelServerBackend == "mlx-lm" && !(lib.elem "vllm-mlx" cfg.enabledBackends);
```

Same stated intent — *"vllm-mlx remains preserved but disabled"* — and `modelServerBackend` is still pinned to `mlx-lm`. A per-model override can now reach `mlx-vlm-native`, which the OCR entry already does for `mlx-vlm` today via `modelBackends`, unblocked only because nothing gates that path on `enabledBackends`.

**2. Add `lib/checks/mlx-mtp-reachable.nix`**, which reads `config.assertions` off a real evaluation with a profile enabled, so a reintroduced contradiction fails the suite. Paired with a scope note on the old check so the two aren't confused again.

## Two things pinned deliberately

**Concurrency is a coupling, not a cap.** `maxNumSeqs` and `modelConcurrencyLimits` are both `ints.between 1 4`, and the assertion asks only that they be **equal**. The fixture uses a matched pair at **2**, not 1 — because `proxy.concurrencyLimit` defaults to 1, which makes the 1-1 case indistinguishable from "MTP must be serialized". It isn't, and that misreading is what the pinned pair exists to prevent. (I made exactly this mistake while investigating; the reviewer question that caught it is why this line is here.)

**The drafter is quantized independently of the target.** `lukaskremla/Qwen3.8-27B-MTP-6bit-MLX` is the native MTP tensors from `Qwen/Qwen3.8-27B` in the standalone MLX drafter format, and serves 2/3/4/5/6/8-bit targets — so the deployed 4-bit weights are unchanged. This is what makes the option newly usable at all: it needed a drafter, and none existed for this model until now.

## Not done here

- **No backend flip.** `modelServerBackend` stays `mlx-lm` fleet-wide, so this deploys no behavior change. Enabling MTP for real needs an isolated worker and a measurement.
- **`resident.flags.maxNumSeqs = 8`** on `qwen38-27b` is outside the profile's 1–4 domain. Inert today (mlx-lm ignores it, as its own comment says) but must be reconciled before that entry moves to `mlx-vlm-native`.
- **OptiQ quant gap left open.** The catalog uses OptiQ builds for Qwen3.5-9B, Qwen3.6-35B-A3B and Gemma-4-31B, but `qwen38-27b` is on plain `mlx-community/Qwen3.8-27B-4bit` while `mlx-community/Qwen3.8-27B-OptiQ-4bit` exists. Deliberately not swapped — that's a measurement, not a family-consistency argument.

## Verification

**CI is green on `ca21474`.** `Nix Validate / Validate` passes, and with it the new `checks.x86_64-linux.mlx-mtp-reachable` — which is the substantive proof: a config with an enabled MTP profile now evaluates with every assertion satisfied, at a matched concurrency of 2. It failed to do so before this change.

Two caveats a reviewer should know:

- The three commits took two extra rounds purely on `treefmt`/`nixfmt`. This environment has no `nix` and no `nixfmt`, and the proxy blocks fetching one, so the formatting was derived from the rule as evidenced by existing clean files (an assert fits on one line when the whole `assert COND || throw "..."` is ≤100 columns; there are 32 such asserts in `lib/checks/`). The final commit sidesteps the question by mirroring `lib/checks/mlx-cluster-sharding.nix` structurally. Nothing about the assertions themselves changed across those rounds.
- Worth confirming the new check *can* fail, since I could not: flip the fixture's `maxNumSeqs` to 3 against `modelConcurrencyLimits = 2` and it should report the MTP assertion by name.

File sizes were checked against `.file-size.yml` (warn 6144 / error 12288); `File Size / Check` is green. The fixture lives inside the check rather than in `lib/checks.nix` because that file sits ~100 bytes under the error gate, and the repo's rule is split rather than exempt.

## Provenance

Triage of a Reddit thread about MTP on Qwen3.8-27B. Most of its advice was already implemented here with better data — the `xhigh` reasoning-effort trap, the 4× hybrid KV over-reserve, the quant lever — but chasing whether its MTP suggestion was actionable surfaced that the option was unreachable.

Companions: dryvist/docs#250 (documents MTP and the measurement trap) and dryvist/ansible-proxmox-ai#598 (records a context-window drift found while cross-checking).

---
_Generated by [Claude Code](https://claude.ai/code/session_01958YZZy8AwpswXE2E5K5XG)_


---

> [!NOTE]
> **Medium Risk**
> Relaxes a global `enabledBackends` equality gate in MLX module assertions, which could admit configs that previously failed eval; mitigated by a new reachability regression and unchanged `modelServerBackend == mlx-lm"` pin.
> 
> **Overview**
> **Fixes a logic bug where `programs.mlx.modelMtpProfiles` could never be enabled:** the backend-policy assertion required `enabledBackends == [ "mlx-lm" ]` while the MTP assertion required `"mlx-vlm-native"` in that list, so every enabled profile failed evaluation.
> 
> The backend policy in `modules/mlx/assertions.nix` is restated as *deny `vllm-mlx`* (with `modelServerBackend` still pinned to `mlx-lm`), preserving the “vllm-mlx disabled” intent but allowing per-model `mlx-vlm-native` overrides needed for MTP.
> 
> A new flake check **`lib/checks/mlx-mtp-reachable.nix`** evaluates a real Home Manager config with an enabled MTP profile and asserts all `config.assertions` pass, including the backend-policy and MTP messages matched by pattern (fixture uses matched concurrency **2** so proxy/worker coupling is not confused with “must serialize at 1”). **`lib/checks.nix`** registers the check; **`mlx-catalog-vlm.nix`** documents that `mlx-mtp-native-contract` only validates argv via a hand-built cfg and must stay paired with the reachability check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca21474c24473b214e934b6a2e79780720fe5a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
