### PR TITLE
feat(herdr): correct qwen-code coverage and document herdr operations

### DIFF
--- a/docs/ai-tool-decision-tree.md
+++ b/docs/ai-tool-decision-tree.md
@@ -12,6 +12,7 @@ When to use which tool for AI-assisted tasks in the nix-ai ecosystem.
 | Want to explicitly call a pattern from Claude Code | Fabric MCP server | Pattern appears as a callable MCP tool |
 | Single local model call | llama-swap (`127.0.0.1:11434`) | OpenAI-compatible, direct to local MLX |
 | Second opinion / adversarial review from another model | `/delegate-to-ai` (Codex / native subagent) | No local gateway needed |
+| Long-running agent session that must survive a client disconnect, or be driven by another agent | herdr | The server owns the PTY; panes carry working/blocked/idle state over a socket API |
 | Writing Python/Go code that calls an LLM | Anthropic SDK / OpenAI SDK | Direct API, no middleware |
 
 ## When to Use Fabric CLI
@@ -92,6 +93,30 @@ For a non-Claude *cloud* model or a second opinion from another model, use
 `/delegate-to-ai` (Codex or a native subagent) — there is no local gateway to
 route through.
 
+## When to Use herdr
+
+Best for: **running agent CLIs in panes that something else can observe or drive**
+
+```bash
+# start an agent in a pane and confirm it was detected
+herdr agent start <name> --kind claude --pane <id>
+
+# block until it finishes, then act on the result
+herdr agent wait <name> --until idle --timeout 300000
+```
+
+Use when:
+
+- An agent must be driven programmatically, not typed at
+- Something downstream needs to know whether an agent is working, blocked, or idle
+- You want the pane layout to survive the client going away
+
+Not for:
+
+- One-shot pipelines — use the Fabric CLI, which needs no PTY
+- Making an agent's config changes stick; `herdr integration install` and the
+  `herdr config` writers fight Nix-managed files
+
 ## Anti-Patterns
 
 | Don't Do This | Do This Instead |
@@ -99,3 +124,4 @@ route through.
 | Use MCP server for a quick shell pipeline | `echo "text" \| fabric --pattern X` |
 | Manually invoke fabric skills from Claude Code | Let auto-discovery match by description |
 | Use fabric for multi-step automated workflows | Use the orchestrator (when it has consumers) |
+| Run `herdr integration install <agent>` | Declare the hooks in Nix (`programs.claude.hooks`); the config file is a read-only store symlink |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -23,6 +23,16 @@ across tools vs product-specific.
 **Read when**: Understanding the overall topology, debugging why a tool cannot reach another,
 adding a new AI product.
 
+### [herdr.md](herdr.md)
+
+The terminal multiplexer that owns agent panes: the workstation and Linux-guest
+halves, what pins the control socket, how a pane becomes a classified
+working/blocked/idle agent, and why manifest precedence means detection rules
+are mostly fetched at runtime rather than pinned by this flake.
+
+**Read when**: Enabling herdr on a new host, debugging a pane that shows as a bare
+shell, or deciding whether an agent CLI needs a local detection manifest.
+
 ### [config-lifecycle.md](config-lifecycle.md)
 
 The 3-phase config generation pipeline unique to Nix home-manager: build-time pure evaluation,
@@ -92,5 +102,6 @@ If you find yourself wondering "why does it work this way?", the ADR index is th
 
 | Runbook | Purpose |
 |---------|---------|
+| [herdr.md](../runbooks/herdr.md) | Enabling herdr, verifying agent detection on a live pane, authoring a manifest, and diagnosing a pane stuck as a bare shell |
 | [galileo-onboarding.md](../runbooks/galileo-onboarding.md) | Galileo AI observability setup, daily use, denylist management, and kill switches |
 | [rdma-protection-domains.md](../runbooks/rdma-protection-domains.md) | Why a leaked RDMA protection domain needs a reboot, the boot-scoped ledger that counts them, and the guards that halt before exhaustion |

