### PR TITLE
feat(herdr): add herdr and source agent CLIs from llm-agents.nix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # nix-ai - AI Agent Instructions
 
 AI CLI ecosystem for Claude, Antigravity, Codex, Copilot, and MCP servers via
-Nix home-manager modules.
+Nix home-manager modules, plus the herdr multiplexer they run inside.
 
 ## Critical Constraints
 
@@ -62,8 +62,16 @@ This repo exports home-manager modules consumed by nix-darwin:
 
 - `homeManagerModules.default` — Full AI stack
 - `homeManagerModules.claude` — Claude Code only
+- `homeManagerModules.herdr` — herdr client (workstation half)
 - `homeManagerModules.maestro` — Maestro orchestration only
+- `nixosModules.herdr` — herdr server (Linux guest half)
 - `lib.ci.claudeSettingsJson` — Pure JSON for CI validation
+
+`nixosModules` is new. Everything this flake managed used to run on one Mac
+under launchd; herdr is the first component that also runs as a systemd service
+on a Linux guest. Both halves take their binaries from the same `llm-agents`
+input, which is what makes "one flake, server and workstation" true rather than
+aspirational.
 
 ### Self-contained design
 
@@ -119,6 +127,28 @@ this one.
 - MLX inference server (vllm-mlx LaunchAgent + wrappers)
 - AI-specific shell utilities (hf CLI wrapper, Doppler-wrapped aliases)
 
+### Where CLI binaries come from
+
+**nixpkgs → llm-agents.nix → homebrew (GUI only) → bunx → uvx.**
+
+`github:numtide/llm-agents.nix` supplies the agent CLIs nixpkgs does not carry
+(`claude-code`, `antigravity-cli`, `copilot-cli`, `herdr`) for
+`aarch64-darwin`, `x86_64-linux` and `aarch64-linux`, rebuilt daily and
+substituted from `cache.numtide.com`. It replaced four Homebrew casks/brews —
+`claude-code@latest`, `codex`, `antigravity-cli`, `qwen-code` — which had no
+Linux path and were the concrete reason this stack could not leave the MacBook.
+
+Two things to know before touching that input:
+
+- **It deliberately does not `follows` nixpkgs**, unlike every other input.
+  It pins its own `nixpkgs-unstable` and the numtide cache is keyed to that
+  pin; forcing 26.05 breaks builds *and* loses every cache hit.
+- **`lib/homebrew.nix` is GUI-only now.** Do not add a CLI cask back. If macOS
+  starts re-prompting for TCC permissions after a Codex or Claude Code bump,
+  that is the known cost of a Nix store path changing per version — the
+  Homebrew cask existed for stable TCC paths. Fix it for darwin specifically
+  rather than reverting the Linux path.
+
 ### Package placement
 
 The `nix-package-placement` rule lives in
@@ -142,8 +172,10 @@ instead. Design decisions in [`docs/adr/`](docs/adr/README.md).
 - `modules/mcp/catalog.nix` — MCP server definitions
 - `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
 - `modules/common/` — Shared permission engine and formatters
+- `modules/herdr/` — herdr config + `nixos.nix` (the systemd service)
+- `lib/homebrew.nix` — GUI casks only; CLIs come from nixpkgs/llm-agents.nix
 - `vars/ai-stack.nix` — Central model/endpoint/version registry
-- `lib/checks/` — Per-domain regression tests (lint, claude, mlx)
+- `lib/checks/` — Per-domain regression tests (lint, claude, mlx, herdr)
 
 ## MLX Ecosystem
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # nix-ai - AI Agent Instructions
 
 AI CLI ecosystem for Claude, Antigravity, Codex, Copilot, and MCP servers via
-Nix home-manager modules, plus the herdr multiplexer they run inside.
+Nix home-manager modules.
 
 ## Critical Constraints
 
@@ -61,17 +61,9 @@ feature loads without errors before claiming done.
 This repo exports home-manager modules consumed by nix-darwin:
 
 - `homeManagerModules.default` — Full AI stack
-- `homeManagerModules.claude` — Claude Code only
-- `homeManagerModules.herdr` — herdr client (workstation half)
-- `homeManagerModules.maestro` — Maestro orchestration only
-- `nixosModules.herdr` — herdr server (Linux guest half)
+- `homeManagerModules.{claude,herdr,maestro}` — subsets
+- `nixosModules.herdr` — herdr server (only non-darwin output)
 - `lib.ci.claudeSettingsJson` — Pure JSON for CI validation
-
-`nixosModules` is new. Everything this flake managed used to run on one Mac
-under launchd; herdr is the first component that also runs as a systemd service
-on a Linux guest. Both halves take their binaries from the same `llm-agents`
-input, which is what makes "one flake, server and workstation" true rather than
-aspirational.
 
 ### Self-contained design
 
@@ -127,28 +119,6 @@ this one.
 - MLX inference server (vllm-mlx LaunchAgent + wrappers)
 - AI-specific shell utilities (hf CLI wrapper, Doppler-wrapped aliases)
 
-### Where CLI binaries come from
-
-**nixpkgs → llm-agents.nix → homebrew (GUI only) → bunx → uvx.**
-
-`github:numtide/llm-agents.nix` supplies the agent CLIs nixpkgs does not carry
-(`claude-code`, `antigravity-cli`, `copilot-cli`, `herdr`) for
-`aarch64-darwin`, `x86_64-linux` and `aarch64-linux`, rebuilt daily and
-substituted from `cache.numtide.com`. It replaced four Homebrew casks/brews —
-`claude-code@latest`, `codex`, `antigravity-cli`, `qwen-code` — which had no
-Linux path and were the concrete reason this stack could not leave the MacBook.
-
-Two things to know before touching that input:
-
-- **It deliberately does not `follows` nixpkgs**, unlike every other input.
-  It pins its own `nixpkgs-unstable` and the numtide cache is keyed to that
-  pin; forcing 26.05 breaks builds *and* loses every cache hit.
-- **`lib/homebrew.nix` is GUI-only now.** Do not add a CLI cask back. If macOS
-  starts re-prompting for TCC permissions after a Codex or Claude Code bump,
-  that is the known cost of a Nix store path changing per version — the
-  Homebrew cask existed for stable TCC paths. Fix it for darwin specifically
-  rather than reverting the Linux path.
-
 ### Package placement
 
 The `nix-package-placement` rule lives in
@@ -166,15 +136,14 @@ instead. Design decisions in [`docs/adr/`](docs/adr/README.md).
 
 ## Key Files
 
-- `modules/default.nix` — Module entry point
-- `modules/claude-config.nix` — Claude Code config (settings/permissions/marketplace catalog come from the `nix-claude-code` flake input)
-- `modules/claude/plugins/` — Plugin tier files ([README](modules/claude/plugins/README.md))
+- `modules/default.nix` — Entry point
+- `modules/claude-config.nix` — Claude Code config (schema/renderer from `nix-claude-code`)
+- `modules/claude/plugins/` — Plugin tiers ([README](modules/claude/plugins/README.md))
 - `modules/mcp/catalog.nix` — MCP server definitions
-- `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
-- `modules/common/` — Shared permission engine and formatters
-- `modules/herdr/` — herdr config + `nixos.nix` (the systemd service)
-- `lib/homebrew.nix` — GUI casks only; CLIs come from nixpkgs/llm-agents.nix
-- `vars/ai-stack.nix` — Central model/endpoint/version registry
+- `modules/herdr/` — herdr ([README](modules/herdr/README.md))
+- `modules/mlx/` — MLX inference server (LaunchAgent, CLI tools)
+- `modules/common/` — Permission engine and formatters
+- `vars/ai-stack.nix` — Model/endpoint/version registry
 - `lib/checks/` — Per-domain regression tests (lint, claude, mlx, herdr)
 
 ## MLX Ecosystem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,8 @@ feature loads without errors before claiming done.
 This repo exports home-manager modules consumed by nix-darwin:
 
 - `homeManagerModules.default` — Full AI stack
-- `homeManagerModules.{claude,herdr,maestro}` — subsets
-- `nixosModules.herdr` — herdr server (only non-darwin output)
+- `homeManagerModules.claude` — Claude Code only
+- `homeManagerModules.maestro` — Maestro orchestration only
 - `lib.ci.claudeSettingsJson` — Pure JSON for CI validation
 
 ### Self-contained design
@@ -136,15 +136,14 @@ instead. Design decisions in [`docs/adr/`](docs/adr/README.md).
 
 ## Key Files
 
-- `modules/default.nix` — Entry point
-- `modules/claude-config.nix` — Claude Code config (schema/renderer from `nix-claude-code`)
-- `modules/claude/plugins/` — Plugin tiers ([README](modules/claude/plugins/README.md))
+- `modules/default.nix` — Module entry point
+- `modules/claude-config.nix` — Claude Code config (settings/permissions/marketplace catalog come from the `nix-claude-code` flake input)
+- `modules/claude/plugins/` — Plugin tier files ([README](modules/claude/plugins/README.md))
 - `modules/mcp/catalog.nix` — MCP server definitions
-- `modules/herdr/` — herdr ([README](modules/herdr/README.md))
-- `modules/mlx/` — MLX inference server (LaunchAgent, CLI tools)
-- `modules/common/` — Permission engine and formatters
-- `vars/ai-stack.nix` — Model/endpoint/version registry
-- `lib/checks/` — Per-domain regression tests (lint, claude, mlx, herdr)
+- `modules/mlx/` — MLX inference server (vllm-mlx LaunchAgent, CLI tools)
+- `modules/common/` — Shared permission engine and formatters
+- `vars/ai-stack.nix` — Central model/endpoint/version registry
+- `lib/checks/` — Per-domain regression tests (lint, claude, mlx)
 
 ## MLX Ecosystem
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "AI CLI ecosystem for Claude, Gemini, Copilot, and Codex (Nix flake)";
 
