### PR TITLE
fix(deps): lock the llm-agents input that flake.nix already declares

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -149,6 +149,39 @@
         "type": "github"
       }
     },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "cc-dev-tools": {
       "flake": false,
       "locked": {
@@ -316,7 +349,7 @@
           "nix-claude-code",
           "nixpkgs"
         ],
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1785341240,
@@ -366,6 +399,27 @@
       }
     },
     "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787559586,
+        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
           "nix-claude-code",
@@ -550,6 +604,28 @@
         "type": "github"
       }
     },
+    "llm-agents": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1788126251,
+        "narHash": "sha256-XWa7++jRhXl52KVtR4UkZWcjy8oyrckCDvD+3DhKftI=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "461871c22df47477c78ae7ea6bf2f5bcf004beb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "lunar-claude": {
       "flake": false,
       "locked": {
@@ -629,7 +705,7 @@
         "fabric-src": [
           "fabric-src"
         ],
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "home-manager": [
           "home-manager"
         ],
@@ -687,16 +763,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786920013,
-        "narHash": "sha256-tlbRqzZ3suDUO3vyR0QFBk0TrxJiRP50t7VWfHhtVrw=",
+        "lastModified": 1787424095,
+        "narHash": "sha256-dWLO5AHhKaw6rdWCtTes8hnntT1r0/J5yhQGm0f0ZgU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33da5f36e599b50aa7dbbfacb718254423b18354",
+        "rev": "174eb786fb68e3a13e4e535a3deea479a0c07a6a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-26.05-darwin",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -713,6 +789,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1786920013,
+        "narHash": "sha256-tlbRqzZ3suDUO3vyR0QFBk0TrxJiRP50t7VWfHhtVrw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "33da5f36e599b50aa7dbbfacb718254423b18354",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -781,11 +873,12 @@
         "karpathy-skills": "karpathy-skills",
         "langfuse-skills": "langfuse-skills",
         "last30days-skill": "last30days-skill",
+        "llm-agents": "llm-agents",
         "managing-dependencies": "managing-dependencies",
         "nix-agy": "nix-agy",
         "nix-claude-code": "nix-claude-code",
         "nix-codex": "nix-codex",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "ponytail": "ponytail",
         "vct-cribl-cli": "vct-cribl-cli",
@@ -808,7 +901,43 @@
         "type": "github"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nix-claude-code",

--- a/lib/checks-fixtures.nix
+++ b/lib/checks-fixtures.nix
@@ -1,0 +1,238 @@
+# Test fixtures for the regression suite in ./checks.nix.
+#
+# Split out of ./checks.nix to stay under the .file-size.yml ceiling. The seam
+# is by responsibility, not by size: this file BUILDS the evaluated
+# home-manager configurations the checks assert against, while ./checks.nix
+# decides which check groups run and wires each one to the fixtures it needs.
+#
+# `rec` because the fixtures are layered — mkHmConfig sits on mkHmConfigWith,
+# and most hmConfig* sit on mkHmConfig plus judgeModelStub.
+{
+  pkgs,
+  home-manager,
+  aiModule,
+}:
+rec {
+  # Placeholder physical model id for regression tests. The real value is
+  # sourced by consumers (nix-darwin) from AI_MODEL_LOCAL_LLM; tests only need
+  # a valid non-empty mlx-community/* string to populate services.aiStack and
+  # exercise lib/ai-stack-models.nix (a function since the role registry was
+  # parameterized).
+  testLocalModelId = "mlx-community/test-model";
+
+  # Shared test module configuration — used by claude, mlx, and fabric regression
+  # checks. `userConfig` reaches modules through `_module.args`, which admits
+  # exactly one non-default definition, so the maintainer-profile knobs cannot be
+  # overridden from an extra module the way an ordinary option can. Taking the
+  # extra attrs here instead lets a check evaluate the stack under a different
+  # profile (e.g. telemetry on) without a definition conflict.
+  mkBaseTestModule = userConfigExtra: {
+    _module.args.userConfig = {
+      user.fullName = "JacobPEvans";
+    }
+    // userConfigExtra;
+    services.aiStack.defaultLocalModelId = testLocalModelId;
+    home = {
+      username = "test-user";
+      homeDirectory = "/home/test-user";
+      stateVersion = "25.11";
+    };
+  };
+
+  mkHmConfigWith =
+    userConfigExtra: extraModules:
+    home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        aiModule
+        (mkBaseTestModule userConfigExtra)
+      ]
+      ++ extraModules;
+    };
+
+  mkHmConfig = mkHmConfigWith { };
+
+  hmConfig = mkHmConfig [ ];
+
+  hmConfigAgentSkillsShared = mkHmConfig [
+    {
+      programs.agentSkills.root = "agents";
+    }
+  ];
+
+  hmConfigVctCli = mkHmConfig [
+    {
+      programs.vctCli.enable = true;
+    }
+  ];
+
+  # Second evaluation with fabric REST API LaunchAgent enabled — used by the
+  # fabric-launchd positive check (default eval has enableServer = false).
+  hmConfigFabricServer = mkHmConfig [ { programs.fabric.enableServer = true; } ];
+
+  # Third evaluation exercising programs.mlx.catalog (lib/checks/mlx.nix
+  # mlx-catalog): a server-like selection plus one direct host override that
+  # must beat the catalog's mkDefault.
+  hmConfigCatalog = mkHmConfig [
+    {
+      programs.mlx = {
+        catalog = {
+          qwen35-9b-optiq = {
+            class = "swap";
+          };
+          qwen38-27b = {
+            class = "resident";
+            roles = [ "goal-judge" ];
+          };
+          qwen36-optiq.class = "resident";
+          # Stock Qwen3.6 sibling, swap-class: enabled so the compiled
+          # modelContextWindows carries its declared 65536 window for
+          # mlx-catalog.nix to assert. Resident would push the fixture past
+          # residentWeightBudgetGb for no added coverage.
+          qwen36-35b.class = "swap";
+          qwen3-coder-30b.class = "resident";
+          gpt-oss-120b.class = "swap";
+          qwen3-next-80b = {
+            class = "swap";
+            tweaks.ttl = 600;
+          };
+          # Carries an intrinsic proxy concurrencyLimit=1 (metal::malloc under
+          # concurrency) — exercises modelConcurrencyLimits compilation.
+          qwen3-next-80b-instruct.class = "swap";
+          # Vision-language entry: exercises the per-model backend override
+          # (catalog `backend` -> modelBackends -> mlx_vlm.server) while the
+          # host backend stays mlx-lm for every other model.
+          unlimited-ocr = {
+            class = "swap";
+            tweaks.ttl = 600;
+          };
+        };
+        # Direct host setting on a catalog-managed key must win over the catalog.
+        modelFlagOverrides."mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit".cacheMemoryMb = 8192;
+      };
+    }
+  ];
+
+  # Evaluation exercising programs.mlx.defaultModelKey (lib/checks/
+  # mlx-default-model.nix): the declared default is one catalog entry, the
+  # runtime override re-points it at another — the two-Mac shape where the
+  # serving config is shared and only this key differs.
+  hmConfigDefaultModel = mkHmConfig [
+    {
+      programs.mlx = {
+        defaultModelKey = "qwen38-27b";
+        catalog = {
+          qwen38-27b.class = "resident";
+          qwen36-35b = {
+            class = "resident";
+            roles = [ "goal-judge" ];
+          };
+        };
+      };
+    }
+  ];
+
+  # Two evaluations for the role-registry check (lib/checks/mlx-catalog-roles.nix).
+  # The first binds the `small` role to a swap-class entry; the second assigns
+  # one role name to two enabled entries, so the uniqueness assertion must come
+  # back false. Kept out of hmConfigCatalog so the duplicate case cannot leak
+  # into the checks that read that fixture.
+  #
+  # Both set programs.mlx.judge.model even though the judge stays disabled: the
+  # check locates assertions by matching their `message`, and the judge
+  # assertion's message interpolates that option, which has no default.
+  judgeModelStub.programs.mlx.judge.model = "mlx-community/test-judge-model";
+  hmConfigSmallRole = mkHmConfig [
+    judgeModelStub
+    {
+      programs.mlx.catalog = {
+        qwen38-27b.class = "resident";
+        qwen35-9b-optiq = {
+          class = "swap";
+          roles = [ "small" ];
+        };
+      };
+    }
+  ];
+  hmConfigDupRole = mkHmConfig [
+    judgeModelStub
+    {
+      programs.mlx.catalog = {
+        qwen38-27b = {
+          class = "resident";
+          roles = [ "small" ];
+        };
+        qwen35-9b-optiq = {
+          class = "swap";
+          roles = [ "small" ];
+        };
+      };
+    }
+  ];
+
+  # Fourth evaluation exercising programs.mlx.clusterMode as the coordinator
+  # (lib/checks/mlx-cluster.nix): rank env contract, watcher wiring, prefetch.
+  # judgeModelStub rides along because lib/checks/mlx-cluster-sharding.nix reads
+  # this config's `assertions` list, and the judge assertion's message
+  # interpolates an option carrying no default — the same reason the role
+  # fixtures above carry it.
+  hmConfigCluster = mkHmConfig [
+    judgeModelStub
+    {
+      programs.mlx.clusterMode = {
+        enable = true;
+        role = "coordinator";
+        modelCatalogKey = "glm47-reap50";
+        # glm4_moe is pipeline-only; the clusterMode assertions now reject
+        # tensor-parallel on it, so this fixture must name the real mode.
+        shardingMode = "pipeline";
+        wiredLimitMb = 90000;
+        standaloneWiredLimitMb = 118000;
+      };
+    }
+  ];
+  # Fifth evaluation exercising the token-meter HTTPS gate (lib/checks/
+  # token-meter.nix): the module is off by default, so the agent only exists here.
+  hmConfigTokenMeter = mkHmConfig [
+    {
+      programs.token-meter = {
+        enable = true;
+        bindAddress = "127.0.0.1";
+      };
+    }
+  ];
+  # Sixth evaluation exercising the session-sync agent (lib/checks/
+  # session-sync.nix): also off by default, so the agent only exists here.
+  hmConfigSessionSync = mkHmConfig [
+    {
+      programs.sessionSync = {
+        enable = true;
+        remote = "peer.example";
+      };
+    }
+  ];
+  # Seventh evaluation exercising the session-archive agent (lib/checks/
+  # session-archive.nix): also off by default, so the agent only exists here.
+  hmConfigSessionArchive = mkHmConfig [
+    {
+      programs.sessionArchive = {
+        enable = true;
+        endpoint = "https://example.invalid";
+      };
+    }
+  ];
+  # Evaluation with the local LiteLLM proxy enabled. The module is off by
+  # default, so without this fixture every `lib.optionalAttrs
+  # litellmLocal.enable` branch across the client modules would go unevaluated
+  # and a typo in one of them would pass CI.
+  hmConfigLitellmLocal = mkHmConfig [
+    {
+      programs.litellmLocal.enable = true;
+      services.aiStack = {
+        llmEndpoint = "router";
+        llmRouterEndpoint = "https://llm.example.invalid/v1";
+        llmEndpointTokenFile = "/run/secrets/LLM_ROUTER_BEARER";
+      };
+    }
+  ];
+}

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -22,228 +22,24 @@
   renderAutonomous,
 }:
 let