--- a/docs/architecture/herdr.md
+++ b/docs/architecture/herdr.md
@@ -1,0 +1,97 @@
+# herdr
+
+How the terminal multiplexer that owns agent panes is wired: where the daemon
+runs, what owns its socket, and how a pane becomes a classified agent.
+
+## Documents in This Directory
+
+_This document is part of [`docs/architecture/`](README.md)._
+
+## Two halves, one flake
+
+herdr is a background server that owns the terminals coding agents run in.
+Panes carry a working/blocked/idle state, and agents drive the server through a
+CLI and a Unix-socket JSON API.
+
+```mermaid
+graph TD
+    subgraph Workstation["Workstation — home-manager"]
+        HMOPT["programs.herdr\nmodules/herdr/options.nix"]
+        CFG["~/.config/herdr/config.toml\n(read-only store symlink)"]
+        WSOCK["$HOME/.config/herdr/herdr.sock"]
+        WSRV["herdr server\n(started on demand)"]
+    end
+
+    subgraph Guest["Linux guest — NixOS"]
+        NIXOPT["services.herdr\nmodules/herdr/nixos.nix"]
+        UNIT["systemd unit\nUser=herdr"]
+        GSOCK["/run/herdr/herdr.sock\nRuntimeDirectory=herdr"]
+    end
+
+    AGENTS["llm-agents.nix + nixpkgs\nthe same agent CLI builds"]
+
+    HMOPT --> CFG --> WSRV --> WSOCK
+    NIXOPT --> UNIT --> GSOCK
+    AGENTS --> WSRV
+    AGENTS --> UNIT
+    WSOCK -->|"herdr --remote <name>"| GSOCK
+```
+
+Both halves take their binary from the same `llm-agents` input, so a pane on
+the guest runs the same build as a pane on the workstation.
+
+The guest pins its socket at a fixed path rather than a uid-derived
+`$XDG_RUNTIME_DIR` one, because a bridge forwards that socket over SSH and
+needs a predictable path. Changing it fails silently — a quiet fleet, not an
+error.
+
+## How a pane becomes a classified agent
+
+Detection is rule-based, not process-name-based. herdr matches manifest rules
+against what the pane is actually rendering.
+
+```mermaid
+graph LR
+    PANE["pane at a shell prompt"] -->|"agent start --kind"| PROC["agent CLI in a PTY"]
+    PROC --> REGIONS["screen regions\nosc_title · prompt_box · bottom lines"]
+    MANIFEST["manifest rules\nlocal > remote > bundled"] --> MATCH
+    REGIONS --> MATCH{"highest-priority\nmatching rule"}
+    MATCH --> STATE["working / blocked / idle"]
+    STATE --> CONSUMERS["agent wait · blocked-agent alerts · dashboard approvals"]
+```
+
+`herdr agent explain <target> --json` reports every rule it evaluated, which
+one won, and which manifest supplied it. That command is the only correct way
+to author or debug detection — the rule schema is herdr's, not this flake's.
+
+### Manifest precedence, and why it matters
+
+A local manifest beats a fetched one, which beats the bundled copy. That
+ordering is the whole reason `programs.herdr.agentManifests` exists: without a
+local override, the rules deciding agent state are remote state refreshed at
+runtime.
+
+Measured on a workstation: **19 of 20 active manifests came from the network**,
+with one falling back to the bundled copy because the fetched version was older
+than the one herdr shipped. `herdr server agent-manifests` reports the live
+answer, and `explain` names the winner in `manifest_source`.
+
+## Coverage is enforced at evaluation time
+
+`lib/checks/herdr.nix` fails when a CLI this flake enables is neither detected
+upstream, nor given a local manifest, nor explicitly declared unsupported. The
+gap is therefore always declared rather than silent.
+
+Two traps in that check:
+
+- It keys off **this flake's option names**, not herdr's manifest names. herdr
+  calls Antigravity CLI `agy` and Qwen Code `qwen`.
+- Its list of managed agents is hand-maintained. A newly enabled CLI that is
+  not added there is skipped silently rather than caught.
+
+## Related
+
+- [`modules/herdr/README.md`](../../modules/herdr/README.md) — where the agent
+  CLI binaries come from, and the two conflicts with declarative config.
+- [`docs/runbooks/herdr.md`](../runbooks/herdr.md) — enabling it, verifying
+  detection, and diagnosing a pane stuck as a bare shell.

