### PR TITLE
fix(antigravity-cli): stop defaulting the model to a router role

### DIFF
--- a/modules/antigravity-cli/default.nix
+++ b/modules/antigravity-cli/default.nix
@@ -67,12 +67,23 @@ in
       # alike; nixpkgs does not carry it at all.
       package = lib.mkDefault agyPackage;
 
-      # Select the role rather than a Gemini registry id, so this CLI resolves
-      # the same way as every other client. mkDefault, because whether this CLI
-      # accepts a model name outside its own registry is not verified here — a
-      # consumer that finds it rejected sets defaultModel back to an alias
-      # without editing this module.
-      defaultModel = lib.mkIf config.programs.litellmLocal.enable (lib.mkDefault "subagent");
+      # Deliberately left unset. Selecting the router role here (`"subagent"`)
+      # was tried and is now known to be rejected: the CLI validates `model`
+      # against its own registry when it LOADS the settings file, and on a
+      # miss discards the whole file — not just the model key — falling back
+      # to built-in defaults. Sandbox, folder trust, permissions, policyPaths
+      # and every configured MCP server silently stop applying:
+      #
+      #   failed to load cli settings, using defaults: invalid settings:
+      #   model: invalid value { "name": "subagent" }
+      #
+      # This is schema validation, not routing, so no proxy alias or catch-all
+      # route can satisfy it — the file is rejected before any request is made.
+      # With the key absent the CLI picks its own default and still routes
+      # through the proxy via GOOGLE_GEMINI_BASE_URL above, which is the
+      # behaviour this module wants anyway. A consumer that needs a specific
+      # model sets a value the CLI's own registry accepts (see the in-CLI
+      # /model dialog), never a router role name.
     };
   };
 }


### PR DESCRIPTION
## Problem

When the local proxy is enabled, this module defaulted `defaultModel` to the
router role `"subagent"`. The CLI validates `model` against its own registry
when it **loads** the settings file, and on a miss discards the entire file —
not just the model key:

```
failed to load cli settings, using defaults: invalid settings:
model: invalid value { "name": "subagent" }
```

So sandbox, folder trust, permissions, `policyPaths` and every configured MCP
server silently stop applying. The CLI keeps working, which is why this went
unnoticed: the only symptom is a log line, and everything the settings file
configures just quietly does not take effect.

Observed in five separate CLI sessions between 2026-08-25 and 2026-08-29 on a
workstation running this default.

The module's existing comment anticipated the possibility ("whether this CLI
accepts a model name outside its own registry is not verified here"), so this
change is confirming the open question rather than reversing a verified
decision.

## Change

Leave `defaultModel` unset and record why.

Validation happens at settings-load time, before any request is issued, so this
was never a routing problem — no proxy alias, catch-all route, or model-group
change could have satisfied it. With the key absent the CLI selects its own
default and still routes through the proxy via `GOOGLE_GEMINI_BASE_URL`, which
is the behaviour the module wants regardless.

A consumer that needs a specific model can still set one; the comment notes it
must be a value the CLI's own registry accepts, not a router role name.

## Verification

- With `model` removed from the live settings file, the CLI loads it cleanly —
  no `invalid settings` line in any subsequent log, and `antigravity mcp list`
  enumerates all configured MCP servers (it previously fell back to defaults).
- `nix flake check` passes on aarch64-darwin.
- No check asserts the previous value, so nothing needed updating alongside it.

## Not included

I could not verify from outside the binary whether the tier aliases the option's
description mentions (`"pro"`, `"flash"`, `"flash-lite"`) are accepted by the
settings validator — the non-interactive subcommands do not exercise the
validation path, so a probe cannot distinguish accepted from rejected. Since the
description may well be correct, I left `options.nix` untouched rather than
"fixing" documentation on an unproven claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nix module default-only change with no auth or data-path impact; restores intended settings application when the proxy is on.
> 
> **Overview**
> **Stops auto-setting `defaultModel` to `"subagent"` when the local LiteLLM proxy is enabled**, so generated `settings.json` no longer includes a `model` name the CLI rejects at load time.
> 
> Previously that value caused the CLI to throw away the entire settings file and fall back to built-ins, which silently dropped sandbox, permissions, `policyPaths`, and MCP configuration. The module now leaves `defaultModel` unset and documents that validation is registry-based (not proxy-routable) and that traffic still goes through the proxy via `GOOGLE_GEMINI_BASE_URL` when no model is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758038169aa7c6c0e4bb90b5e9a5c78f0dd326c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->