-  # Placeholder physical model id for regression tests. The real value is
-  # sourced by consumers (nix-darwin) from AI_MODEL_LOCAL_LLM; tests only need
-  # a valid non-empty mlx-community/* string to populate services.aiStack and
-  # exercise lib/ai-stack-models.nix (a function since the role registry was
-  # parameterized).
-  testLocalModelId = "mlx-community/test-model";
-
-  # Shared test module configuration — used by claude, mlx, and fabric regression
-  # checks. `userConfig` reaches modules through `_module.args`, which admits
-  # exactly one non-default definition, so the maintainer-profile knobs cannot be
-  # overridden from an extra module the way an ordinary option can. Taking the
-  # extra attrs here instead lets a check evaluate the stack under a different
-  # profile (e.g. telemetry on) without a definition conflict.
-  mkBaseTestModule = userConfigExtra: {
-    _module.args.userConfig = {
-      user.fullName = "JacobPEvans";
-    }
-    // userConfigExtra;
-    services.aiStack.defaultLocalModelId = testLocalModelId;
-    home = {
-      username = "test-user";
-      homeDirectory = "/home/test-user";
-      stateVersion = "25.11";
-    };
-  };
-
-  mkHmConfigWith =
-    userConfigExtra: extraModules:
-    home-manager.lib.homeManagerConfiguration {
-      inherit pkgs;
-      modules = [
-        aiModule
-        (mkBaseTestModule userConfigExtra)
-      ]
-      ++ extraModules;
-    };
-
-  mkHmConfig = mkHmConfigWith { };
-
-  hmConfig = mkHmConfig [ ];
-
-  hmConfigAgentSkillsShared = mkHmConfig [
-    {
-      programs.agentSkills.root = "agents";
-    }
-  ];
-
-  hmConfigVctCli = mkHmConfig [
-    {
-      programs.vctCli.enable = true;
-    }
-  ];
-
-  # Second evaluation with fabric REST API LaunchAgent enabled — used by the
-  # fabric-launchd positive check (default eval has enableServer = false).
-  hmConfigFabricServer = mkHmConfig [ { programs.fabric.enableServer = true; } ];
-
-  # Third evaluation exercising programs.mlx.catalog (lib/checks/mlx.nix
-  # mlx-catalog): a server-like selection plus one direct host override that
-  # must beat the catalog's mkDefault.
-  hmConfigCatalog = mkHmConfig [
-    {
-      programs.mlx = {
-        catalog = {
-          qwen35-9b-optiq = {
-            class = "swap";
-          };
-          qwen38-27b = {
-            class = "resident";
-            roles = [ "goal-judge" ];
-          };
-          qwen36-optiq.class = "resident";
-          # Stock Qwen3.6 sibling, swap-class: enabled so the compiled
-          # modelContextWindows carries its declared 65536 window for
-          # mlx-catalog.nix to assert. Resident would push the fixture past
-          # residentWeightBudgetGb for no added coverage.
-          qwen36-35b.class = "swap";
-          qwen3-coder-30b.class = "resident";
-          gpt-oss-120b.class = "swap";
-          qwen3-next-80b = {
-            class = "swap";
-            tweaks.ttl = 600;
-          };
-          # Carries an intrinsic proxy concurrencyLimit=1 (metal::malloc under
-          # concurrency) — exercises modelConcurrencyLimits compilation.
-          qwen3-next-80b-instruct.class = "swap";
-          # Vision-language entry: exercises the per-model backend override
-          # (catalog `backend` -> modelBackends -> mlx_vlm.server) while the
-          # host backend stays mlx-lm for every other model.
-          unlimited-ocr = {
-            class = "swap";
-            tweaks.ttl = 600;
-          };
-        };
-        # Direct host setting on a catalog-managed key must win over the catalog.
-        modelFlagOverrides."mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit".cacheMemoryMb = 8192;
-      };
-    }
-  ];
-
-  # Evaluation exercising programs.mlx.defaultModelKey (lib/checks/
-  # mlx-default-model.nix): the declared default is one catalog entry, the
-  # runtime override re-points it at another — the two-Mac shape where the
-  # serving config is shared and only this key differs.
-  hmConfigDefaultModel = mkHmConfig [
-    {
-      programs.mlx = {
-        defaultModelKey = "qwen38-27b";
-        catalog = {
-          qwen38-27b.class = "resident";
-          qwen36-35b = {
-            class = "resident";
-            roles = [ "goal-judge" ];
-          };
-        };
-      };
-    }
-  ];
-
-  # Two evaluations for the role-registry check (lib/checks/mlx-catalog-roles.nix).
-  # The first binds the `small` role to a swap-class entry; the second assigns
-  # one role name to two enabled entries, so the uniqueness assertion must come
-  # back false. Kept out of hmConfigCatalog so the duplicate case cannot leak
-  # into the checks that read that fixture.
-  #
-  # Both set programs.mlx.judge.model even though the judge stays disabled: the
-  # check locates assertions by matching their `message`, and the judge
-  # assertion's message interpolates that option, which has no default.
-  judgeModelStub.programs.mlx.judge.model = "mlx-community/test-judge-model";
-  hmConfigSmallRole = mkHmConfig [
-    judgeModelStub
-    {
-      programs.mlx.catalog = {
-        qwen38-27b.class = "resident";
-        qwen35-9b-optiq = {
-          class = "swap";
-          roles = [ "small" ];
-        };
-      };
-    }
-  ];
-  hmConfigDupRole = mkHmConfig [
-    judgeModelStub
-    {
-      programs.mlx.catalog = {
-        qwen38-27b = {
-          class = "resident";
-          roles = [ "small" ];
-        };
-        qwen35-9b-optiq = {
-          class = "swap";
-          roles = [ "small" ];
-        };
-      };
-    }
-  ];
-
-  # Fourth evaluation exercising programs.mlx.clusterMode as the coordinator
-  # (lib/checks/mlx-cluster.nix): rank env contract, watcher wiring, prefetch.
-  # judgeModelStub rides along because lib/checks/mlx-cluster-sharding.nix reads
-  # this config's `assertions` list, and the judge assertion's message
-  # interpolates an option carrying no default — the same reason the role
-  # fixtures above carry it.
-  hmConfigCluster = mkHmConfig [
-    judgeModelStub
-    {
-      programs.mlx.clusterMode = {
-        enable = true;
-        role = "coordinator";
-        modelCatalogKey = "glm47-reap50";
-        # glm4_moe is pipeline-only; the clusterMode assertions now reject
-        # tensor-parallel on it, so this fixture must name the real mode.
-        shardingMode = "pipeline";
-        wiredLimitMb = 90000;
-        standaloneWiredLimitMb = 118000;
-      };
-    }
-  ];
-  # Fifth evaluation exercising the token-meter HTTPS gate (lib/checks/
-  # token-meter.nix): the module is off by default, so the agent only exists here.
-  hmConfigTokenMeter = mkHmConfig [
-    {
-      programs.token-meter = {
-        enable = true;
-        bindAddress = "127.0.0.1";
-      };
-    }
-  ];
-  # Sixth evaluation exercising the session-sync agent (lib/checks/
-  # session-sync.nix): also off by default, so the agent only exists here.
-  hmConfigSessionSync = mkHmConfig [
-    {
-      programs.sessionSync = {
-        enable = true;
-        remote = "peer.example";
-      };
-    }
-  ];
-  # Seventh evaluation exercising the session-archive agent (lib/checks/
-  # session-archive.nix): also off by default, so the agent only exists here.
-  hmConfigSessionArchive = mkHmConfig [
-    {
-      programs.sessionArchive = {
-        enable = true;
-        endpoint = "https://example.invalid";
-      };
-    }
-  ];
-  # Evaluation with the local LiteLLM proxy enabled. The module is off by
-  # default, so without this fixture every `lib.optionalAttrs
-  # litellmLocal.enable` branch across the client modules would go unevaluated
-  # and a typo in one of them would pass CI.
-  hmConfigLitellmLocal = mkHmConfig [
-    {
-      programs.litellmLocal.enable = true;
-      services.aiStack = {
-        llmEndpoint = "router";
-        llmRouterEndpoint = "https://llm.example.invalid/v1";
-        llmEndpointTokenFile = "/run/secrets/LLM_ROUTER_BEARER";
-      };
-    }
-  ];
+  inherit (import ./checks-fixtures.nix { inherit pkgs home-manager aiModule; })
+    testLocalModelId
+    mkHmConfigWith
+    mkHmConfig
+    hmConfig
+    hmConfigAgentSkillsShared
+    hmConfigVctCli
+    hmConfigFabricServer
+    hmConfigCatalog
+    hmConfigDefaultModel
+    hmConfigSmallRole
+    hmConfigDupRole
+    hmConfigCluster
+    hmConfigTokenMeter
+    hmConfigSessionSync
+    hmConfigSessionArchive
+    hmConfigLitellmLocal
+    ;
 in
 (import ./checks/lint.nix { inherit pkgs src; })
 // (import ./checks/token-meter.nix {


