### PR TITLE
chore: promote develop to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -726,11 +726,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1788148280,
-        "narHash": "sha256-OzJqTpfF7LejtD1jEsizEW0xQXfiJBCw4tllH2sdGbU=",
+        "lastModified": 1788152415,
+        "narHash": "sha256-EaSyKDKcxN5IbP8Ol/gQM0/4F2VrzvlP0YW/Gl3R/zI=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "a0d5b80ce7e2fb3ef61419af8266ab3d0934ceed",
+        "rev": "4c743aca6b838f88ac3197edad52a81c6ff191db",
         "type": "github"
       },
       "original": {

--- a/lib/checks/litellm-local-claude-tier.nix
+++ b/lib/checks/litellm-local-claude-tier.nix
@@ -1,0 +1,86 @@
+# Claude Code tier-name checks for the local LiteLLM proxy.
+#
+# Split out of ./litellm-local.nix to stay under the repo's 12KB file-size
+# error ceiling, the same reason ./litellm-local-fallbacks.nix and
+# ./litellm-local-keys.nix are separate. The split is by responsibility: this
+# file answers "can every model name Claude Code is pointed at resolve without
+# the `*` wildcard, and does it carry the context window a subagent needs".
+{
+  lib,
+  claudeEnv,
+  rendered,
+  routerUrl,
+  tokenFilePath,
+}:
+rec {
+  # Every model name Claude Code is pointed at must be one the proxy can resolve
+  # WITHOUT the `*` wildcard — either an Anthropic capability alias / model id
+  # that lands in the `claude-*` group, or an explicit `model_name` in the
+  # model_list. Naming an upstream ROLE is what caused the outage: the router
+  # served no `subagent` group, so the request fell through `*` and 404'd on
+  # every subagent spawn. `*` must never be what makes a Claude Code tier work.
+  explicitGroups = map (d: d.model_name) rendered.model_list;
+  claudeTierNames = lib.filter (n: n != null) [
+    (claudeEnv.CLAUDE_CODE_SUBAGENT_MODEL or null)
+    (claudeEnv.ANTHROPIC_MODEL or null)
+  ];
+  #
+  # A bare capability alias is NOT accepted, and that is the point. `opus`,
+  # `sonnet` and `haiku` used to be allowed here on the belief that the harness
+  # expands them before the request leaves. It does not: a `sonnet[1m]` request
+  # was observed reaching the proxy verbatim, missing `claude-*`, falling
+  # through `*` and egressing to a third-party provider. An alias that looks
+  # Claude-shaped but routes to the router is worse than a name that fails,
+  # because the session keeps working and only the destination changed.
+  claudeTierNamesResolveLocally = lib.all (
+    n: lib.hasPrefix "claude" n || lib.elem n explicitGroups
+  ) claudeTierNames;
+
+  # Every tier name that DOES reach Anthropic must carry the 1M-context suffix.
+  # A subagent here routinely carries more than a 200k window holds, so a
+  # 200k-window id is a truncation waiting to happen — and truncation returns a
+  # confident wrong answer rather than an error.
+  claudeTierNamesAre1m = lib.all (
+    n: !(lib.hasPrefix "claude" n) || lib.hasSuffix "[1m]" n
+  ) claudeTierNames;
+
+  # THE LEAK GATE. `*` must not be reachable by anything Claude-shaped.
+  #
+  # LiteLLM resolves an exact `model_name` first and only then the `*` group,
+  # so a Claude-shaped name that is neither a `claude-*` match nor an explicit
+  # group silently becomes router egress. Enumerating the shapes the harness
+  # actually emits is the only way to catch it before a request does: a bare
+  # alias, and an alias carrying the `[1m]` suffix.
+  claudeShapedNames =
+    lib.concatMap
+      (a: [
+        a
+        "${a}[1m]"
+      ])
+      [
+        "opus"
+        "sonnet"
+        "haiku"
+        "fable"
+      ];
+  claudeShapedNamesCannotReachWildcard = lib.all (
+    n: !(lib.elem n claudeTierNames) || lib.elem n explicitGroups
+  ) claudeShapedNames;
+
+  # The haiku tier stays on Anthropic: Claude Code's background requests carry
+  # its full system prompt (~36k tokens), which the `cheap` role's 32k-window
+  # local target cannot hold, so an override fails every background call.
+  claudeHaikuUntouched = !(claudeEnv ? ANTHROPIC_DEFAULT_HAIKU_MODEL);
+
+  # The header is what makes LiteLLM forward the OAuth bearer instead of
+  # treating it as the proxy credential. It must be in settings.json (every
+  # surface) and it must be the constant marker, never a key.
+  # Discovery would list the two wildcard groups as picker rows.
+  claudeNoDiscovery = !(claudeEnv ? CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY);
+
+  # The private-workspace guard asks the upstream router what a role resolves
+  # to; it must find the address and the bearer file PATH from settings.json,
+  # since a GUI-launched session never runs shell init.
+  claudeGetsRouterAddress = claudeEnv.LLM_ROUTER_URL == routerUrl;
+  claudeGetsTokenPathOnly = claudeEnv.LLM_ROUTER_TOKEN_FILE == tokenFilePath;
+}

--- a/lib/checks/litellm-local.nix
+++ b/lib/checks/litellm-local.nix
@@ -60,47 +60,39 @@ let
   # tiers are repointed at roles.
   claudeMainUntouched = !(claudeEnv ? ANTHROPIC_MODEL);
 
-  # Every model name Claude Code is pointed at must be one the proxy can resolve
-  # WITHOUT the `*` wildcard — either an Anthropic capability alias / model id
-  # that lands in the `claude-*` group, or an explicit `model_name` in the
-  # model_list. Naming an upstream ROLE is what caused the outage: the router
-  # served no `subagent` group, so the request fell through `*` and 404'd on
-  # every subagent spawn. `*` must never be what makes a Claude Code tier work.
-  explicitGroups = map (d: d.model_name) rendered.model_list;
-  claudeTierNames = lib.filter (n: n != null) [
-    (claudeEnv.CLAUDE_CODE_SUBAGENT_MODEL or null)
-    (claudeEnv.ANTHROPIC_MODEL or null)
-  ];
-  claudeTierNamesResolveLocally = lib.all (
-    n:
-    lib.hasPrefix "claude" n
-    || lib.elem n [
-      "opus"
-      "sonnet"
-      "haiku"
-    ]
-    || lib.elem n explicitGroups
-  ) claudeTierNames;
+  # Claude tier-name resolution + the wildcard leak gate (12KB gate).
+  inherit
+    (import ./litellm-local-claude-tier.nix {
+      inherit
+        lib
+        claudeEnv
+        rendered
+        routerUrl
+        tokenFilePath
+        ;
+    })
+    claudeTierNames
+    claudeTierNamesResolveLocally
+    claudeTierNamesAre1m
+    claudeShapedNamesCannotReachWildcard
+    claudeHaikuUntouched
+    claudeNoDiscovery
+    claudeGetsRouterAddress
+    claudeGetsTokenPathOnly
+    ;
 
-  # The haiku tier stays on Anthropic: Claude Code's background requests carry
-  # its full system prompt (~36k tokens), which the `cheap` role's 32k-window
-  # local target cannot hold, so an override fails every background call.
-  claudeHaikuUntouched = !(claudeEnv ? ANTHROPIC_DEFAULT_HAIKU_MODEL);
-
-  # The header is what makes LiteLLM forward the OAuth bearer instead of
-  # treating it as the proxy credential. It must be in settings.json (every
-  # surface) and it must be the constant marker, never a key.
+  # Under `claudeDirect` the proxy is out of Claude Code's path, so both the
+  # base URL and the marker header are absent by design. The pair must move
+  # together: a URL without the header is the 2026-08-24 outage, and a header
+  # without the URL points at nothing.
+  claudeDirect = enabled.programs.litellmLocal.claudeDirect;
+  claudeHasBaseUrl = claudeEnv ? ANTHROPIC_BASE_URL;
   claudeHeaderIsMarker =
-    claudeEnv.ANTHROPIC_CUSTOM_HEADERS == "x-litellm-api-key: Bearer ${clientToken}";
-
-  # Discovery would list the two wildcard groups as picker rows.
-  claudeNoDiscovery = !(claudeEnv ? CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY);
-
-  # The private-workspace guard asks the upstream router what a role resolves
-  # to; it must find the address and the bearer file PATH from settings.json,
-  # since a GUI-launched session never runs shell init.
-  claudeGetsRouterAddress = claudeEnv.LLM_ROUTER_URL == routerUrl;
-  claudeGetsTokenPathOnly = claudeEnv.LLM_ROUTER_TOKEN_FILE == tokenFilePath;
+    if claudeDirect then
+      !claudeHasBaseUrl && !(claudeEnv ? ANTHROPIC_CUSTOM_HEADERS)
+    else
+      claudeHasBaseUrl
+      && claudeEnv.ANTHROPIC_CUSTOM_HEADERS == "x-litellm-api-key: Bearer ${clientToken}";
 
   # Codex must gain the proxy as an ADDITIONAL provider without the default
   # provider or model changing.
@@ -169,15 +161,21 @@ in
       || throw "enabling the proxy must not pin Claude Code's main model; ANTHROPIC_MODEL was set";
     assert
       claudeTierNamesResolveLocally
-      || throw "every model name Claude Code is pointed at must resolve without the `*` wildcard — an Anthropic alias (opus/sonnet/haiku), a claude-* id, or an explicit model_list group. Naming an upstream ROLE 404s every call in that tier the moment the router stops serving it; got: ${builtins.toJSON claudeTierNames}";
+      || throw "a Claude Code tier name must resolve without `*`: a full claude-* id or an explicit model_list group. A bare alias (opus/sonnet/haiku, with or without [1m]) does not match claude-*, so it egresses to the router; got: ${builtins.toJSON claudeTierNames}";
+    assert
+      claudeTierNamesAre1m
+      || throw "a claude-* tier id must carry [1m]: a subagent outgrows a 200k window, and an over-long request truncates into a confident wrong answer; got: ${builtins.toJSON claudeTierNames}";
+    assert
+      claudeShapedNamesCannotReachWildcard
+      || throw "a Claude-shaped alias names a tier with no explicit model_list group, so it resolves through `*` and leaves for the router; got: ${builtins.toJSON claudeTierNames}";
     assert
       claudeHaikuUntouched
       || throw "Claude Code's haiku tier must stay on Anthropic: the `cheap` role's local target cannot hold Claude Code's system prompt, so an override fails every background call";
     assert
       claudeHeaderIsMarker
-      || throw "settings.json must carry ANTHROPIC_CUSTOM_HEADERS as the constant marker `x-litellm-api-key: Bearer ${clientToken}`: it is what makes LiteLLM forward the OAuth bearer, and it must reach every session surface; got: ${
-        claudeEnv.ANTHROPIC_CUSTOM_HEADERS or "<unset>"
-      }";
+      || throw "Claude Code's proxy wiring is all-or-nothing: claudeDirect=false needs ANTHROPIC_BASE_URL plus the constant marker header `x-litellm-api-key: Bearer ${clientToken}` (what makes LiteLLM forward the OAuth bearer) on every surface; claudeDirect=true needs neither. Got direct=${lib.boolToString claudeDirect}, url ${
+        if claudeHasBaseUrl then "set" else "unset"
+      }, header ${claudeEnv.ANTHROPIC_CUSTOM_HEADERS or "unset"}";
     assert
       claudeNoDiscovery
       || throw "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY must stay unset: the proxy's /v1/models lists wildcard groups, not models";