+  # Binary cache for the llm-agents.nix input below. Without it every agent CLI
+  # is a from-source build; with it they are all substituted.
+  nixConfig = {
+    extra-substituters = [ "https://cache.numtide.com" ];
+    extra-trusted-public-keys = [
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+    ];
+  };
+
   inputs = {
     # Both are channel branches = the intended major-version pins. Renovate
     # cannot bump either — a branch ref never changes, so there is nothing to
@@ -9,6 +18,17 @@
     # Second nixpkgs only for llama-swap: 25.11-darwin froze it at v165 on
     # 2025-09-22 with no backports. See nix-ai#801.
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    # Nix packages for AI coding agent CLIs (claude-code, codex, antigravity-cli,
+    # copilot-cli, herdr, ...), rebuilt daily by numtide CI for x86_64-linux,
+    # aarch64-linux and aarch64-darwin. This is what lets the stack run anywhere
+    # but the Mac: the CLIs it supplies used to come from Homebrew casks, which
+    # have no Linux path at all.
+    #
+    # Deliberately does NOT set `inputs.nixpkgs.follows`, unlike every other
+    # input here. It pins its own nixpkgs-unstable and cache.numtide.com is keyed
+    # to that pin — forcing 26.05 both breaks builds and loses every cache hit.
+    llm-agents.url = "github:numtide/llm-agents.nix";
 
     home-manager = {
       url = "github:nix-community/home-manager/release-26.05";
@@ -167,6 +187,7 @@
       self,
       nixpkgs,
       nixpkgs-unstable,
+      llm-agents,
       home-manager,
       ai-llm-prompts,
       ai-assistant-instructions,
@@ -207,15 +228,6 @@
           homebrewNix
           ;
       };
-      orchestratorPromptNames = [
-        "nix-ai-code-explain-example"
-        "nix-ai-code-review-analysis-example"
-        "nix-ai-code-review-categorization-example"
-        "nix-ai-code-review-example"
-        "nix-ai-default-system"
-        "nix-ai-structured-extract-example"
-        "nix-ai-vault-search-example"
-      ];
       orchestratorPromptDir =
         system: "${ai-llm-prompts.packages.${system}.applications}/share/ai-llm-prompts/applications";
     in
@@ -228,6 +240,7 @@
           nix-claude-code
           karpathy-skills
           nixpkgs-unstable
+          llm-agents
           dashmotion
           ponytail
           last30days-skill
@@ -246,49 +259,23 @@
       # comments — see that file. The public `nix-ai.lib.*` shape is unchanged.
       lib = nixAiLib;
 
-      # Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds
-      # from a single linux runner. All checks in lib/checks.nix are source-only
-      # or evaluation-wrapped — running once on the CI system is sufficient.
-      # Cross-platform breakage is still caught by `--all-systems` evaluating
-      # `packages.<system>`, `formatter.<system>`, and `overlays.default` on
-      # every declared system.
-      checks =
-        let
-          system = "x86_64-linux";
-          pkgs = import nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
-        in
-        {
-          ${system} =
-            (import ./lib/checks.nix {
-              inherit
-                pkgs
-                home-manager
-                ;
-              src = ./.;
-              aiModule = self.homeManagerModules.default;
-              inherit (nixAiLib) renderAutonomous;
-            })
-            // {
-              # `nix flake check` only *evaluates* packages.<system> (reports
-              # "build skipped") — it never compiles them, so a stale fabric
-              # vendorHash after a fabric-src bump passes CI unnoticed (this
-              # happened twice: #1145, fixed by #1156/#1159). Aliasing the package
-              # as a check forces the Go build — and its vendorHash verification —
-              # to actually run. Scoped to the CI system (x86_64-linux) like every
-              # other check so a single linux runner covers it.
-              fabric-ai-build = self.packages.${system}.fabric-ai;
-              orchestrator-prompt-assets =
-                assert builtins.all (
-                  name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")
-                ) orchestratorPromptNames;
-                pkgs.writeText "nix-ai-orchestrator-prompt-assets" ''
-                  Validated ${toString (builtins.length orchestratorPromptNames)} catalog prompts.
-                '';
-            };
-        };
+      # System-level modules. herdr is the first thing this flake manages that
+      # runs as a service on a Linux guest rather than a launchd agent on the
+      # Mac, so this output is new — see flake/nixos-modules.nix.
+      nixosModules = import ./flake/nixos-modules.nix { inherit llm-agents; };
+
+      # Extracted to flake/checks.nix to stay under the 12KB file-size gate.
+      # Still x86_64-linux-scoped; see that file for why.
+      checks = import ./flake/checks.nix {
+        inherit
+          self
+          nixpkgs
+          home-manager
+          nixAiLib
+          ai-llm-prompts
+          ;
+        src = ./.;
+      };
 
       # Extracted to flake/packages.nix to stay under the 12KB file-size gate.
       packages = import ./flake/packages.nix {

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -1,0 +1,61 @@
+# Regression suite wiring, extracted from flake.nix to stay under the 12KB
+# file-size gate. The public `nix-ai.checks.<system>` shape is unchanged.
+#
+# Scoped to x86_64-linux only so `nix flake check --all-systems` succeeds from
+# a single linux runner. All checks in lib/checks.nix are source-only or
+# evaluation-wrapped — running once on the CI system is sufficient.
+# Cross-platform breakage is still caught by `--all-systems` evaluating
+# `packages.<system>`, `formatter.<system>`, and `overlays.default` on every
+# declared system.
+{
+  self,
+  nixpkgs,
+  home-manager,
+  nixAiLib,
+  ai-llm-prompts,
+  src,
+}:
+let
+  system = "x86_64-linux";
+  pkgs = import nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
+  orchestratorPromptNames = [
+    "nix-ai-code-explain-example"
+    "nix-ai-code-review-analysis-example"
+    "nix-ai-code-review-categorization-example"
+    "nix-ai-code-review-example"
+    "nix-ai-default-system"
+    "nix-ai-structured-extract-example"
+    "nix-ai-vault-search-example"
+  ];
+in
+{
+  ${system} =
+    (import (src + "/lib/checks.nix") {
+      inherit
+        pkgs
+        home-manager
+        src
+        ;
+      aiModule = self.homeManagerModules.default;
+      inherit (nixAiLib) renderAutonomous;
+    })
+    // {
+      # `nix flake check` only *evaluates* packages.<system> (reports "build
+      # skipped") — it never compiles them, so a stale fabric vendorHash after a
+      # fabric-src bump passes CI unnoticed (this happened twice: #1145, fixed by
+      # #1156/#1159). Aliasing the package as a check forces the Go build — and
+      # its vendorHash verification — to actually run. Scoped to the CI system
+      # (x86_64-linux) like every other check so a single linux runner covers it.
+      fabric-ai-build = self.packages.${system}.fabric-ai;
+      orchestrator-prompt-assets =
+        assert builtins.all (
+          name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")
+        ) orchestratorPromptNames;
+        pkgs.writeText "nix-ai-orchestrator-prompt-assets" ''
+          Validated ${toString (builtins.length orchestratorPromptNames)} catalog prompts.
+        '';
+    };
+}

--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -5,6 +5,7 @@
   nix-claude-code,
   karpathy-skills,
   nixpkgs-unstable,
+  llm-agents,
   dashmotion,
   ponytail,
   last30days-skill,
@@ -81,6 +82,7 @@ in
         awesome-claude-skills
         marketplaceInputs
         nixpkgs-unstable
+        llm-agents
         vct-cribl-cli
         vct-splunk-cli
         ;
@@ -111,6 +113,7 @@ in
       inherit
         nix-claude-code
         marketplaceInputs
+        llm-agents
         ;
     };
   };
@@ -154,6 +157,7 @@ in
         ai-assistant-instructions
         nix-claude-code
         marketplaceInputs
+        llm-agents
         ;
     };
   };
@@ -222,6 +226,13 @@ in
     ];
     _module.args = {
       inherit nix-claude-code;
+    };
+  };
+
+  herdr = {
+    imports = [ ../modules/herdr ];
+    _module.args = {
+      inherit llm-agents;
     };
   };
 

--- a/flake/nixos-modules.nix
+++ b/flake/nixos-modules.nix
@@ -1,0 +1,20 @@
+# NixOS modules exported by nix-ai.
+#
+# nix-ai has historically exported home-manager modules only, because
+# everything it managed ran on one Mac under launchd. herdr is the first thing
+# that also has to run as a service on a Linux guest, so this is where the
+# system-level half lives.
+#
+# Same wrapper shape as flake/home-manager-modules.nix: flake inputs reach
+# modules through `_module.args`, never as function parameters.
+{
+  llm-agents,
+}:
+{
+  herdr = {
+    imports = [ ../modules/herdr/nixos.nix ];
+    _module.args = {
+      inherit llm-agents;
+    };
+  };
+}

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -282,6 +282,7 @@ in
 })
 // (import ./checks/codex.nix { inherit pkgs hmConfig; })
 // (import ./checks/cursor.nix { inherit pkgs hmConfig; })
+// (import ./checks/herdr.nix { inherit pkgs hmConfig; })
 // (import ./checks/qwen-code.nix { inherit pkgs hmConfig; })
 // (import ./checks/antigravity-cli.nix { inherit pkgs hmConfig; })
 // (import ./checks/vct-cli.nix {

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -91,7 +91,13 @@ in
       ours = lib.filterAttrs (name: _: lib.hasPrefix "${cfg.configDir}/" name) files;
     in
     assert lib.hasAttr configPath files || throw "herdr: ${configPath} is not rendered";
