### PR TITLE
feat(agent-skills): mirror categories into a groups default

### DIFF
--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -3,6 +3,7 @@
 # Declarative configuration for shared cross-tool skills.
 # Discovers plugin skills and deploys them to the configured canonical root.
 {
+  config,
   lib,
   pkgs,
   marketplaceInputs,
@@ -313,35 +314,17 @@ in
         observability = [ "langfuse" ];
       };
 
-      # Deployment groups, mirroring the categories above 1:1. `categories`
-      # only affects the generated INDEX.md's headings (cosmetic); `groups` is
-      # what `activeGroups` actually gates. They started separate and drifted
-      # apart — most skills are still Uncategorized here, same as in
-      # `categories`, so no host should set `activeGroups` to a subset of
-      # these six names yet: it would silently drop everything uncategorized,
-      # commit/plan-task/create-pr included. Curating the other ~220 skills
-      # into real groups is the remaining work before activeGroups is safe to
-      # use as a restrictive filter.
-      groups = lib.mkDefault {
-        research = [
-          "github-code-search"
-          "last30days"
-          "managing-dependencies"
-        ];
-        reasoning = [
-          "why"
-          "kaizen"
-          "ponytail"
-        ];
-        engineering = [
-          "kaizen"
-          "managing-dependencies"
-          "ponytail"
-        ];
-        workspace = [ "file-organizer" ];
-        diagrams = [ "dashmotion" ];
-        observability = [ "langfuse" ];
-      };
+      # Deployment groups. `categories` only drives the generated INDEX.md
+      # headings; `groups` is what `activeGroups` actually gates. Spelling the
+      # same map twice would leave two copies to keep in sync, so derive one
+      # from the other — a host overriding categories gets matching groups for
+      # free and the two cannot drift apart.
+      #
+      # NOT yet safe as a restrictive filter: most skills are named in no
+      # category, so setting `activeGroups` would silently drop everything
+      # uncategorized, commit/plan-task/create-pr included. Curating the rest
+      # is the remaining work before any host sets it.
+      groups = lib.mkDefault config.programs.agentSkills.categories;
     };
   };
 }

--- a/modules/agent-skills/default.nix
+++ b/modules/agent-skills/default.nix
@@ -312,6 +312,36 @@ in
         diagrams = [ "dashmotion" ];
         observability = [ "langfuse" ];
       };
+
+      # Deployment groups, mirroring the categories above 1:1. `categories`
+      # only affects the generated INDEX.md's headings (cosmetic); `groups` is
+      # what `activeGroups` actually gates. They started separate and drifted
+      # apart — most skills are still Uncategorized here, same as in
+      # `categories`, so no host should set `activeGroups` to a subset of
+      # these six names yet: it would silently drop everything uncategorized,
+      # commit/plan-task/create-pr included. Curating the other ~220 skills
+      # into real groups is the remaining work before activeGroups is safe to
+      # use as a restrictive filter.
+      groups = lib.mkDefault {
+        research = [
+          "github-code-search"
+          "last30days"
+          "managing-dependencies"
+        ];
+        reasoning = [
+          "why"
+          "kaizen"
+          "ponytail"
+        ];
+        engineering = [
+          "kaizen"
+          "managing-dependencies"
+          "ponytail"
+        ];
+        workspace = [ "file-organizer" ];
+        diagrams = [ "dashmotion" ];
+        observability = [ "langfuse" ];
+      };
     };
   };
 }


### PR DESCRIPTION
## Summary
- \`activeGroups\` (the deployment gate for the shared skill catalog) had no \`groups\` data anywhere — only \`categories\` (cosmetic, drives the generated INDEX.md headings only) was populated.
- Mirror the same six curated categories into \`groups\` so \`activeGroups\` is wired and usable.

## Not done here, on purpose
No host sets \`activeGroups\` yet. Most of the shared catalog (~220 of ~230 skills) is still uncategorized, so restricting to these six group names today would silently drop everything else — commit/plan-task/create-pr included. Actually shrinking a session's skill surface needs the rest of the catalog sorted into real groups first; that's separate follow-on work.

## Test plan
- [x] \`nix-instantiate --parse\` on the edited file
- [x] \`nixfmt --check\` clean
- [ ] CI: existing \`agent-skills-options-regression\` / group-gated fixture checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a Nix default and documentation only; no host enables restrictive `activeGroups` yet, so runtime skill deployment behavior is unchanged.
> 
> **Overview**
> **Wires deployment gating data** by defaulting `programs.agentSkills.groups` to the same map as `categories`, instead of leaving `groups` empty while `activeGroups` filters against it in `components.nix`.
> 
> The module now takes **`config`** so `groups` can be set with `lib.mkDefault config.programs.agentSkills.categories`, keeping INDEX headings (`categories`) and the group catalog (`groups`) in sync when a host overrides categories. Comments note that turning on `activeGroups` is still unsafe until more of the shared catalog is categorized, because uncategorized skills would be dropped from deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8eefe783dd2c68d6adbb7be7eebb126ae7079e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->