--- a/modules/claude/settings-env.nix
+++ b/modules/claude/settings-env.nix
@@ -109,37 +109,44 @@
 # groups, so `/v1/models` would list `claude-*` and `*` — not models — and the
 # picker would show those as rows. The role names are declared below instead.
 // lib.optionalAttrs litellmLocal.enable (
-  {
+  # The proxy hop itself. Omitted entirely when `claudeDirect` is set, which
+  # is the "no routing at all" switch: with no base URL and no marker header,
+  # Claude Code resolves Anthropic directly and nothing here can reroute it.
+  lib.optionalAttrs (!litellmLocal.claudeDirect) {
     ANTHROPIC_BASE_URL = litellmLocal.rootUrl;
     ANTHROPIC_CUSTOM_HEADERS = "x-litellm-api-key: Bearer ${litellmLocal.clientToken}";
-    # The entry point of the cost-ordered chain in
-    # modules/litellm-local/fallback-tier.nix, not a single model: cheapest
-    # capable tier first, falling through to progressively more expensive ones
-    # only when a tier is actually down.
+  }
+  // {
+    # Which tier subagents run on. Default `anthropic` — a NATIVE Claude
+    # subagent, pinned to an explicit `claude-*[1m]` id so it matches the
+    # `claude-*` group and reaches Anthropic on the caller's own forwarded
+    # credential. It never touches the router leg, so there is no third-party
+    # egress and no retention question.
     #
-    # An explicit model_list group, never an upstream role name. A role falls
-    # through the `*` wildcard to the router, and if the router's own alias is
-    # stale the request 404s on every subagent spawn — which is exactly what
-    # happened when this was `subagent` and the router still pointed that alias
-    # at a model whose preview period had ended. The flake check
-    # `claudeTierNamesResolveLocally` enforces the explicit-group rule.
-    #
-    # A cheaper tier than the caller is the point — the parent corrects its
-    # subagents. Every member of the chain clears the ~284k p90 subagent
-    # context measured on this host; that window is a selection criterion for
-    # membership, so it does not need restating per tier here.
-    CLAUDE_CODE_SUBAGENT_MODEL = "subagent";
+    # `router` names `subagent`, the head of the generated chain in
+    # ./fallback-tier.nix. That is a LOCAL model_list group which deliberately
+    # shadows the upstream router's same-named alias — the upstream one still
+    # points at a model whose preview period ended and 404s every call. Naming
+    # the role without that local group is what breaks every subagent spawn,
+    # and `claudeShapedNamesCannotReachWildcard` is what keeps a Claude-shaped
+    # name from silently taking that path instead.
+    CLAUDE_CODE_SUBAGENT_MODEL =
+      if litellmLocal.subagentTier == "anthropic" then
+        litellmLocal.subagentAnthropicModel
+      else
+        "subagent";
+
     # The haiku tier deliberately stays on Anthropic. Claude Code's background
     # requests carry its full system prompt (measured ~36k tokens), and the
     # `cheap` role targets the always-on small local model, whose 32k window
     # the router's pre-call check honestly refuses — so an override here fails
-    # every background call rather than saving money. The subscription covers
-    # the haiku tier; `cheap` stays the role for bounded CLI work (fabric,
-    # summaries), whose prompts fit.
+    # every background call rather than saving money.
+
     # For the private-workspace agent guard (nix-claude-code): it asks the
     # UPSTREAM router what a role resolves to, because the local `*` wildcard
     # hides that. Address and path only — the bearer file's contents are read
-    # by the hook at the moment it needs them, never exported.
+    # by the hook at the moment it needs them, never exported. Kept even under
+    # `claudeDirect`: the guard still needs to resolve roles.
     LLM_ROUTER_URL = aiStack.llmRouterEndpoint;
     LLM_ROUTER_TOKEN_FILE = toString aiStack.llmEndpointTokenFile;
   }

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -22,6 +22,68 @@ in
       without losing the subscription (see the module header)
     '';
 