-    assert builtins.deepSeq (lib.mapAttrsToList (_: f: f.source) ours) true;
+    # Force each rendered file's STORE PATH, not the derivation itself.
+    # `deepSeq` over a derivation walks its whole attrset — drvAttrs, passthru,
+    # every build input — which is both enormously slow and prone to erroring on
+    # attributes that were never meant to be forced. Interpolating to a string
+    # forces exactly what this check is about: that every file under configDir
+    # actually renders to a path.
+    assert builtins.deepSeq (lib.mapAttrsToList (_: f: "${f.source}") ours) true;
     helpers.mkMarker "check-herdr-rendered-files-regression" "herdr renders ${toString (lib.length (lib.attrNames ours))} file(s) under ${cfg.configDir}.";
 
   herdr-agent-coverage-regression =

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -1,0 +1,116 @@
+# herdr module regression tests
+#
+# The coverage check is the load-bearing one. herdr classifies a pane as
+# working/blocked/idle by matching manifest rules against the foreground
+# process; a CLI with no manifest shows up as a bare shell, and every downstream
+# consumer — the Slack bridge's blocked-agent alerts, `herdr agent wait`, the
+# web dashboard's approvals — silently sees nothing to report. Adding a CLI to
+# this flake without a manifest is exactly the "a newly advertised tier cannot
+# go unmonitored" failure the fabric watchdog's assert exists to prevent.
+{ pkgs, hmConfig }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+  inherit (pkgs) lib;
+  cfg = hmConfig.config.programs.herdr;
+  programs = hmConfig.config.programs;
+
+  # Which of this flake's CLIs herdr is expected to recognise, and the manifest
+  # name herdr knows each by (its own name, not ours).
+  managedAgents = {
+    claude = programs.claude.enable or false;
+    codex = programs.codex.enable or false;
+    cursor = programs.cursor.enable or false;
+    opencode = programs.opencode.enable or false;
+    antigravity-cli = programs.antigravity-cli.enable or false;
+    qwen-code = programs.qwen-code.enable or false;
+    cecli = programs.cecli.enable or false;
+  };
+
+  enabledAgents = lib.attrNames (lib.filterAttrs (_: v: v) managedAgents);
+
+  covered =
+    name:
+    lib.elem name cfg.knownUpstreamAgents
+    || lib.hasAttr name cfg.agentManifests
+    || lib.elem name cfg.knownUnsupportedAgents;
+
+  uncovered = lib.filter (name: !(covered name)) enabledAgents;
+in
+{
+  herdr-options-regression = helpers.mkOptionsRegression {
+    label = "herdr";
+    checkName = "check-herdr-options-regression";
+    inherit cfg;
+    expectedOptions = [
+      "agentManifests"
+      "configDir"
+      "defaultRemote"
+      "enable"
+      "knownUnsupportedAgents"
+      "knownUpstreamAgents"
+      "package"
+      "remotes"
+      "settings"
+    ];
+  };
+
+  herdr-defaults-regression = helpers.mkDefaultsRegression {
+    label = "herdr";
+    checkName = "check-herdr-defaults-regression";
+    checks = [
+      {
+        name = "herdr.enable";
+        actual = cfg.enable;
+        expected = true;
+      }
+      {
+        name = "herdr.configDir";
+        actual = cfg.configDir;
+        expected = ".config/herdr";
+      }
+      {
+        name = "herdr.package is installed (not null)";
+        actual = cfg.package != null;
+        expected = true;
+      }
+      {
+        name = "herdr binary lands in home.packages";
+        actual = lib.elem cfg.package hmConfig.config.home.packages;
+        expected = true;
+      }
+    ];
+  };
+
+  # Forces the rendered config.toml and every manifest, not just their
+  # attribute names — a check that reads a few attributes of a large structure
+  # proves nothing about the rest (see CLAUDE.md).
+  herdr-rendered-files-regression =
+    let
+      files = hmConfig.config.home.file;
+      configPath = "${cfg.configDir}/config.toml";
+      ours = lib.filterAttrs (name: _: lib.hasPrefix "${cfg.configDir}/" name) files;
+    in
+    assert lib.hasAttr configPath files || throw "herdr: ${configPath} is not rendered";
+    assert builtins.deepSeq (lib.mapAttrsToList (_: f: f.source) ours) true;
+    helpers.mkMarker "check-herdr-rendered-files-regression"
+      "herdr renders ${toString (lib.length (lib.attrNames ours))} file(s) under ${cfg.configDir}.";
+
+  herdr-agent-coverage-regression =
+    assert uncovered == [ ]
+      || throw ''
+        herdr agent-detection coverage gap: ${lib.concatStringsSep ", " uncovered}
+
+        These CLIs are enabled in this flake but herdr has no manifest for them,
+        so their panes will show no working/blocked/idle state and nothing
+        downstream (Slack alerts, `herdr agent wait`, dashboard approvals) will
+        fire for them.
+
+        Fix by adding an entry to programs.herdr.agentManifests. Author it
+        against `herdr agent explain <target> --json` on a live pane — the rule
+        schema is herdr's, so do not guess it. If the gap is deliberate for
+        now, name it in programs.herdr.knownUnsupportedAgents instead, which
+        makes it reviewable rather than invisible.
+      '';
+    helpers.mkMarker "check-herdr-agent-coverage-regression"
+      "herdr detection covers all ${toString (lib.length enabledAgents)} enabled agent CLIs.";
+}

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -92,11 +92,11 @@ in
     in
     assert lib.hasAttr configPath files || throw "herdr: ${configPath} is not rendered";
     assert builtins.deepSeq (lib.mapAttrsToList (_: f: f.source) ours) true;
-    helpers.mkMarker "check-herdr-rendered-files-regression"
-      "herdr renders ${toString (lib.length (lib.attrNames ours))} file(s) under ${cfg.configDir}.";
+    helpers.mkMarker "check-herdr-rendered-files-regression" "herdr renders ${toString (lib.length (lib.attrNames ours))} file(s) under ${cfg.configDir}.";
 
   herdr-agent-coverage-regression =
-    assert uncovered == [ ]
+    assert
+      uncovered == [ ]
       || throw ''
         herdr agent-detection coverage gap: ${lib.concatStringsSep ", " uncovered}
 
@@ -111,6 +111,5 @@ in
         now, name it in programs.herdr.knownUnsupportedAgents instead, which
         makes it reviewable rather than invisible.
       '';
-    helpers.mkMarker "check-herdr-agent-coverage-regression"
-      "herdr detection covers all ${toString (lib.length enabledAgents)} enabled agent CLIs.";
+    helpers.mkMarker "check-herdr-agent-coverage-regression" "herdr detection covers all ${toString (lib.length enabledAgents)} enabled agent CLIs.";
 }

--- a/lib/homebrew.nix
+++ b/lib/homebrew.nix
@@ -1,35 +1,27 @@
 # AI tool Homebrew packages managed by nix-ai.
+#
 # Single source of truth consumed by:
 #   - flake.nix lib exports  → nix-darwin homebrew.nix (host capabilities)
 #   - modules/default.nix   → ~/.homebrew/trust.json (macOS only)
 #
 # Packages are keyed by injected, default-off host capabilities so consumers
 # never repeat package names or embed host-class policy.
