### PR TITLE
chore(deps): bump nix-claude-code to the current main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1788144105,
-        "narHash": "sha256-oT+SZKVehUbKCsA8c9JOVqQ/j18SvaknYsk4k2dVeUY=",
+        "lastModified": 1788146817,
+        "narHash": "sha256-pi5krgZiydZBUM8OLPc8OLmZ+2YRH0PrX8Sv/fBY2uU=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "62391ef4d1fc36cb230e0a4bdba730cfd98a1253",
+        "rev": "0bce5ad039784229f1c87c342c6ff1d6cedb8927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Advances the nix-claude-code input to current main.

Brings in the settings renderer fix for sandbox sub-keys and the typed sandbox/policy option surface. All new options default to null, so the generated settings.json is unchanged unless a consumer sets one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency lock bump only; behavior changes apply when new nix-claude-code options are set, and defaults preserve existing settings output.
> 
> **Overview**
> Updates **`flake.lock`** so the **`nix-claude-code`** flake input points to **`0bce5ad`** on **`dryvist/nix-claude-code`** `main` (replacing **`62391ef`**).
> 
> That upstream revision includes a **settings renderer fix** for sandbox sub-keys and a **typed sandbox/policy option surface**. New options default to **`null`**, so generated **`settings.json`** should stay the same unless this repo or a consumer explicitly sets them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb01827da90d589afd03f08180e9606fc1338fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->