+    subagentTier = lib.mkOption {
+      type = lib.types.enum [
+        "anthropic"
+        "router"
+      ];
+      default = "anthropic";
+      description = ''
+        Which tier Claude Code's subagents run on.
+
+        `anthropic` (default) pins `CLAUDE_CODE_SUBAGENT_MODEL` to an explicit
+        `claude-*` id, so a subagent is a NATIVE Claude subagent: the request
+        matches the `claude-*` group, reaches Anthropic with the caller's own
+        forwarded credential, and never touches the router leg. No third-party
+        egress, so no data-retention question to answer.
+
+        `router` points subagents at the generated cost-ordered tier in
+        ./fallback-tier.nix, which egresses to OpenRouter. That path is opt-in
+        on purpose. Two constraints make it unsuitable as a default: every
+        endpoint meeting the 512k floor AND a zero-data-retention policy is
+        PAID (the free head the tier policy assumes does not exist at that
+        window — verified against OpenRouter's /api/v1/endpoints/zdr), and a
+        role that quietly bills turns a backend outage into spend nobody
+        chose.
+      '';
+    };
+
+    claudeDirect = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Take the proxy out of Claude Code's path entirely.
+
+        When true, `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS` are not
+        emitted at all, so Claude Code talks straight to Anthropic with no
+        LiteLLM hop, no wildcard group, and nothing that can reroute a
+        Claude-shaped model name. The proxy keeps running for the OpenAI-shaped
+        clients that need it; only Claude Code stops using it.
+
+        This is the panic switch for "no routing or impact at all". The cost is
+        observability: Claude Code traffic no longer passes the proxy, so the
+        `otel` callback there sees none of it (Claude Code's own OTEL export is
+        unaffected).
+      '';
+    };
+
+    subagentAnthropicModel = lib.mkOption {
+      type = lib.types.str;
+      default = "claude-sonnet-5[1m]";
+      description = ''
+        The model id `subagentTier = "anthropic"` pins subagents to.
+
+        Must be a full `claude-*` id carrying the `[1m]` suffix. Both halves
+        matter. A bare capability alias (`sonnet`, or `sonnet[1m]`) does NOT
+        match the proxy's `claude-*` group, so it falls through the `*`
+        wildcard to the router and egresses to a third party — the exact leak
+        `claudeShapedNamesCannotReachWildcard` in
+        lib/checks/litellm-local.nix now rejects. The `[1m]` suffix is
+        required because a subagent here is expected to carry a context no
+        200k window can hold.
+      '';
+    };
+
     port = lib.mkOption {
       type = lib.types.port;
       default = 4100;

--- a/modules/litellm-local/tier-candidates.json
+++ b/modules/litellm-local/tier-candidates.json
@@ -1,36 +1,37 @@
 {
-  "policy": {
-    "requiredInputTokens": 262144,
-    "memberCount": 3,
-    "paidTail": 1,
-    "pin": [],
-    "deny": []
-  },
   "generatedAt": "2026-08-29T00:02:39Z",
   "members": [
     {
-      "name": "subagent",
-      "upstream": "nvidia/nemotron-3-ultra-550b-a55b:free",
-      "catalogId": "nvidia/nemotron-3-ultra-550b-a55b:free",
-      "contextLength": 1000000,
-      "promptCostPerMtok": 0.0,
-      "completionCostPerMtok": 0.0
-    },
-    {
-      "name": "subagent-fallback1",
-      "upstream": "deepseek/deepseek-v4-flash",
       "catalogId": "deepseek/deepseek-v4-flash",
+      "completionCostPerMtok": 0.177212,
       "contextLength": 1048576,
-      "promptCostPerMtok": 0.086,
-      "completionCostPerMtok": 0.172
+      "name": "subagent",
+      "promptCostPerMtok": 0.088606,
+      "upstream": "deepseek/deepseek-v4-flash"
     },
     {
+      "catalogId": "xiaomi/mimo-v2.5",
+      "completionCostPerMtok": 0.28,
+      "contextLength": 1050000,
+      "name": "subagent-fallback1",
+      "promptCostPerMtok": 0.14,
+      "upstream": "openrouter/xiaomi/mimo-v2.5"
+    },
+    {
+      "catalogId": "openai/gpt-4.1-nano",
+      "completionCostPerMtok": 0.4,
+      "contextLength": 1047576,
       "name": "subagent-fallback2",
-      "upstream": "openrouter/nvidia/nemotron-3.5-lightning",
-      "catalogId": "nvidia/nemotron-3.5-lightning",
-      "contextLength": 262144,
-      "promptCostPerMtok": 0.08,
-      "completionCostPerMtok": 0.2
+      "promptCostPerMtok": 0.1,
+      "upstream": "openrouter/openai/gpt-4.1-nano"
     }
-  ]
+  ],
+  "policy": {
+    "deny": [],
+    "memberCount": 3,
+    "paidTail": 3,
+    "pin": [],
+    "requireZdr": true,
+    "requiredInputTokens": 524288
+  }
 }

