### PR TITLE
fix(claude): stop declaring Remote Control enabled where it cannot run

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -143,9 +143,13 @@ in
         expected = true;
       }
       {
+        # null, not true: Remote Control cannot start while ANTHROPIC_BASE_URL
+        # points at the local proxy, so declaring it true wrote an inert `true`
+        # into settings.json. Opt in per session with `claude-rc`. See
+        # modules/claude-config.nix for the full rationale.
         name = "remoteControlAtStartup";
         actual = cfg.remoteControlAtStartup;
-        expected = true;
+        expected = null;
       }
       {
         name = "apiKeyHelper.enable";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -142,8 +142,13 @@ in
       # to null, which Claude Code reads as the upstream default. Override
       # per-session via /effort.
 
-      # Enable Remote Control for all sessions (Feb 2026 feature).
-      remoteControlAtStartup = true;
+      # Deliberately unset, not true. Remote Control refuses to start while
+      # ANTHROPIC_BASE_URL points anywhere but api.anthropic.com, and
+      # modules/claude/settings-env.nix points it at the local proxy for every
+      # session, so the two are mutually exclusive and this flag was inert.
+      # No per-session opt-in exists; removing the variable from settings.json
+      # works but trades away subagent routing. Detail: dryvist/nix-ai#1852.
+      remoteControlAtStartup = null;
 
       # Auto-approve CLAUDE.md external imports under the consumer's workspace
       # roots (userConfig.trustedProjectDirs, maintainer profile). Empty default


### PR DESCRIPTION
## Problem

`remoteControlAtStartup = true` renders `true` into `settings.json` and
`~/.claude.json`, but Claude Code declines to start Remote Control whenever
`ANTHROPIC_BASE_URL` points anywhere other than `api.anthropic.com`:

```
Remote Control is only available when using Claude via api.anthropic.com.
ANTHROPIC_BASE_URL is set and does not point at api.anthropic.com.
```

`modules/claude/settings-env.nix` sets that variable for every session, which is
what gives subagents the cost-ordered fallback chain. The two are mutually
exclusive. The check compares the configured base-URL string, not the upstream a
request reaches, so a proxy forwarding to `api.anthropic.com` does not satisfy it.

## Change

Set the flag `null` and document the constraint. The consumer check expects
`null` to match.

No behaviour change: the flag was already inert. This makes the declared config
agree with what the runtime does.

## Constraints confirmed against 2.1.251

- `settings.json` takes precedence over the environment, so unsetting or
  overriding `ANTHROPIC_BASE_URL` in the shell does not change the outcome.
- `--settings` before `remote-control` is rejected, with a message naming the
  flag to remove.
- `CLAUDE_CONFIG_DIR` pointing at a directory whose `settings.json` omits the
  variable passes the base-URL check and then fails the subscription check.

Remote Control becomes available when the variable is absent from `settings.json`
itself. That trades away subagent routing for every session, so it is left as a
deliberate configuration choice rather than made here.

## Verification

```
claude remote-control --help   # error, with the variable set
                               # flag list, with it absent
```

`nix flake check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Aligns declared config with existing runtime behavior; no change to proxy routing or API env unless users separately opt into Remote Control.
> 
> **Overview**
> **`remoteControlAtStartup`** is changed from **`true`** to **`null`** in `claude-config.nix`, so generated `settings.json` no longer writes an enabled flag that Claude Code ignores.
> 
> Remote Control only starts when **`ANTHROPIC_BASE_URL`** targets `api.anthropic.com`, but every session still gets that variable from `settings-env.nix` (local proxy for subagent routing), so the two options conflict and the old default was effectively inert. Comments document that tradeoff and point to per-session **`claude-rc`** / issue **#1852**.
> 
> The Claude defaults regression check in `lib/checks/claude.nix` now expects **`null`** to match the module override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9e477d6eddc9e90d3cfabab4eaf0150deaeb192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->