+#
+# GUI APPLICATIONS ONLY. Every CLI that used to live here — claude-code@latest,
+# codex, antigravity-cli, qwen-code — now comes from nixpkgs or the
+# llm-agents.nix flake input, because a Homebrew cask has no Linux path and so
+# pinned the whole AI stack to the MacBook. Do not add a CLI back here: check
+# nixpkgs first, then llm-agents.nix, and only then reach for a cask.
 {
-  # claude-code@latest is now in Homebrew core, so no vendor tap is required.
+  # No vendor tap is required for any of the GUI casks below.
   taps = [ ];
 
   brews = {
     goose = [ "block-goose-cli" ];
-    qwenCode = [ "qwen-code" ];
     langgraphCli = [ "langgraph-cli" ];
   };
 
   casks = {
-    claudeCode = [
-      {
-        name = "claude-code@latest";
-        greedy = true;
-      }
-    ];
-
-    codex = [
-      {
-        name = "codex";
-        greedy = true;
-      }
-    ];
-
     claudeDesktop = [
       {
         name = "claude";
@@ -51,15 +43,9 @@
       }
     ];
 
-    # Google ships three independent Antigravity products. The standalone
-    # desktop no longer provides `agy`; the CLI cask owns that binary.
-    antigravityCli = [
-      {
-        name = "antigravity-cli";
-        greedy = true;
-      }
-    ];
-
+    # Google ships three independent Antigravity products. The `agy` CLI is no
+    # longer one of them here — it comes from llm-agents.nix. These two are the
+    # GUI halves.
     antigravityDesktop = [
       {
         name = "antigravity";

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -7,55 +7,27 @@
 # PACKAGE HIERARCHY (STRICT - NO EXCEPTIONS)
 # ============================================================================
 #
-# ALWAYS follow this order when choosing how to install a package:
+# nixpkgs -> llm-agents.nix -> homebrew (GUI only) -> bunx wrapper -> uvx.
 #
-# 1. **nixpkgs** (ALWAYS FIRST, NO EXCEPTIONS)
-#    - Check: nix search nixpkgs <package>
-#    - Use if package exists and is reasonably up-to-date
-#    - Benefits: Binary cache, security updates, integration
-#    - Example: github-mcp-server, terraform-mcp-server
-#
-# 2. **llm-agents.nix** (AI agent CLIs missing from nixpkgs)
-#    - github:numtide/llm-agents.nix — 150+ agent CLIs, rebuilt daily,
-#      substituted from cache.numtide.com
-#    - Covers x86_64-linux, aarch64-linux and aarch64-darwin
-#    - Example: copilot-cli, antigravity-cli, claude-code, herdr
-#    - Reach for this BEFORE homebrew: a cask cannot run on the fleet's
-#      Linux guests, which is what used to pin this stack to one MacBook
-#
-# 3. **homebrew** (GUI applications only — see lib/homebrew.nix)
-#    - macOS .app bundles with no Nix equivalent: Claude Desktop, ChatGPT,
-#      Antigravity IDE, Codex app
-#    - NOT for CLIs. Every CLI cask has been retired; do not add one back.
-#
-# 4. **bunx wrapper** (for npm packages not in nixpkgs or llm-agents.nix)
-#    - Standard solution for npm/bun packages
-#    - Always pin to specific version: package@x.y.z
-#    - Downloads on first run, cached locally by bun
-#    - Benefits: Simple, minimal code, easy version updates
-#    - Pattern: writeShellScriptBin with bunx --bun
-#
-# 5. **uvx** (for Python packages not in nixpkgs or version-lagging)
-#    - Standard solution for Python CLI tools
-#    - Run on-demand: uvx <package>
-#    - Benefits: Isolated environments, always-latest, no global pollution
-#    - Replaced pipx (pipx removed from nix-home — antipattern in Nix env)
+# The full decision matrix, and why each rung exists, lives in
+# modules/herdr/README.md. The short version: check `nix search nixpkgs <pkg>`
+# first; reach for github:numtide/llm-agents.nix for an agent CLI nixpkgs does
+# not carry; homebrew is GUI applications ONLY (a cask cannot run on the
+# fleet's Linux guests, which is what used to pin this stack to one MacBook —
+# do not add a CLI cask back); bunx for npm packages, always version-pinned;
+# uvx for Python CLI tools.
 #
 # ============================================================================
 # CURRENT STATUS
 # ============================================================================
 #
-# NIXPKGS PACKAGES (from nixpkgs, available on stable 26.05):
-#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper, entire,
-#   yt-dlp, codex, opencode, qwen-code, cursor-cli
+# NIXPKGS: github-mcp-server, terraform-mcp-server, whisper-cpp,
+#   openai-whisper, entire, yt-dlp, codex, opencode, qwen-code, cursor-cli
 #
-# LLM-AGENTS.NIX PACKAGES (agent CLIs nixpkgs does not carry):
-#   claude-code, antigravity-cli (`agy`), copilot-cli, herdr
+# LLM-AGENTS.NIX: claude-code, antigravity-cli (`agy`), copilot-cli, herdr
 #
-# HOMEBREW PACKAGES (from lib/homebrew.nix — GUI + two non-agent CLIs):
-#   block-goose-cli: Block's AI agent (nixpkgs outdated at time of addition)
-#   langgraph-cli: LangGraph platform deploy CLI (not in nixpkgs)
-#   claude / codex-app / chatgpt / antigravity / antigravity-ide: desktop apps
+# HOMEBREW (lib/homebrew.nix): block-goose-cli, langgraph-cli, and the desktop
+#   apps (claude, codex-app, chatgpt, antigravity, antigravity-ide)
 #
 # BUNX WRAPPER PACKAGES (npm packages not in nixpkgs/homebrew):
 #   cclint: @felixgeelhaar/cclint (CLAUDE.md linter)

--- a/modules/ai-tools.nix
+++ b/modules/ai-tools.nix
@@ -15,20 +15,27 @@
 #    - Benefits: Binary cache, security updates, integration
 #    - Example: github-mcp-server, terraform-mcp-server
 #
-# 2. **homebrew** (ONLY if not in nixpkgs)
-#    - Fallback for packages missing from nixpkgs
-#    - Check: brew search <package>
-#    - Add to modules/darwin/homebrew.nix with clear justification
-#    - Document WHY homebrew is needed (not in nixpkgs, severely outdated, etc.)
+# 2. **llm-agents.nix** (AI agent CLIs missing from nixpkgs)
+#    - github:numtide/llm-agents.nix — 150+ agent CLIs, rebuilt daily,
+#      substituted from cache.numtide.com
+#    - Covers x86_64-linux, aarch64-linux and aarch64-darwin
+#    - Example: copilot-cli, antigravity-cli, claude-code, herdr
+#    - Reach for this BEFORE homebrew: a cask cannot run on the fleet's
+#      Linux guests, which is what used to pin this stack to one MacBook
 #
-# 3. **bunx wrapper** (for npm packages not in nixpkgs or homebrew)
+# 3. **homebrew** (GUI applications only — see lib/homebrew.nix)
+#    - macOS .app bundles with no Nix equivalent: Claude Desktop, ChatGPT,
+#      Antigravity IDE, Codex app
+#    - NOT for CLIs. Every CLI cask has been retired; do not add one back.
+#
+# 4. **bunx wrapper** (for npm packages not in nixpkgs or llm-agents.nix)
 #    - Standard solution for npm/bun packages
 #    - Always pin to specific version: package@x.y.z
 #    - Downloads on first run, cached locally by bun
 #    - Benefits: Simple, minimal code, easy version updates
 #    - Pattern: writeShellScriptBin with bunx --bun
 #
-# 4. **uvx** (for Python packages not in nixpkgs or version-lagging)
+# 5. **uvx** (for Python packages not in nixpkgs or version-lagging)
 #    - Standard solution for Python CLI tools
 #    - Run on-demand: uvx <package>
 #    - Benefits: Isolated environments, always-latest, no global pollution
@@ -38,14 +45,17 @@
 # CURRENT STATUS
 # ============================================================================
 #
-# NIXPKGS PACKAGES (from nixpkgs, available on stable 25.11):
-#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper, entire
+# NIXPKGS PACKAGES (from nixpkgs, available on stable 26.05):
+#   github-mcp-server, terraform-mcp-server, whisper-cpp, openai-whisper, entire,
+#   yt-dlp, codex, opencode, qwen-code, cursor-cli
 #
-# HOMEBREW PACKAGES (from lib/homebrew.nix):
-#   codex: OpenAI Codex CLI
+# LLM-AGENTS.NIX PACKAGES (agent CLIs nixpkgs does not carry):
+#   claude-code, antigravity-cli (`agy`), copilot-cli, herdr
+#
+# HOMEBREW PACKAGES (from lib/homebrew.nix — GUI + two non-agent CLIs):
 #   block-goose-cli: Block's AI agent (nixpkgs outdated at time of addition)
-#   antigravity-cli: Google Antigravity CLI (`agy`)
 #   langgraph-cli: LangGraph platform deploy CLI (not in nixpkgs)
+#   claude / codex-app / chatgpt / antigravity / antigravity-ide: desktop apps
 #
 # BUNX WRAPPER PACKAGES (npm packages not in nixpkgs/homebrew):
 #   cclint: @felixgeelhaar/cclint (CLAUDE.md linter)
@@ -77,9 +87,10 @@
 #   2. Add to packages list below
 #   3. Add to version check script (scripts/workflows/check-package-versions.sh)
 
-{ pkgs, ... }:
+{ pkgs, llm-agents, ... }:
 let
   versions = import ../lib/versions.nix;
+  llmAgents = llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
   cclintVersion = versions.cclint;
   ghCopilotVersion = versions.ghCopilot;
   chatgptCliVersion = versions.chatgptCli;
@@ -149,8 +160,14 @@ in
     # ==========================================================================
     # GitHub Copilot CLI
     # ==========================================================================
-    # Source: https://github.com/github/gh-copilot
-    # NPM: @githubnext/github-copilot-cli (pinned version)
+    # `copilot` — the current CLI. Not in nixpkgs; llm-agents.nix packages it
+    # for both supported systems. Its config (~/.copilot) is written by
+    # modules/copilot.nix, which previously configured a binary nothing here
+    # installed.
+    llmAgents.copilot-cli
+
+    # `gh-copilot` — the older gh extension, kept for the shell-suggest
+    # workflow it still serves. Source: https://github.com/github/gh-copilot
     (writeShellScriptBin "gh-copilot" ''
       exec ${bun}/bin/bunx --bun @githubnext/github-copilot-cli@${ghCopilotVersion} "$@"
     '')

--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -18,6 +18,8 @@
 {
   config,
   lib,
+  pkgs,
+  llm-agents,
   ...
 }:
 
@@ -40,6 +42,15 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
+    # `agy` came from the antigravity-cli Homebrew cask, which has no Linux
+    # path. llm-agents.nix packages it for aarch64-darwin and x86_64-linux
+    # alike; nixpkgs does not carry it at all.
+    programs.antigravity-cli.package = lib.mkDefault (
+      llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.antigravity-cli
+    );
+
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
     # Ensure directory structure exists
     home.file.".gemini/antigravity-cli/.keep".text = ''
       # Managed by Nix - programs.antigravity-cli module

--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -25,6 +25,7 @@
 
 let
   cfg = config.programs.antigravity-cli;
+  agyPackage = llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.antigravity-cli;
 in
 {
   # home-manager release-26.05 gained its own programs.antigravity-cli
@@ -42,36 +43,36 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
-    # `agy` came from the antigravity-cli Homebrew cask, which has no Linux
-    # path. llm-agents.nix packages it for aarch64-darwin and x86_64-linux
-    # alike; nixpkgs does not carry it at all.
-    programs.antigravity-cli.package = lib.mkDefault (
-      llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.antigravity-cli
-    );
+    home = {
+      packages = lib.optional (cfg.package != null) cfg.package;
 
-    home.packages = lib.optional (cfg.package != null) cfg.package;
+      # Ensure directory structure exists
+      file.".gemini/antigravity-cli/.keep".text = ''
+        # Managed by Nix - programs.antigravity-cli module
+      '';
 
-    # Ensure directory structure exists
-    home.file.".gemini/antigravity-cli/.keep".text = ''
-      # Managed by Nix - programs.antigravity-cli module
-    '';
-
-    # This CLI accepts only a Gemini-format endpoint, so it can follow the
-    # local proxy only because that proxy serves the Gemini generateContent
-    # route natively (`/v1beta/models/<model>:generateContent` and its
-    # streaming twin) alongside the OpenAI-compatible one. The root URL is
-    # what goes here — the CLI appends the `/v1beta/...` path itself.
-    home.sessionVariables = lib.mkIf config.programs.litellmLocal.enable {
-      GOOGLE_GEMINI_BASE_URL = config.programs.litellmLocal.rootUrl;
+      # This CLI accepts only a Gemini-format endpoint, so it can follow the
+      # local proxy only because that proxy serves the Gemini generateContent
+      # route natively (`/v1beta/models/<model>:generateContent` and its
+      # streaming twin) alongside the OpenAI-compatible one. The root URL is
+      # what goes here — the CLI appends the `/v1beta/...` path itself.
+      sessionVariables = lib.mkIf config.programs.litellmLocal.enable {
+        GOOGLE_GEMINI_BASE_URL = config.programs.litellmLocal.rootUrl;
+      };
     };
 
-    # Select the role rather than a Gemini registry id, so this CLI resolves
-    # the same way as every other client. mkDefault, because whether this CLI
-    # accepts a model name outside its own registry is not verified here — a
-    # consumer that finds it rejected sets defaultModel back to an alias
-    # without editing this module.
-    programs.antigravity-cli.defaultModel = lib.mkIf config.programs.litellmLocal.enable (
-      lib.mkDefault "subagent"
-    );
+    programs.antigravity-cli = {
+      # `agy` came from the antigravity-cli Homebrew cask, which has no Linux
+      # path. llm-agents.nix packages it for aarch64-darwin and x86_64-linux
+      # alike; nixpkgs does not carry it at all.
+      package = lib.mkDefault agyPackage;
+
+      # Select the role rather than a Gemini registry id, so this CLI resolves
+      # the same way as every other client. mkDefault, because whether this CLI
+      # accepts a model name outside its own registry is not verified here — a
+      # consumer that finds it rejected sets defaultModel back to an alias
+      # without editing this module.
+      defaultModel = lib.mkIf config.programs.litellmLocal.enable (lib.mkDefault "subagent");
+    };
   };
 }

--- a/modules/antigravity-cli/options.nix
+++ b/modules/antigravity-cli/options.nix
@@ -41,6 +41,17 @@ in
   options.programs.antigravity-cli = {
     enable = lib.mkEnableOption "Antigravity CLI configuration";
 
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        Antigravity CLI (`agy`) package. Defaults to llm-agents.nix's
+        antigravity-cli — nixpkgs does not carry it, and the Homebrew cask it
+        replaces was macOS-only. Null skips installation, for a host that
+        supplies the binary itself.
+      '';
+    };
+
     # Commands
     commands = {
       fromFlakeInputs = lib.mkOption {

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -15,6 +15,7 @@
   ai-assistant-instructions,
   nix-claude-code,
   marketplaceInputs,
+  llm-agents,
   claude-cookbooks,
   fabric-src,
   userConfig ? {
@@ -115,11 +116,12 @@ in
     programs.claude = {
       enable = true;
 
-      # Binary comes from Homebrew (claude-code@latest cask in nix-darwin);
-      # Nix manages config only. Claude's native updater (latest channel)
-      # overlays the newest build at ~/.local/bin/claude on top of the brew
-      # baseline. See nix-claude-code core.nix: package = null skips home.packages.
-      package = null;
+      # Binary comes from llm-agents.nix, which packages claude-code for
+      # aarch64-darwin AND x86_64-linux. It used to be the claude-code@latest
+      # Homebrew cask, which is why nothing but the Mac could run this stack.
+      # Claude's native updater (programs.claude.latest) still overlays a newer
+      # build at ~/.local/bin/claude on top of this baseline.
+      package = llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
 
       # API Key Helper for headless authentication (cron jobs, CI/CD)
       # Uses Bitwarden Secrets Manager to securely fetch OAuth token

--- a/modules/codex/default.nix
+++ b/modules/codex/default.nix
@@ -11,6 +11,7 @@
 {
   config,
   lib,
+  pkgs,
   ai-assistant-instructions,
   ...
 }:
@@ -26,8 +27,13 @@ in
 
   config = lib.mkIf cfg.enable {
     programs.codex = {
-      # nix-darwin installs Codex via Homebrew for stable TCC paths.
-      package = lib.mkDefault null;
+      # nixpkgs packages codex for both supported systems (26.05 ships 0.146).
+      # This used to be the `codex` Homebrew cask, chosen for stable TCC paths
+      # on macOS — a Nix store path changes on every version bump, so watch for
+      # macOS re-prompting for permissions after an upgrade. That tradeoff is
+      # deliberate: the cask had no Linux path, which is what pinned the whole
+      # stack to the MacBook.
+      package = lib.mkDefault pkgs.codex;
       context = lib.mkDefault (builtins.readFile "${ai-assistant-instructions}/AGENTS.md");
       # config.toml is managed via home.activation — do NOT set settings here.
     };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@
   ai-assistant-instructions,
   nix-claude-code,
   marketplaceInputs,
+  llm-agents,
   userConfig ? {
     user.fullName = "JacobPEvans";
   },
@@ -90,6 +91,7 @@ in
     ./antigravity-ide
     ./antigravity-cli
     ./fabric
+    ./herdr
     ./litellm-local
     ./maestro
     ./mcp/module.nix
@@ -105,7 +107,7 @@ in
   config = {
     home = {
       # AI development tools (MCP servers, linters, CLI wrappers)
-      inherit (import ./ai-tools.nix { inherit pkgs; }) packages;
+      inherit (import ./ai-tools.nix { inherit pkgs llm-agents; }) packages;
 
       file = copilotFiles // agentsMdSymlinks // brewTrustFiles;
 
@@ -220,6 +222,12 @@ in
       # Bleeding-edge Claude Code at ~/.local/bin/claude via the upstream
       # opt-in module (nix-claude-code owns programs.claude.latest).
       claude.latest.enable = true;
+
+      # herdr — the multiplexer the agent CLIs above run inside. On the
+      # workstation this is the client half; `herdr --remote <name>` attaches
+      # to a server-hosted herd using the same config.toml the server renders
+      # from this flake.
+      herdr.enable = true;
     };
   };
 }

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -1,0 +1,92 @@
+# herdr
+
+[herdr](https://github.com/herdrdev/herdr) is a background server that owns the
+terminals coding agents run in: sessions survive a reboot, panes are marked
+working/blocked/idle, and agents drive it themselves through a CLI and a
+Unix-socket JSON API.
+
+Two halves, one flake:
+
+| Output | File | Runs |
+| --- | --- | --- |
+| `homeManagerModules.herdr` | `default.nix`, `options.nix`, `settings.nix` | the workstation |
+| `nixosModules.herdr` | `nixos.nix` | the Linux guest, as a systemd service |
+
+Both take their binary from the same `llm-agents` input, so a pane on the
+server runs the same build as a pane on the Mac.
+
+## Where CLI binaries come from
+
+**nixpkgs → llm-agents.nix → homebrew (GUI only) → bunx → uvx.**
+
+Claude Code, Codex, Antigravity CLI (`agy`) and qwen-code used to come from
+**Homebrew casks and brews**. A cask has no Linux path, so a host evaluating
+this flake on `x86_64-linux` got config files and no binaries — concretely why
+the stack could not leave the MacBook.
+
+| CLI | Source |
+| --- | --- |
+| Claude Code, `agy`, Copilot CLI, herdr | `llm-agents.nix` |
+| Codex, OpenCode, qwen-code, Cursor | nixpkgs 26.05 |
+| Claude Desktop, Codex app, ChatGPT, Antigravity, Antigravity IDE | homebrew |
+
+[`numtide/llm-agents.nix`](https://github.com/numtide/llm-agents.nix) carries
+150+ agent CLIs for `x86_64-linux`, `aarch64-linux` and `aarch64-darwin` — an
+exact match for this flake's `supportedSystems` — rebuilt daily and substituted
+from `cache.numtide.com`.
+
+Two rules that will bite otherwise:
+
+- **It deliberately does not `follows` nixpkgs**, unlike every other input.
+  It pins its own `nixpkgs-unstable` and the numtide cache is keyed to that
+  pin; forcing 26.05 breaks builds *and* loses every cache hit.
+- **`lib/homebrew.nix` is GUI-only.** Do not add a CLI cask back.
+
+### Known cost: macOS TCC
+
+`modules/codex/default.nix` used to note that Codex was a cask specifically for
+*stable TCC paths*. A Nix store path changes on every version bump, so macOS
+may re-prompt for permissions after an upgrade. That is the accepted tradeoff
+for having a Linux path at all. If it proves disruptive, fix it for darwin
+specifically rather than reverting the Linux path.
+
+## Two conflicts with declarative config
+
+Both are things herdr's own quick-start walks straight into.
+
+**Do not run `herdr integration install <agent>`.** It writes lifecycle hooks
+into each agent's own config. For Claude Code that means editing
+`~/.claude/settings.json`, which `nix-claude-code` renders read-only from the
+Nix store — the write fails, or the next `switch` reverts it. Express those
+hooks as `programs.claude.hooks` in `modules/claude-config.nix` instead.
+
+**herdr fetches agent-manifest updates from `herdr.dev` at runtime** and applies
+them without a restart: undeclared mutable state reaching the internet on an
+otherwise declarative guest. Local manifests take precedence, so declare the
+ones that matter in `programs.herdr.agentManifests` rather than trusting
+whatever the network last handed the daemon, and set the guest's egress policy
+deliberately.
+
+## Agent detection
+
+herdr classifies a pane by matching manifest rules against the foreground
+process. A CLI with no manifest shows as a bare shell, and everything
+downstream — the Slack bridge's blocked-agent alerts, `herdr agent wait`, the
+dashboard's approvals — silently sees nothing to report.
+
+`lib/checks/herdr.nix` fails when an enabled CLI is neither detected upstream,
+nor given a manifest here, nor named in `knownUnsupportedAgents`.
+
+`qwen-code` and `cecli` are in that list today: herdr ships no manifest for
+either, and the rule schema is herdr's, so those entries are **declared rather
+than guessed at**. Author real ones against
+`herdr agent explain <target> --json` on a live pane, then reload with
+`herdr server reload-agent-manifests`.
+
+## The socket path is a contract
+
+`nixos.nix` sets `RuntimeDirectory=herdr`, pinning the control socket at
+`/run/herdr` instead of a uid-derived `$XDG_RUNTIME_DIR` path. That is
+deliberate: the Slack bridge runs in its own container and forwards the socket
+over SSH, which needs a predictable path. Changing it breaks that forward, and
+the failure mode is a permanently quiet fleet rather than an error.

--- a/modules/herdr/default.nix
+++ b/modules/herdr/default.nix
@@ -1,0 +1,48 @@
+# herdr Module — Aggregator
+#
+# herdr (https://github.com/herdrdev/herdr) is a background server that owns
+# the terminals coding agents run in: sessions survive reboot and reattach over
+# SSH, panes are marked working/blocked/idle, and agents drive it themselves
+# through a CLI and a Unix-socket JSON API.
+#
+# This module is the workstation half. The server half is modules/herdr/nixos.nix,
+# exported as nixosModules.herdr; both take their binary from the same
+# llm-agents.nix input, which is the whole point — one flake, both setups.
+#
+# Two things NOT to do, both of which herdr's own quick-start will suggest:
+#
+#   1. Do not run `herdr integration install <agent>`. It writes lifecycle
+#      hooks into each agent's own config — for Claude Code that means editing
+#      ~/.claude/settings.json, which nix-claude-code renders read-only from the
+#      Nix store. The write fails, or is reverted on the next switch. Express
+#      those hooks as programs.claude.hooks in modules/claude-config.nix.
+#
+#   2. Be aware herdr fetches agent-manifest updates from herdr.dev at runtime
+#      and applies them without a restart. Local manifests take precedence, so
+#      declare the ones that matter in programs.herdr.agentManifests rather
+#      than relying on whatever the network last handed the daemon.
+{
+  config,
+  lib,
+  pkgs,
+  llm-agents,
+  ...
+}:
+
+let
+  cfg = config.programs.herdr;
+in
+{
+  imports = [
+    ./options.nix
+    ./settings.nix
+  ];
+
+  config = lib.mkIf cfg.enable {
+    programs.herdr.package = lib.mkDefault (
+      llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.herdr
+    );
+
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+  };
+}

--- a/modules/herdr/default.nix
+++ b/modules/herdr/default.nix
@@ -31,6 +31,7 @@
 
 let
   cfg = config.programs.herdr;
+  herdrPackage = llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.herdr;
 in
 {
   imports = [
@@ -39,9 +40,7 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
-    programs.herdr.package = lib.mkDefault (
-      llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.herdr
-    );
+    programs.herdr.package = lib.mkDefault herdrPackage;
 
     home.packages = lib.optional (cfg.package != null) cfg.package;
   };

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -95,17 +95,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    users.groups.${cfg.user} = { };
+    users = {
+      groups.${cfg.user} = { };
 
-    users.users.${cfg.user} = {
-      isSystemUser = true;
-      group = cfg.user;
-      home = cfg.stateDir;
-      createHome = true;
-      # A real shell, deliberately: herdr's whole job is to run interactive
-      # agent CLIs in PTYs. The guest is the blast-radius boundary, the same
-      # reasoning the fleet's hermes and agent-exec users are documented with.
-      shell = pkgs.bashInteractive;
+      users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.user;
+        home = cfg.stateDir;
+        createHome = true;
+        # A real shell, deliberately: herdr's whole job is to run interactive
+        # agent CLIs in PTYs. The guest is the blast-radius boundary, the same
+        # reasoning the fleet's hermes and agent-exec users are documented with.
+        shell = pkgs.bashInteractive;
+      };
     };
 
     environment.systemPackages = [ cfg.package ] ++ cfg.agentPackages ++ cfg.extraPackages;

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -1,0 +1,155 @@
+# herdr — NixOS service module
+#
+# The server half of modules/herdr/. Exported as nixosModules.herdr.
+#
+# herdr's own docs describe a user-session daemon you attach to from a terminal.
+# On a single-purpose guest a system service running as a dedicated user is more
+# deterministic — no lingering, no login session to lose — and it buys the thing
+# the rest of this design needs: a STABLE SOCKET PATH. RuntimeDirectory pins it
+# at /run/herdr, so the Slack bridge can forward it over SSH from its own
+# container (`ssh -L /run/herdr/herdr.sock:/run/herdr/herdr.sock`) instead of
+# guessing at $XDG_RUNTIME_DIR/<uid>.
+{
+  config,
+  lib,
+  pkgs,
+  llm-agents,
+  ...
+}:
+
+let
+  cfg = config.services.herdr;
+  agents = llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
+in
+{
+  options.services.herdr = {
+    enable = lib.mkEnableOption "the herdr agent-multiplexer server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = agents.herdr;
+      defaultText = lib.literalExpression "llm-agents.packages.\${system}.herdr";
+      description = "herdr package to run.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "herdr";
+      description = "User the herdr server and every agent pane runs as.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/herdr";
+      description = ''
+        Home and state directory. This is the ONLY path on the guest worth
+        backing up: agent credentials, git worktrees, and session state all
+        live here. Everything else rebuilds from the flake.
+      '';
+    };
+
+    agentPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [
+        agents.claude-code
+        agents.antigravity-cli
+        agents.copilot-cli
+        pkgs.codex
+        pkgs.opencode
+        pkgs.qwen-code
+        pkgs.cursor-cli
+      ];
+      defaultText = lib.literalExpression "the AI CLIs this flake manages";
+      description = ''
+        The agent CLIs herdr can start in a pane. Same source as the
+        home-manager module uses on the workstation, so a pane on the server
+        runs the same build as a pane on the Mac.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = "Additional tools the agents need on PATH (git, ripgrep, language toolchains).";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/var/lib/herdr/.env";
+      description = ''
+        systemd EnvironmentFile holding the per-guest secrets NixOS cannot know
+        — API keys, router endpoint, Slack tokens. Written out of band at mode
+        0600; never rendered into the Nix store, which is world-readable.
+        Loaded with a leading `-`, so a missing file leaves the service inert
+        rather than failing to start.
+      '';
+    };
+
+    onFailureUnit = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "herdr-unit-alert@%n.service";
+      description = "Unit to trigger via OnFailure=, mirroring the fleet's hermes-unit-alert pattern.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.${cfg.user} = { };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.user;
+      home = cfg.stateDir;
+      createHome = true;
+      # A real shell, deliberately: herdr's whole job is to run interactive
+      # agent CLIs in PTYs. The guest is the blast-radius boundary, the same
+      # reasoning the fleet's hermes and agent-exec users are documented with.
+      shell = pkgs.bashInteractive;
+    };
+
+    environment.systemPackages = [ cfg.package ] ++ cfg.agentPackages ++ cfg.extraPackages;
+
+    systemd.services.herdr = {
+      description = "herdr agent multiplexer server";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      path = [ cfg.package ] ++ cfg.agentPackages ++ cfg.extraPackages;
+
+      unitConfig = {
+        # In [Unit], not [Service]. systemd moved these and silently ignores
+        # them in the wrong section — the same trap hermes-gateway.service
+        # documents.
+        StartLimitIntervalSec = 300;
+        StartLimitBurst = 5;
+      }
+      // lib.optionalAttrs (cfg.onFailureUnit != null) { OnFailure = cfg.onFailureUnit; };
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/herdr server";
+        ExecStop = "${cfg.package}/bin/herdr server stop";
+        User = cfg.user;
+        Group = cfg.user;
+        WorkingDirectory = cfg.stateDir;
+        StateDirectory = "herdr";
+        # Pins the control socket at /run/herdr instead of a uid-derived
+        # $XDG_RUNTIME_DIR path, so remote bridges can forward a known path.
+        RuntimeDirectory = "herdr";
+        RuntimeDirectoryMode = "0750";
+        Restart = "always";
+        RestartSec = "5s";
+      }
+      // lib.optionalAttrs (cfg.environmentFile != null) {
+        EnvironmentFile = "-${cfg.environmentFile}";
+      };
+
+      environment = {
+        HOME = cfg.stateDir;
+        XDG_RUNTIME_DIR = "/run/herdr";
+      };
+    };
+  };
+}

--- a/modules/herdr/options.nix
+++ b/modules/herdr/options.nix
@@ -31,7 +31,7 @@ in
     };
 
     settings = lib.mkOption {
-      type = tomlFormat.type;
+      inherit (tomlFormat) type;
       default = { };
       example = lib.literalExpression ''
         {

--- a/modules/herdr/options.nix
+++ b/modules/herdr/options.nix
@@ -1,0 +1,136 @@
+#
+# herdr Module — Option Declarations
+#
+{ lib, pkgs, ... }:
+
+let
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.programs.herdr = {
+    enable = lib.mkEnableOption "herdr (terminal workspace manager for AI coding agents)";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        herdr package. Defaults to llm-agents.nix's herdr — nixpkgs carries it
+        only on unstable, and this flake pins the 26.05 channel. Null skips
+        installation, for a host that supplies the binary itself.
+      '';
+    };
+
+    configDir = lib.mkOption {
+      type = lib.types.str;
+      default = ".config/herdr";
+      description = ''
+        Directory (relative to $HOME) holding `config.toml` and the
+        `agent-detection/` manifest overrides. Upstream default; changing it
+        also requires HERDR_CONFIG_DIR in the environment.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          ui.sidebar = "left";
+          worktrees.directory = "~/git/worktrees";
+        }
+      '';
+      description = ''
+        Contents of `config.toml`. Upstream sections are [terminal],
+        [worktrees], [remote], [keys], [theme], [ui], [ui.sound],
+        [experimental] and [session]. Free-form on purpose: herdr's config
+        reference is the schema, and mirroring it here would go stale.
+      '';
+    };
+
+    remotes = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = {
+        herdr = "herdr.example.invalid";
+      };
+      description = ''
+        Named SSH remotes, rendered into `[remote]`. `herdr --remote <name>`
+        then starts or attaches to that host's herdr server and streams its UI
+        back, which is how a workstation drives the server-hosted herd.
+      '';
+    };
+
+    defaultRemote = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Name from `remotes` to use when `--remote` is given no argument.";
+    };
+
+    agentManifests = lib.mkOption {
+      type = lib.types.attrsOf tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        { qwen-code = { detection = { }; }; }
+      '';
+      description = ''
+        Local agent-detection manifest overrides, rendered to
+        `<configDir>/agent-detection/<name>.toml`. Local manifests take
+        precedence over herdr's bundled and remotely-fetched ones.
+
+        herdr ships manifests for Claude Code, Codex, Cursor Agent, OpenCode,
+        Copilot CLI, Antigravity CLI, Grok, Droid, Pi and Hermes Agent. Any CLI
+        this flake enables that is NOT on that list needs an entry here, or
+        herdr will show its pane as a bare shell with no working/blocked/idle
+        state. `lib/checks/herdr.nix` enforces that.
+
+        The rule schema is herdr's, not ours — author an entry against
+        `herdr agent explain <target> --json` on a live pane rather than from
+        memory, and reload with `herdr server reload-agent-manifests`.
+      '';
+    };
+
+    knownUnsupportedAgents = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "cecli"
+        "qwen-code"
+      ];
+      description = ''
+        CLIs this flake enables that herdr knowingly cannot detect, and for
+        which no local manifest has been authored yet. Their panes work — they
+        are just reported as a plain shell, so nothing downstream fires on
+        their state.
+
+        This list exists so the gap is DECLARED rather than silent: the
+        coverage check in lib/checks/herdr.nix fails for any enabled CLI that
+        is neither detected upstream, nor given a manifest, nor listed here.
+        Adding a name here is a deliberate, reviewable act; forgetting one is
+        not possible.
+
+        Shrink it by authoring manifests against `herdr agent explain` output.
+      '';
+    };
+
+    knownUpstreamAgents = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      readOnly = true;
+      default = [
+        "antigravity-cli"
+        "claude"
+        "codex"
+        "copilot"
+        "cursor"
+        "droid"
+        "grok"
+        "hermes"
+        "opencode"
+        "pi"
+      ];
+      description = ''
+        Agents herdr detects out of the box, as declared by its own supported-
+        agents documentation. Read-only: it describes upstream, so a consumer
+        overriding it would only be lying to the coverage check.
+      '';
+    };
+  };
+}