--- a/modules/scripts/litellm-tier-refresh.sh
+++ b/modules/scripts/litellm-tier-refresh.sh
@@ -34,6 +34,7 @@ fi
 [ -f "$CANDIDATES" ] || { echo "no such file: $CANDIDATES" >&2; exit 2; }
 
 CATALOG_URL="${OPENROUTER_CATALOG_URL:-https://openrouter.ai/api/v1/models}"
+ZDR_URL="${OPENROUTER_ZDR_URL:-https://openrouter.ai/api/v1/endpoints/zdr}"
 
 ROUTER_URL="${LLM_ROUTER_URL:?LLM_ROUTER_URL must be set}"
 ROUTER_TOKEN_FILE="${LLM_ROUTER_TOKEN_FILE:?LLM_ROUTER_TOKEN_FILE must be set}"
@@ -72,6 +73,16 @@ if ! fetch -H "Authorization: Bearer $(cat "$ROUTER_TOKEN_FILE")" \
   exit 1
 fi
 
+# The retention gate's data source. Separate fetch because the model catalog
+# carries no retention field — see the ZDR block in the selector below.
+if ! fetch "$ZDR_URL" > "$work/zdr.json"; then
+  echo "failed to fetch the ZDR endpoint list after retries: $ZDR_URL" >&2
+  echo "Refusing to regenerate: without it every candidate would be treated" >&2
+  echo "as non-ZDR and the tier would come back empty, or worse, unfiltered." >&2
+  exit 1
+fi
+
+ZDR_ENDPOINTS_JSON="$work/zdr.json" \
 python3 - "$CANDIDATES" "$work/catalog.json" "$work/served.json" <<'PY'
 import json, os, sys, datetime
 