### PR DESCRIPTION
## Summary

`flake.nix` declares `llm-agents.url` (line 31) but `flake.lock` carried no entry for it. Every evaluation of this flake therefore rewrote `flake.lock` in place and resolved the input at evaluation time rather than from a pinned revision.

## Changes

`nix flake lock` — adds `llm-agents` (`461871c2`) and its transitive inputs (`bun2nix`, `flake-parts`, `treefmt-nix`, `systems`). No other input is moved.

## Test Plan

- `nix eval --raw .#checks.x86_64-linux --apply 'cs: builtins.concatStringsSep "\n" (map (c: c.outPath) (builtins.attrValues cs))'` — exit 0, 130 checks evaluated.
- A second evaluation leaves `flake.lock` unmodified, which is the behaviour this restores.

Note that `nix flake check` alone does not surface this on aarch64-darwin; see `CLAUDE.md` for the evaluation form used above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly lockfile pinning and a no-behavior refactor of test fixtures; the main caveat is ensuring CI still evaluates the same checks after the input graph split.
> 
> **Overview**
> Pins the **`llm-agents`** flake input (and transitive **`bun2nix`**, **`systems`**, and related **`flake-parts`** / **`treefmt-nix`** nodes) in **`flake.lock`** so evaluations stop rewriting the lockfile and resolve **`github:numtide/llm-agents.nix`** at a fixed revision instead of at eval time. The lockfile also follows inputs for that subtree (e.g. **`llm-agents`**’s **`nixpkgs`** on **`nixpkgs-unstable`**) while the root flake keeps its existing **`nixpkgs_2`** pin.
> 
> Separately, **home-manager regression fixtures** move from **`lib/checks.nix`** into new **`lib/checks-fixtures.nix`**; **`checks.nix`** only imports and wires them into the check modules, keeping file size under the repo’s **`.file-size.yml`** limit without changing check behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1455ee12f6cd1ad6251729a18caf385662bf7bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->