--- a/modules/herdr/settings.nix
+++ b/modules/herdr/settings.nix
@@ -1,0 +1,44 @@
+#
+# herdr Module — config.toml and agent-detection manifests
+#
+# Both are plain declarative home.file entries. herdr does not rewrite its own
+# config.toml (session state lives under its state dir), so no deep-merge
+# activation is needed — unlike Codex and Antigravity, which do.
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.herdr;
+  tomlFormat = pkgs.formats.toml { };
+
+  # `remotes` / `defaultRemote` are conveniences over the same [remote] section
+  # `settings` can write directly. Merged so an explicit `settings.remote` wins.
+  remoteSection = lib.optionalAttrs (cfg.remotes != { }) {
+    remote = {
+      hosts = cfg.remotes;
+    }
+    // lib.optionalAttrs (cfg.defaultRemote != null) { default = cfg.defaultRemote; };
+  };
+
+  merged = lib.recursiveUpdate remoteSection cfg.settings;
+
+  manifestFiles = lib.mapAttrs' (
+    name: value:
+    lib.nameValuePair "${cfg.configDir}/agent-detection/${name}.toml" {
+      source = tomlFormat.generate "herdr-agent-${name}.toml" value;
+    }
+  ) cfg.agentManifests;
+in
+{
+  config = lib.mkIf cfg.enable {
+    home.file = {
+      "${cfg.configDir}/config.toml".source = tomlFormat.generate "herdr-config.toml" merged;
+    }
+    // manifestFiles;
+  };
+}

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -133,12 +133,14 @@ in
       # config with nothing to run it.
       programs.opencode.package = lib.mkDefault pkgs.opencode;
 