@@ -97,6 +108,24 @@ for row in served_rows:
             request_name[cid] = name
 
 need_ctx = policy["requiredInputTokens"]
+# Zero data retention is a HARD gate, not a ranking preference: this tier
+# carries delegated bulk labor, so every prompt it sees is workspace content
+# leaving the machine. OpenRouter publishes the qualifying endpoint list at
+# /api/v1/endpoints/zdr, keyed by `model_id` (NOT `model_name`, which is the
+# human-readable display string and matches nothing). Fetched separately
+# because the main catalog carries no retention field at all — there is no way
+# to derive this from catalog metadata.
+require_zdr = policy.get("requireZdr", False)
+zdr_ids = set()
+if require_zdr:
+    zdr_path = os.environ.get("ZDR_ENDPOINTS_JSON")
+    if not zdr_path:
+        sys.exit("requireZdr is set but ZDR_ENDPOINTS_JSON was not provided")
+    for e in json.load(open(zdr_path)).get("data", []):
+        if e.get("model_id"):
+            zdr_ids.add(e["model_id"])
+    if not zdr_ids:
+        sys.exit("the ZDR endpoint list came back empty; refusing to widen the tier")
 deny = set(policy.get("deny", []))
 pin = policy.get("pin", [])
 count = policy["memberCount"]