--- a/docs/runbooks/herdr.md
+++ b/docs/runbooks/herdr.md
@@ -1,0 +1,103 @@
+# herdr operations: enable, verify detection, author a manifest
+
+> Detection state is mostly fetched from the network, not pinned by this flake.
+> Read [`docs/architecture/herdr.md`](../architecture/herdr.md) before changing
+> anything about manifests — it explains the precedence that decides which
+> rules are actually live.
+
+herdr is enabled by default in `modules/default.nix`, so a consumer normally
+needs no config at all. A workstation that has no `herdr` binary is running a
+stale pin of this flake, not a disabled module. Check the pin before adding an
+enable line that will do nothing.
+
+## Verify it is actually running
+
+1. `herdr --version` — confirms the binary is on PATH from the current
+   generation. If it is missing, bump the consumer's pin; do not add config.
+2. `herdr status` — reports client and server separately. The workstation half
+   starts no daemon of its own, so `server: not running` is normal until a
+   client or `herdr server` starts one. On a guest, the systemd unit owns it.
+3. `herdr session list` — a running session and its socket path.
+
+## Verify detection on a live pane
+
+Do this on a real pane. Detection reads what the terminal renders, so it cannot
+be checked from the schema or from memory.
+
+1. Create a workspace, which also creates its root pane:
+   `herdr workspace create --cwd <repo> --label <name> --focus`
+2. Start the agent in that pane, which must be at an interactive shell prompt:
+   `herdr agent start <name> --kind <kind> --pane <id>`
+   A successful start already reports `agent`, `agent_status` and
+   `interactive_ready`.
+3. `herdr agent explain <name> --json` — the authoritative answer. Read
+   `state`, `matched_rule`, and `manifest_source`. `manifest_source` tells you
+   whether a local override or a fetched manifest decided the outcome.
+
+## Author a manifest for an undetected agent
+
+Only for a CLI herdr does not already know. Check first: a manifest may already
+exist under a different name — herdr's names are its own, not this flake's
+option names.
+
+1. `herdr server agent-manifests` — lists every active manifest and where it
+   came from. If the agent appears here, no authoring is needed.
+2. Start the agent in a pane and capture real output with
+   `herdr agent explain <name> --json`. Author rules against that, never from
+   the rule schema alone.
+3. Declare it in `programs.herdr.agentManifests.<name>`, which renders to
+   `<configDir>/agent-detection/<name>.toml` and takes precedence over both the
+   fetched and bundled copies.
+4. `herdr server reload-agent-manifests`, then re-run `explain` and confirm
+   `local_override_shadowing_remote` is now true.
+5. Remove the name from `knownUnsupportedAgents` only after step 4 passes.
+
+## Diagnose a pane stuck as a bare shell
+
+A pane with no detected agent still works — it is just reported as a plain
+shell, so nothing downstream fires on its state. Work down this list:
+
+1. `herdr agent list` — if the agent is absent, the pane never had one started,
+   or the process exited.
+2. `herdr agent explain <name> --json` and read `fallback_reason` and
+   `warning`. A populated `fallback_reason` means rules were evaluated and none
+   matched, which is a manifest problem.
+3. `herdr server agent-manifests` — confirm a manifest for that agent is active
+   at all, and check whether a fetched copy was ignored for being older than
+   the bundled one.
+4. If the agent is genuinely unsupported, add it to `knownUnsupportedAgents` so
+   the gap is declared, and the coverage check stops failing.
+
+## Two traps that cost real time
+
+**`agent wait` immediately after `agent prompt` returns instantly.** The agent
+has not left `idle` yet, so a wait for `idle` matches the state it never left.
+Wait for the transition first, then for completion:
+
+```bash
+herdr agent wait <name> --until working --timeout 20000 &
+herdr agent prompt <name> "<text>"
+wait
+herdr agent wait <name> --until idle --timeout 300000
+```
+
+**`config.toml` is a read-only symlink into the Nix store.** Any herdr
+subcommand that rewrites its own config fails or is reverted on the next
+switch. Express the change as `programs.herdr.settings` instead. This is the
+same conflict class as `herdr integration install`, which
+[`modules/herdr/README.md`](../../modules/herdr/README.md) covers.
+
+## What survives a restart, and what does not
+
+Stopping and restarting the server restores workspaces, panes and their working
+directories from the persisted session. It does **not** resurrect the agent
+processes that were running in those panes — they come back as plain shells at
+the right directory. Plan reattachment around that: the layout survives, the
+running agent does not.
+
+## Related
+
+- [`docs/architecture/herdr.md`](../architecture/herdr.md) — topology, socket
+  ownership, and detection precedence.
+- [`modules/herdr/README.md`](../../modules/herdr/README.md) — binary sources
+  and the declarative-config conflicts.

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -100,6 +100,19 @@ refreshed at runtime — which is why `agentManifests` exists. A local override
 wins, and `explain` names the winner in `manifest_source` and flags it in
 `local_override_shadowing_remote`.
 