-      home.packages = lib.optional (cfg.package != null) cfg.package;
+      home = {
+        packages = lib.optional (cfg.package != null) cfg.package;
 
-      home.file = {
-        "${configDir}/opencode.json".source = settingsJson;
-      }
-      // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
+        file = {
+          "${configDir}/opencode.json".source = settingsJson;
+        }
+        // lib.foldl' (acc: dir: acc // mkCommandLinks dir) { } cfg.commandDirs;
+      };
     })
   ];
 }

--- a/modules/opencode/default.nix
+++ b/modules/opencode/default.nix
@@ -1,6 +1,6 @@
 # OpenCode Module
 #
-# Config-only (binary installed out-of-band, like qwen-code). OpenCode never
+# Binary from nixpkgs; config declarative. OpenCode never
 # rewrites its global config — state lives in ~/.local/share/opencode — so
 # opencode.json is a plain declarative home.file, no deep-merge activation.
 #
@@ -128,6 +128,13 @@ in
       programs.opencode.mcpServerNames = lib.attrNames mcpServers;
     }
     (lib.mkIf cfg.enable {
+      # nixpkgs packages opencode for both supported systems, so the binary is
+      # no longer "installed out-of-band" — that gap is why a Linux host got
+      # config with nothing to run it.
+      programs.opencode.package = lib.mkDefault pkgs.opencode;
+
+      home.packages = lib.optional (cfg.package != null) cfg.package;
+
       home.file = {
         "${configDir}/opencode.json".source = settingsJson;
       }

--- a/modules/opencode/options.nix
+++ b/modules/opencode/options.nix
@@ -7,6 +7,15 @@ in
   options.programs.opencode = {
     enable = lib.mkEnableOption "OpenCode (sst/opencode terminal agent)";
 
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        OpenCode package. Defaults to pkgs.opencode (nixpkgs).
+        Null skips installation, for a host that supplies the binary itself.
+      '';
+    };
+
     configDir = lib.mkOption {
       type = lib.types.str;
       default = ".config/opencode";

--- a/modules/qwen-code/default.nix
+++ b/modules/qwen-code/default.nix
@@ -33,9 +33,7 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
-    programs.qwen-code.package = lib.mkIf (cfg.installVia == "nixpkgs") (
-      lib.mkDefault pkgs.qwen-code
-    );
+    programs.qwen-code.package = lib.mkIf (cfg.installVia == "nixpkgs") (lib.mkDefault pkgs.qwen-code);
 
     home = {
       packages = lib.optional (cfg.package != null) cfg.package;

--- a/modules/qwen-code/default.nix
+++ b/modules/qwen-code/default.nix
@@ -37,8 +37,9 @@ in
       lib.mkDefault pkgs.qwen-code
     );
 
-    home.packages = lib.optional (cfg.package != null) cfg.package;
-
-    home.file.".qwen/.keep".text = "# Managed by Nix — programs.qwen-code\n";
+    home = {
+      packages = lib.optional (cfg.package != null) cfg.package;
+      file.".qwen/.keep".text = "# Managed by Nix — programs.qwen-code\n";
+    };
   };
 }

--- a/modules/qwen-code/default.nix
+++ b/modules/qwen-code/default.nix
@@ -11,22 +11,15 @@
 # Dashscope / OpenRouter / OpenAI access is opt-in via the `d-qwen`
 # Doppler-wrapped shell alias.
 #
-# Why brew (not nixpkgs / uvx):
-#   - Not packaged in nixpkgs.
-#   - Homebrew has a bottled formula (`qwen-code`) — this is the
-#     install-order rule's preferred path after nixpkgs and a local
-#     buildNpmPackage derivation. The npm-derivation path is deferred
-#     (qwen-code's workspace + cross-platform optionalDependencies
-#     need deeper packaging work).
-#
-# The brew install itself lives in nix-darwin (homebrew.brews is a
-# nix-darwin option, not a home-manager one). lib/homebrew.nix owns the
-# package identity; nix-darwin enables its capability. This module only
-# handles configuration.
+# Why nixpkgs (not brew / uvx): nixpkgs packages qwen-code as of 26.05.
+# It used to come from a Homebrew formula, which had no Linux path and so was
+# one of the reasons this stack could not leave the Mac. `installVia = "brew"`
+# is still selectable for a host that wants the bottled build.
 #
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -40,6 +33,12 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
+    programs.qwen-code.package = lib.mkIf (cfg.installVia == "nixpkgs") (
+      lib.mkDefault pkgs.qwen-code
+    );
+
+    home.packages = lib.optional (cfg.package != null) cfg.package;
+
     home.file.".qwen/.keep".text = "# Managed by Nix — programs.qwen-code\n";
   };
 }