@@ -124,6 +153,11 @@ def eligible(m):
     if m["id"] not in request_name:
         return False
     if (m.get("context_length") or 0) < need_ctx:
+        return False
+    # Non-ZDR is disqualifying, never a penalty. An endpoint OpenRouter cannot
+    # establish a policy for is marked as retaining, so absence from the list
+    # is itself the conservative answer.
+    if require_zdr and m["id"] not in zdr_ids:
         return False
     p, c = price(m, "prompt"), price(m, "completion")
     if p is None or c is None:


### PR DESCRIPTION
Promotes develop to main.

- Subagent model selection is pinned to a first-party 1M-context model by default, with an opt-in routed tier that is gated on zero-data-retention and a 512k minimum input window.
- A toggle bypasses the local proxy entirely for first-party traffic.
- Marketplace wrapper entries are materialized inside their own output rather than referenced out of it, with a check that keeps them there.

Checks: unit checks forced-evaluated for the Linux system set; validate, file size, CodeQL and OSV all green on the contributing PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default LLM routing, egress, and data-retention boundaries for Claude Code subagents; misconfiguration could send workspace prompts to third parties or truncate context without obvious errors.
> 
> **Overview**
> **Claude Code + local LiteLLM** defaults change so subagents use a full **`claude-*[1m]`** id on Anthropic (opt-in **`subagentTier = "router"`** still targets the local **`subagent`** chain). New **`claudeDirect`** drops **`ANTHROPIC_BASE_URL`** and the marker header so first-party traffic skips the proxy entirely while router guard env stays.
> 
> **Safety checks** move into **`litellm-local-claude-tier.nix`**: bare aliases (`sonnet`, `sonnet[1m]`, etc.) no longer count as local resolution; **`claude-*`** tiers must end with **`[1m]`**; configured tiers cannot silently hit the **`*`** wildcard. Header/base URL assertions respect **`claudeDirect`**.
> 
> **Router subagent tier** policy tightens: **`requireZdr`**, **512k** minimum context, all-paid chain members; **`litellm-tier-refresh.sh`** fetches OpenRouter’s ZDR list and disqualifies non-ZDR endpoints. **`tier-candidates.json`** is regenerated under that policy.
> 
> **`flake.lock`** bumps the **`nix-claude-code`** input revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c12154092669812d59a594e7e47efa0cd0a6991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->