### PR TITLE
chore(deps): bump nix-claude-code to pick up the marketplace fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1787907038,
-        "narHash": "sha256-iJU5VFoT4VDuNBieQzkRA3wDOfqZqwwSl2xCd2bEEYM=",
+        "lastModified": 1788138193,
+        "narHash": "sha256-HZrVZo8r/uMOShIoG1QSjI5zliUrYbyqtP9CJgcZUno=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "3199c92110e5864a4a7be8c92aea530b5ebaf113",
+        "rev": "f11f9f900b66f95c22c6448904c6f2ce7e9ad90a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps `nix-claude-code` from `3199c92` to `f11f9f9`.

Picks up two fixes now on that repo's `main`:

- **Marketplace containment.** The `jacobpevans-cc-plugins-patched` derivation
  now copies the marketplace instead of building a per-plugin symlink farm.
  Under the previous shape each plugin directory resolved into a different store
  path, and Claude Code 2.1.251 refuses any plugin whose source resolves outside
  its marketplace directory — so every plugin in that marketplace was rejected,
  along with the skills and hooks they provide.

- **Activation-merge hook strip.** Hook events the Nix config no longer declares
  are now removed from the runtime settings file instead of persisting across
  activations. Stripping is conditional on the generated settings actually
  declaring `hooks`, so runtime-added hooks are preserved when Nix declares none.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin-only change; risk is limited to Claude Code plugin packaging and settings-merge behavior from the updated flake input.
> 
> **Overview**
> Updates the **`nix-claude-code`** flake input in `flake.lock` from `3199c92` to **`f11f9f9`**, pulling in upstream fixes without changing this repo’s own Nix sources.
> 
> That revision restores **JacobPEvans marketplace plugins** under Claude Code 2.1.251+ by packaging the marketplace as a single copied tree instead of per-plugin symlinks that pointed outside the marketplace root (which caused every plugin—and their skills/hooks—to be rejected).
> 
> It also **cleans hook entries on activation merge**: hook events no longer declared in the generated Nix settings are removed from the runtime settings file, while runtime-added hooks are left alone when Nix does not declare any `hooks`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2660cbc7c7841654878434475239cd66b3a7ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->