--- a/modules/qwen-code/options.nix
+++ b/modules/qwen-code/options.nix
@@ -10,19 +10,27 @@ in
   options.programs.qwen-code = {
     enable = lib.mkEnableOption "Qwen Code (Alibaba terminal coding agent)";
 
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        Qwen Code package. Defaults to pkgs.qwen-code (nixpkgs).
+        Null skips installation, for a host that supplies the binary itself.
+      '';
+    };
+
     installVia = lib.mkOption {
       type = lib.types.enum [
+        "nixpkgs"
         "brew"
       ];
-      default = "brew";
+      default = "nixpkgs";
       description = ''
-        Install source. Currently brew-only — declared via nix-darwin's
-        homebrew.brews, sourced from this flake's lib.homebrewFor.
-        The npm activation-script fallback was removed in favor of
-        proper Nix derivations elsewhere; a buildNpmPackage derivation
-        for qwen-code's workspace + cross-platform optionalDependencies
-        layout is non-trivial and deferred. Linux hosts need brew (or
-        Linuxbrew) to use qwen-code through this module.
+        Install source. nixpkgs ships qwen-code as of 26.05, so the brew
+        formula is no longer needed and no longer the default — that
+        dependency is what kept this module macOS-only. "brew" is retained
+        for a host that deliberately wants the bottled build; it installs
+        nothing here, relying on nix-darwin's homebrew.brews.
       '';
     };
 