+## Enabling the server half pulls an unfree package
+
+`services.herdr.agentPackages` defaults to the CLIs this flake manages, and one
+of them (`cursor-cli`) is unfree. On a NixOS host that has not allowed unfree
+packages, `services.herdr.enable = true` therefore fails at **evaluation**:
+
+```text
+error: Refusing to evaluate package 'cursor-cli-...' because it has an unfree license
+```
+
+Allow that one package on the host, or narrow `agentPackages`. The error names
+a package the operator never asked for, so it reads as unrelated to herdr.
+
 ## The socket path is a contract
 
 `nixos.nix` sets `RuntimeDirectory=herdr`, pinning the control socket at

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -77,11 +77,28 @@ dashboard's approvals — silently sees nothing to report.
 `lib/checks/herdr.nix` fails when an enabled CLI is neither detected upstream,
 nor given a manifest here, nor named in `knownUnsupportedAgents`.
 
-`qwen-code` and `cecli` are in that list today: herdr ships no manifest for
-either, and the rule schema is herdr's, so those entries are **declared rather
-than guessed at**. Author real ones against
-`herdr agent explain <target> --json` on a live pane, then reload with
-`herdr server reload-agent-manifests`.
+Only `cecli` is in that list. herdr ships no manifest for it, and the rule
+schema is herdr's, so the entry is **declared rather than guessed at**. Author
+a real one against `herdr agent explain <target> --json` on a live pane, then
+reload with `herdr server reload-agent-manifests`.
+
+`qwen-code` was listed too, and that was wrong. herdr detects it out of the box
+via its `qwen` manifest — a live pane reports `manifest qwen.toml`
+`2026.08.14.1`, matched rule `composer_idle`, no fallback and no warning. Names
+skew between the two systems: herdr calls it `qwen`, this flake calls the option
+`qwen-code`, the same skew `antigravity-cli` (herdr: `agy`) already carries.
+
+## Detection state is fetched, not pinned
+
+`herdr server agent-manifests` reports what is actually live. Measured on the
+workstation: **19 of 20 manifests came from the network**, one (`grok`) fell
+back to the bundled copy because the fetched version was older than the one
+herdr shipped.
+
+So the rules that decide working/blocked/idle are, by default, remote state
+refreshed at runtime — which is why `agentManifests` exists. A local override
+wins, and `explain` names the winner in `manifest_source` and flags it in
+`local_override_shadowing_remote`.
 
 ## The socket path is a contract
 

--- a/modules/herdr/options.nix
+++ b/modules/herdr/options.nix
@@ -93,7 +93,6 @@ in
       type = lib.types.listOf lib.types.str;
       default = [
         "cecli"
-        "qwen-code"
       ];
       description = ''
         CLIs this flake enables that herdr knowingly cannot detect, and for
@@ -125,11 +124,20 @@ in
         "hermes"
         "opencode"
         "pi"
