### PR TITLE
perf(claude): disable fourteen never-invoked plugins

### DIFF
--- a/modules/claude/plugins/01-official.nix
+++ b/modules/claude/plugins/01-official.nix
@@ -43,7 +43,9 @@ _:
     # in 04-community.nix (codebase-cleanup, tdd-workflows, code-refactoring all ship
     # a code-reviewer agent that we disable there).
     "code-review@claude-plugins-official" = true;
-    "pr-review-toolkit@claude-plugins-official" = true;
+    # pr-review-toolkit: DISABLED (never invoked). code-review above remains the
+    # keeper code-reviewer; this was the second, unused variant.
+    "pr-review-toolkit@claude-plugins-official" = false;
 
     # Feature Development — provides feature-dev:code-reviewer (high-confidence
     # filter variant, complementary to pr-review-toolkit:code-reviewer).
@@ -52,13 +54,15 @@ _:
     # Security guidance (useful for infra work)
     "security-guidance@claude-plugins-official" = true;
 
-    # Plugin Development (user maintains claude-code-plugins repo)
-    "plugin-dev@claude-plugins-official" = true;
+    # Plugin Development (user maintains claude-code-plugins repo).
+    # DISABLED (never invoked) — re-enable while actually authoring plugins.
+    "plugin-dev@claude-plugins-official" = false;
     "hookify@claude-plugins-official" = true;
 
     # Setup & Management
     "claude-code-setup@claude-plugins-official" = true;
-    "claude-md-management@claude-plugins-official" = true;
+    # claude-md-management: DISABLED (never invoked).
+    "claude-md-management@claude-plugins-official" = false;
 
     # Frontend Design — standalone single-skill plugin. The bundled
     # variant inside anthropic-agent-skills now ships under the kept
@@ -66,14 +70,14 @@ _:
     # standalone is retained because its description text differs from
     # the bundled variant; loaders that match on description benefit
     # from both being present.
-    "frontend-design@claude-plugins-official" = true;
+    "frontend-design@claude-plugins-official" = false;
 
-    # Code transformation skills — refactoring + simplification for docs
-    # work and general code maintenance.
+    # Code transformation skills — refactoring + simplification.
+    # code-simplifier: DISABLED (never invoked).
     # code-modernization: DISABLED (legacy/mainframe uplift; 0 real use per
     # Splunk). Import per-repo via packs.nix `modernization` when needed.
     "code-modernization@claude-plugins-official" = false;
-    "code-simplifier@claude-plugins-official" = true;
+    "code-simplifier@claude-plugins-official" = false;
 
     # Dev kits — Agent SDK + MCP server scaffolding. DISABLED (0 real use per
     # Splunk). Import per-repo via packs.nix `mcp-dev` when building MCP/SDK apps.

--- a/modules/claude/plugins/03-personal.nix
+++ b/modules/claude/plugins/03-personal.nix
@@ -46,5 +46,11 @@ in
   enabledPlugins = jacobpevansPlugins // {
     # Per-plugin overrides go here (e.g., to disable a specific plugin):
     # "<plugin-name>@jacobpevans-cc-plugins" = false;
+
+    # config-management: DISABLED. Both skills it ships (quick-add-permission,
+    # sync-permissions) are self-described as deprecated — permissions moved to
+    # nix-claude-code and permission sync is retired — and it records zero uses.
+    # Its skill descriptions still cost listing budget on every session start.
+    "config-management@jacobpevans-cc-plugins" = false;
   };
 }

--- a/modules/claude/plugins/04-community.nix
+++ b/modules/claude/plugins/04-community.nix
@@ -44,23 +44,24 @@ _:
     # DISABLED (0 real use per Splunk) — import per-repo via packs.nix `api`.
     "backend-development@claude-code-workflows" = false;
 
-    # Agents: django-pro, fastapi-pro, python-pro (all unique).
-    "python-development@claude-code-workflows" = true;
+    # Agents: django-pro, fastapi-pro, python-pro. DISABLED (never invoked).
+    "python-development@claude-code-workflows" = false;
 
-    # Agents: monorepo-architect (unique).
-    "developer-essentials@claude-code-workflows" = true;
+    # Agents: monorepo-architect. DISABLED (never invoked).
+    "developer-essentials@claude-code-workflows" = false;
 
     # Testing (selective)
     # Agents: debugger (unique), test-automator (KEEPER for this role).
     # Best-judgement keeper among 5 community test-automator dups: this one
     # has the most direct name match for general unit-testing work.
-    "unit-testing@claude-code-workflows" = true;
+    # DISABLED (never invoked).
+    "unit-testing@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by Tier 1 pr-review-toolkit:code-reviewer)
+    # DISABLED — code-reviewer (DUP, superseded by Tier 1 code-review:code-reviewer)
     #            tdd-orchestrator (DUP — keeper backend-development:tdd-orchestrator).
     "tdd-workflows@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by Tier 1 pr-review-toolkit:code-reviewer)
+    # DISABLED — code-reviewer (DUP, superseded by Tier 1 code-review:code-reviewer)
     #            legacy-modernizer (rarely used).
     "code-refactoring@claude-code-workflows" = false;
 
@@ -77,20 +78,21 @@ _:
     "performance-testing-review@claude-code-workflows" = false;
 
     # Orchestration & Observability (kept — unique agents)
-    # Agents: context-manager (unique).
-    "agent-orchestration@claude-code-workflows" = true;
+    # Agents: context-manager. DISABLED (never invoked).
+    "agent-orchestration@claude-code-workflows" = false;
 
     # Agents: database-optimizer (unique), network-engineer (unique),
     #         observability-engineer (unique), performance-engineer (KEEPER
     #         for this role across 4 community variants — best domain fit).