### PR DESCRIPTION
Adds [herdr](https://github.com/herdrdev/herdr) — the multiplexer the agent CLIs run inside — as both a home-manager module (workstation) and a NixOS service (Linux guest), and moves the agent CLI binaries off Homebrew so the second half is possible at all.

This is step 1 of a larger change; `tofu-proxmox`, `ansible-proxmox-ai` and `docs` follow separately. It stands on its own: it unblocks Linux and gives the Mac herdr, even if the fleet work slips.

## Packaging: why this was the blocker

Claude Code, Codex, Antigravity CLI (`agy`) and qwen-code came from Homebrew casks/brews. A cask has no Linux path, so a host evaluating this flake on `x86_64-linux` got config files and no binaries. That is concretely why the stack could not leave the MacBook.

New sourcing hierarchy — **nixpkgs → llm-agents.nix → homebrew (GUI only) → bunx → uvx**:

| CLI | Was | Now |
| --- | --- | --- |
| Claude Code | cask `claude-code@latest` | `llm-agents.claude-code` |
| Codex | cask `codex` | `pkgs.codex` (26.05 ships 0.146.0) |
| Antigravity CLI (`agy`) | cask `antigravity-cli` | `llm-agents.antigravity-cli` |
| qwen-code | brew `qwen-code` | `pkgs.qwen-code` (26.05 ships 0.16.0) |
| OpenCode | unmanaged | `pkgs.opencode` (26.05 ships 1.15.10) |
| Copilot CLI | unmanaged | `llm-agents.copilot-cli` |
| herdr | — | `llm-agents.herdr` |
| Cursor | `pkgs.cursor-cli` | unchanged |

`github:numtide/llm-agents.nix` covers `x86_64-linux`, `aarch64-linux` and `aarch64-darwin` — an exact match for this flake's `supportedSystems` — is rebuilt daily by CI, and is substituted from `cache.numtide.com` (added to `nixConfig`).

**That input deliberately does not `follows` nixpkgs**, unlike every other input here. It pins its own `nixpkgs-unstable` and the numtide cache is keyed to that pin, so forcing 26.05 would break builds *and* lose every cache hit. Commented as the deliberate exception it is.

`lib/homebrew.nix` is **GUI-only** from here on: Claude Desktop, Codex app, ChatGPT, Antigravity, Antigravity IDE. `homebrewFor` iterates package keys, not capability keys, so a nix-darwin consumer still passing `claudeCode = true` is silently ignored rather than broken.

## herdr

- `homeManagerModules.herdr` — renders `~/.config/herdr/config.toml` and `agent-detection/*.toml` (plain `home.file`; herdr does not rewrite its own config, so no deep-merge activation).
- `nixosModules.herdr` — **a new top-level output**. Everything this flake managed ran on one Mac under launchd; herdr is the first component that also runs as a systemd service on a guest. Both halves take their binaries from the same input, which is what makes one flake genuinely cover both setups.

The service pins herdr's control socket at `/run/herdr` via `RuntimeDirectory` rather than a uid-derived `$XDG_RUNTIME_DIR` path, so a Slack bridge in a separate container can forward a known path over SSH (`ssh -L /run/herdr/herdr.sock:...`). `StartLimitIntervalSec`/`StartLimitBurst` are in `[Unit]`, not `[Service]` — the trap `hermes-gateway.service` already documents.

## Two conflicts, documented rather than discovered

Both are things herdr's own quick-start walks straight into:

1. **`herdr integration install <agent>` writes lifecycle hooks into each agent's own config.** For Claude Code that means editing `~/.claude/settings.json`, which `nix-claude-code` renders read-only from the store — the write fails or is reverted on the next switch. Express those hooks as `programs.claude.hooks` instead.
2. **herdr fetches agent-manifest updates from `herdr.dev` at runtime** and applies them without a restart — undeclared mutable state reaching the internet on an otherwise declarative guest. Local manifests take precedence, so declare the ones that matter.

## Checks

`lib/checks/herdr.nix` follows `cursor.nix`: options regression, defaults regression, and a `deepSeq` over the rendered `config.toml` and manifest tree (narrowed to herdr's own files) per CLAUDE.md's note that reading a few attributes proves nothing about the rest.

The load-bearing one is **agent coverage**: it fails when an enabled CLI is neither detected upstream, nor given a local manifest, nor named in `knownUnsupportedAgents`. A CLI with no manifest shows as a bare shell, and everything downstream — blocked-agent alerts, `herdr agent wait`, dashboard approvals — silently sees nothing.

`qwen-code` and `cecli` are in `knownUnsupportedAgents` today. herdr ships no manifest for either and the rule schema is herdr's, so those entries are **declared rather than guessed at** — authoring one from memory would be fabrication. They should be written against `herdr agent explain <target> --json` on a live pane.

## `flake.nix` size gate

`flake.nix` was 11 993 bytes against a 12 288-byte gate — no room for a new input plus a new output. `checks` moved to `flake/checks.nix` first, the same split already used for `packages`, `lib` and `home-manager-modules`. Now 11 346 bytes.

## Validation — not run here

This session had no `nix` binary, so **nothing below has been executed**. Before merge:

```bash
nix flake lock          # llm-agents is not yet in flake.lock
nix fmt
nix flake check
nix eval --raw .#checks.x86_64-linux \
  --apply 'cs: builtins.concatStringsSep "\n" (map (c: c.outPath) (builtins.attrValues cs))' >/dev/null
nix build .#nixosModules.herdr   # via a consuming nixosConfiguration
```

Then `darwin-rebuild switch --override-input nix-ai <worktree>` and confirm in a live session.

## Known risk: macOS TCC

`modules/codex/default.nix` documented that Codex was a cask specifically for *stable TCC paths*. A Nix store path changes on every version bump, so macOS may re-prompt for permissions after an upgrade. That tradeoff is deliberate — the cask had no Linux path — but it needs watching on the Mac. If it proves disruptive, fix it for darwin specifically rather than reverting the Linux path.

---
_Generated by [Claude Code](https://claude.ai/code/session_016jcoWME1acwLibqCyas2q8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-cutting packaging and new NixOS service changes affect how binaries are sourced on every host; macOS may re-prompt TCC after Codex store-path updates, and herdr’s runtime manifest/network behavior needs deliberate guest policy.
> 
> **Overview**
> **Adds herdr** as a first-class flake export: `homeManagerModules.herdr` renders workstation config and `nixosModules.herdr` runs the server on Linux via systemd (stable socket at `/run/herdr` for SSH forwarding). Default stack enables `programs.herdr`.
> 
> **Unblocks Linux** by moving agent CLI binaries off macOS-only Homebrew casks onto **nixpkgs** (Codex, OpenCode, qwen-code) and the new **`llm-agents.nix`** input (Claude Code, `agy`, Copilot CLI, herdr), with `cache.numtide.com` in `nixConfig`. `lib/homebrew.nix` is **GUI-only**; install hierarchy docs point at `modules/herdr/README.md`.
> 
> Per-agent modules now **install packages** (`package` options, `home.packages`) where they previously assumed external/Homebrew binaries. **`flake/checks.nix`** extracts checks to satisfy the flake size gate; **`lib/checks/herdr.nix`** adds regression tests including **agent-detection coverage** for enabled CLIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef26b85ce361bcac010dbae63ec3ccc295dded2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->