### PR TITLE
chore(main): promote develop to main

### DIFF
--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -143,9 +143,13 @@ in
         expected = true;
       }
       {
+        # null, not true: Remote Control cannot start while ANTHROPIC_BASE_URL
+        # points at the local proxy, so declaring it true wrote an inert `true`
+        # into settings.json. Opt in per session with `claude-rc`. See
+        # modules/claude-config.nix for the full rationale.
         name = "remoteControlAtStartup";
         actual = cfg.remoteControlAtStartup;
-        expected = true;
+        expected = null;
       }
       {
         name = "apiKeyHelper.enable";

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -142,8 +142,13 @@ in
       # to null, which Claude Code reads as the upstream default. Override
       # per-session via /effort.
 
-      # Enable Remote Control for all sessions (Feb 2026 feature).
-      remoteControlAtStartup = true;
+      # Deliberately unset, not true. Remote Control refuses to start while
+      # ANTHROPIC_BASE_URL points anywhere but api.anthropic.com, and
+      # modules/claude/settings-env.nix points it at the local proxy for every
+      # session, so the two are mutually exclusive and this flag was inert.
+      # No per-session opt-in exists; removing the variable from settings.json
+      # works but trades away subagent routing. Detail: dryvist/nix-ai#1852.
+      remoteControlAtStartup = null;
 
       # Auto-approve CLAUDE.md external imports under the consumer's workspace
       # roots (userConfig.trustedProjectDirs, maintainer profile). Empty default


### PR DESCRIPTION
Promotes develop to main.

Contains one change: `programs.claude.remoteControlAtStartup` moves from `true` to unset.

Claude Code starts Remote Control only when `ANTHROPIC_BASE_URL` is unset or resolves to api.anthropic.com. This configuration sets that variable in `settings.json` for every session, so the flag had no effect. The option and its consumer check now match that constraint, which is documented at the declaration site.

No behavior change for any session: the flag was already inert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and test alignment only; documented as no session behavior change because the flag was already ineffective.
> 
> **Overview**
> **`programs.claude.remoteControlAtStartup` no longer defaults to `true`.** It is explicitly unset (`null`) so `settings.json` does not carry an inert Remote Control flag.
> 
> Remote Control cannot start when **`ANTHROPIC_BASE_URL`** is not Anthropic’s API; this stack sets that variable to the local LiteLLM proxy on every session via `settings-env.nix`, so the previous `true` default had no effect. Comments in **`modules/claude-config.nix`** document the constraint and reference dryvist/nix-ai#1852; **`lib/checks/claude.nix`** now expects `null` in the defaults regression check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c0c67abaf22bcc45b7a31c88df6e12f5c20c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->