-    "observability-monitoring@claude-code-workflows" = true;
+    # DISABLED (never invoked).
+    "observability-monitoring@claude-code-workflows" = false;
 
     # Cloud / DevOps
     # Agents: cloud-architect (unique), deployment-engineer (KEEPER — keeper
     #         for this role; full-stack-orchestration variant disabled above),
     #         devops-troubleshooter, kubernetes-architect, terraform-specialist
-    #         (all unique).
-    "cicd-automation@claude-code-workflows" = true;
+    #         (all unique). DISABLED (never invoked).
+    "cicd-automation@claude-code-workflows" = false;
 
     # ========================================================================
     # superpowers-marketplace — obra/superpowers-marketplace (925★)
@@ -121,10 +123,11 @@ _:
     # Essential issue analysis + worktree creation utilities (unique to this marketplace).
     # analyze-issue: DISABLED (0 real use per Splunk) — packs.nix `devtools`.
     "analyze-issue@cc-marketplace" = false;
-    "create-worktrees@cc-marketplace" = true;
+    # create-worktrees: DISABLED (never invoked).
+    "create-worktrees@cc-marketplace" = false;
 
-    # User actively uses Python — kept for python-expert agent (unique).
-    "python-expert@cc-marketplace" = true;
+    # python-expert: DISABLED (never invoked) despite active Python work.
+    "python-expert@cc-marketplace" = false;
 
     # CI/CD, cloud infra, monitoring, deployment automation (unique).
     # DISABLED (0 real use per Splunk) — import per-repo via packs.nix `devtools`.

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -97,8 +97,10 @@ _:
     # Single skill: karpathy-guidelines. Behavioral rules for LLM coding:
     # Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution.
     # Complements Tier 1 code-review; focuses on pre-coding discipline rather than review.
-    # Also flows to ~/.agents/skills/ automatically via agent-skills auto-discovery.
-    "andrej-karpathy-skills@karpathy-skills" = true;
+    # DISABLED (never invoked). Note this also withdraws the skill from
+    # ~/.agents/skills — agent-skills discovery only contributes a marketplace's
+    # skills while at least one of its plugins is enabled.
+    "andrej-karpathy-skills@karpathy-skills" = false;
 
     # ========================================================================
     # ponytail — DietrichGebert/ponytail (minimalism / YAGNI behavioral mode)


### PR DESCRIPTION
The Claude skill listing is a fixed cost paid on every session start. Fourteen
enabled plugins have never once been used, and each one's skill names and
descriptions are in that listing regardless.

## Evidence

Per-plugin usage was measured two independent ways, and all fourteen are zero
on both:

- `pluginUsage.usageCount == 0` lifetime, across 2,812 recorded startups
- zero Skill dispatches and zero slash invocations in a 50-session transcript
  scan (2026-08-24 → 2026-08-30)

Estimated reclaim is roughly 3.2k tokens per session, derived from each
plugin's `SKILL.md` name and description text. It is an estimate, not a
measurement — see Verification.

## Kept despite measuring zero

`kaizen`, `browser-use` and `managing-dependencies` are asserted in
`lib/checks/agent-skills.nix`. A marketplace contributes skills to
`~/.agents/skills` only while at least one of its plugins is enabled, so
disabling any of the three turns its assertion into a hard eval failure. Their
combined share of the estimate is small; keeping the checks intact is worth
more.

`code-standards` is held back separately — its marketplace cache was
unavailable until today, so its zero may be an artifact of being unloadable
rather than unused.

## Scope

Only the global tier files change. `packs.nix` is untouched, so any repo that
needs one of these can still opt in with `ai-pack`. Comments that justified
keeping an entry were rewritten rather than left contradicting the new value.

## Verification

- `nix fmt` — 211 files emitted, 0 changed
- `nix flake check` — pass
- forced regression suite over `checks.x86_64-linux` — exit 0, which is the
  gate that matters here: three of these plugins break
  `lib/checks/agent-skills.nix` when disabled, and a bare `nix flake check` on
  darwin runs none of `lib/checks/`

The token figure is deliberately not claimed as measured. The running system
predates recent merges, so a before/after taken today would compare against the
old plugin set no matter what lands. It should be measured after this reaches a
deployed generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only plugin toggles with no auth or data-path changes; main behavioral shift is fewer global skills/agents until re-enabled per-repo or in Nix.
> 
> **Overview**
> Turns off **fourteen Claude plugins** that had zero measured usage, so their skill names and descriptions stop being listed on every session start (~3.2k tokens estimated reclaim). Changes are limited to global tier files (`01-official`, `03-personal`, `04-community`, `05-specialty`); **`packs.nix` is unchanged**, so repos can still opt in via `ai-pack`.
> 
> **Official:** `pr-review-toolkit`, `plugin-dev`, `claude-md-management`, `frontend-design`, and `code-simplifier` are set to `false`, with comments noting `code-review` stays the keeper reviewer. **Personal:** `config-management` is disabled because its skills are deprecated and unused. **Community:** eight `claude-code-workflows` / `cc-marketplace` plugins (e.g. `python-development`, `unit-testing`, `cicd-automation`, `create-worktrees`) are disabled. **Specialty:** `andrej-karpathy-skills` is disabled, which also removes that skill from `~/.agents/skills` when no other plugin from that marketplace is enabled.
> 
> Duplicate-resolution comments in `04-community.nix` now point at **Tier 1 `code-review`** instead of `pr-review-toolkit` as the superseding reviewer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21c395dba6df113560bae848cf8cf23cdcb80c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->