+        # herdr's manifest is named `qwen`; this flake's option is `qwen-code`,
+        # the same name skew `antigravity-cli` (herdr: `agy`) already carries.
+        # Verified live: `herdr agent explain` on a qwen pane reports
+        # manifest qwen.toml 2026.08.14.1, matched rule `composer_idle`,
+        # no fallback and no warning.
+        "qwen-code"
       ];
       description = ''
         Agents herdr detects out of the box, as declared by its own supported-
         agents documentation. Read-only: it describes upstream, so a consumer
         overriding it would only be lying to the coverage check.
+
+        Names here are THIS flake's option names, not herdr's manifest names,
+        because the coverage check keys off the option that enables the CLI.
       '';
     };
   };


### PR DESCRIPTION
## Summary

herdr shipped in v4.31.0 with a module README and nothing else. This makes it
operational: it is now running on a workstation, and the parts that bite are
documented.

Two changes:

**`qwen-code` was misclassified as undetectable.** It was listed in
`programs.herdr.knownUnsupportedAgents`, which meant its panes were assumed to
report as a bare shell with no working/blocked/idle state. herdr detects it out
of the box. Verified on a live pane rather than from the schema:
`herdr agent explain` reports manifest `qwen.toml` `2026.08.14.1`, matched rule
`composer_idle`, no fallback and no warning. Moved to `knownUpstreamAgents`;
only `cecli` remains listed, and that gap is real — no manifest for it exists in
herdr's set at all.

Names skew between the two systems: herdr calls it `qwen`, this flake calls the
option `qwen-code`, the same skew `antigravity-cli` (herdr: `agy`) already
carries. The option description now says so, because the coverage check keys off
this flake's names.

**New architecture page and runbook**, registered in the architecture index and
the tool decision tree.

## Behaviours confirmed against a running server

Each of these was measured, not read off the schema:

- `agent wait --until idle` immediately after `agent prompt` returns instantly,
  because the agent has not yet left `idle`. Wait for `working` first. The
  runbook carries the correct sequence.
- `config.toml` is a read-only symlink into the store, so herdr's own config
  writers fail or get reverted — the same conflict class as
  `integration install`.
- A server restart restores workspaces, panes and their working directories, but
  **not** the agent processes inside them; they return as plain shells. Worth
  knowing before planning reattachment around it.
- Detection rules are mostly fetched at runtime: 19 of 20 active manifests came
  from the network, with one falling back to the bundled copy because the
  fetched version was older. This is why `agentManifests` exists.

## Test plan

- `nix fmt` — clean
- `nix flake check` — passes
- Regression suite force-evaluated (a bare `nix flake check` on darwin runs none
  of `lib/checks/`, which are `x86_64-linux`-scoped):
  `nix eval --raw .#checks.x86_64-linux --apply 'cs: builtins.concatStringsSep "\n" (map (c: c.outPath) (builtins.attrValues cs))'` — passes, including
  `herdr-agent-coverage-regression` with the shortened list
- New docs are well under the 3000-token cap and the byte gate
- Verified live: a real agent pane classified via `herdr agent explain --json`,
  and a `working` to `idle` transition observed through `herdr agent wait`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a coverage-list correction only; no runtime or auth behavior changes beyond aligning the flake check with upstream herdr detection.
> 
> **Overview**
> **Fixes `qwen-code` agent-detection coverage:** it is removed from `programs.herdr.knownUnsupportedAgents` and added to `knownUpstreamAgents`, since herdr already classifies Qwen panes via the upstream `qwen` manifest. Option docs now call out flake option name vs herdr manifest name (`qwen-code` vs `qwen`); only `cecli` stays explicitly unsupported.
> 
> **Adds operational docs for herdr:** new architecture page (`docs/architecture/herdr.md`) and runbook (`docs/runbooks/herdr.md`), linked from the architecture index, runbooks table, and `docs/ai-tool-decision-tree.md` (when to use herdr + anti-pattern for `integration install`). **`modules/herdr/README.md`** is expanded with runtime-fetched manifests, NixOS `services.herdr` + unfree `cursor-cli` eval failure, and the corrected qwen story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff7ef733120e5e43e1111bc48f42302ac2ca9eea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->