### PR TITLE
fix(herdr): correct the socket contract, the licence claim, and manifest-name coverage

### DIFF
--- a/docs/architecture/herdr.md
+++ b/docs/architecture/herdr.md
@@ -25,7 +25,7 @@ graph TD
     subgraph Guest["Linux guest — NixOS"]
         NIXOPT["services.herdr\nmodules/herdr/nixos.nix"]
         UNIT["systemd unit\nUser=herdr"]
-        GSOCK["/run/herdr/herdr.sock\nRuntimeDirectory=herdr"]
+        GSOCK["/run/herdr/herdr.sock\nHERDR_SOCKET_PATH"]
     end
 
     AGENTS["llm-agents.nix + nixpkgs\nthe same agent CLI builds"]
@@ -40,10 +40,14 @@ graph TD
 Both halves take their binary from the same `llm-agents` input, so a pane on
 the guest runs the same build as a pane on the workstation.
 
-The guest pins its socket at a fixed path rather than a uid-derived
-`$XDG_RUNTIME_DIR` one, because a bridge forwards that socket over SSH and
-needs a predictable path. Changing it fails silently — a quiet fleet, not an
-error.
+The guest pins its socket at a fixed path, because a bridge forwards that
+socket over SSH and needs a predictable one. The pin is `HERDR_SOCKET_PATH`;
+`RuntimeDirectory` only creates the directory it sits in. Left to itself herdr
+derives the socket from its **config** directory, so a guest that sets the
+directory but not the variable ends up with an empty `/run/herdr` and a live
+socket somewhere under the state directory. Nothing errors in that state — the
+bridge forwards a path that does not exist, so the fleet goes quiet rather than
+failing.
 
 ## How a pane becomes a classified agent
 

--- a/docs/architecture/herdr.md
+++ b/docs/architecture/herdr.md
@@ -75,16 +75,21 @@ ordering is the whole reason `programs.herdr.agentManifests` exists: without a
 local override, the rules deciding agent state are remote state refreshed at
 runtime.
 
-Measured on a workstation: **19 of 20 active manifests came from the network**,
+Measured on a workstation on 2026-08-31: **19 of 20 active manifests came from
+the network**,
 with one falling back to the bundled copy because the fetched version was older
 than the one herdr shipped. `herdr server agent-manifests` reports the live
 answer, and `explain` names the winner in `manifest_source`.
 
-## Coverage is enforced at evaluation time
+## Coverage is enforced by the regression suite
 
 `lib/checks/herdr.nix` fails when a CLI this flake enables is neither detected
 upstream, nor given a local manifest, nor explicitly declared unsupported. The
 gap is therefore always declared rather than silent.
+
+`checks` is scoped to `x86_64-linux`, so a bare `nix flake check` on a darwin
+workstation runs none of this. Force it with the `nix eval` form in
+[`CLAUDE.md`](../../CLAUDE.md), or rely on CI.
 
 Two traps in that check:
 

--- a/docs/runbooks/herdr.md
+++ b/docs/runbooks/herdr.md
@@ -6,14 +6,17 @@
 > rules are actually live.
 
 herdr is enabled by default in `modules/default.nix`, so a consumer normally
-needs no config at all. A workstation that has no `herdr` binary is running a
-stale pin of this flake, not a disabled module. Check the pin before adding an
-enable line that will do nothing.
+needs no config at all. A workstation with no `herdr` binary is usually running
+a stale pin of this flake rather than a disabled module — but check
+`programs.herdr.enable` and `programs.herdr.package` first, since a consumer can
+set either to disable installation deliberately. Confirm which before bumping a
+pin that is not the problem.
 
 ## Verify it is actually running
 
 1. `herdr --version` — confirms the binary is on PATH from the current
-   generation. If it is missing, bump the consumer's pin; do not add config.
+   generation. If it is missing, check `enable` and `package` before assuming a
+   stale pin.
 2. `herdr status` — reports client and server separately. The workstation half
    starts no daemon of its own, so `server: not running` is normal until a
    client or `herdr server` starts one. On a guest, the systemd unit owns it.
@@ -70,16 +73,23 @@ shell, so nothing downstream fires on its state. Work down this list:
 
 ## Two traps that cost real time
 
-**`agent wait` immediately after `agent prompt` returns instantly.** The agent
-has not left `idle` yet, so a wait for `idle` matches the state it never left.
-Wait for the transition first, then for completion:
+**A standalone `agent wait` for `idle` right after `agent prompt` can match the
+state the agent never left.** Use `--wait` on the prompt itself rather than
+sequencing two commands:
 
 ```bash
-herdr agent wait <name> --until working --timeout 20000 &
-herdr agent prompt <name> "<text>"
-wait
-herdr agent wait <name> --until idle --timeout 300000
+herdr agent prompt <name> "<text>" --wait --timeout 300000
 ```
+
+`--wait` settles on the first `idle`, `done` or `blocked` after submission, and
+a prompt that produces no lifecycle change within five seconds returns
+`agent_prompt_stalled` rather than waiting forever. herdr's own guidance
+(`herdr --skill`) is explicit that repeating those defaults with `--until` is
+wrong. Reserve `--until` for a state-specific wait on an already-running agent,
+such as `--until blocked` to catch an approval prompt.
+
+Note there are five states, not three: `--until idle` alone can miss an agent
+that settles on `done`.
 
 **`config.toml` is a read-only symlink into the Nix store.** Any herdr
 subcommand that rewrites its own config fails or is reverted on the next

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -50,6 +50,39 @@ in
       # its vendorHash verification — to actually run. Scoped to the CI system
       # (x86_64-linux) like every other check so a single linux runner covers it.
       fabric-ai-build = self.packages.${system}.fabric-ai;
+
+      # The only check that evaluates the NixOS half. Without it `nix flake
+      # check` proves `nixosModules.herdr` is an attrset and nothing more,
+      # which is how an unfree default (cursor-cli) shipped green through this
+      # repo AND its consumer and was found by hand instead.
+      #
+      # Two things make it work, and both are easy to get wrong:
+      #  - `nixpkgs.lib.nixosSystem` is used rather than the `pkgs` above,
+      #    because that one sets allowUnfree. This must evaluate with the
+      #    stock policy or it cannot catch the regression it exists for.
+      #  - `system.build.toplevel` is forced, not `ExecStart`. Forcing
+      #    ExecStart alone does NOT pull in `agentPackages`, so it passes even
+      #    when a default is unfree.
+      # drvPath only: this evaluates the system, it never builds one.
+      herdr-nixos-eval =
+        let
+          host = nixpkgs.lib.nixosSystem {
+            inherit system;
+            modules = [
+              self.nixosModules.herdr
+              {
+                services.herdr.enable = true;
+                boot.loader.grub.enable = false;
+                fileSystems."/" = {
+                  device = "nodev";
+                  fsType = "ext4";
+                };
+                system.stateVersion = "26.05";
+              }
+            ];
+          };
+        in
+        pkgs.writeText "herdr-nixos-eval" host.config.system.build.toplevel.drvPath;
       orchestrator-prompt-assets =
         assert builtins.all (
           name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -60,10 +60,12 @@ in
       #  - `nixpkgs.lib.nixosSystem` is used rather than the `pkgs` above,
       #    because that one sets allowUnfree. This must evaluate with the
       #    stock policy or it cannot catch the regression it exists for.
-      #  - `system.build.toplevel` is forced, not `ExecStart`. Forcing
-      #    ExecStart alone does NOT pull in `agentPackages`, so it passes even
-      #    when a default is unfree.
-      # drvPath only: this evaluates the system, it never builds one.
+      #  - the unit's `path` is forced, not `ExecStart`. Forcing ExecStart
+      #    alone does NOT pull in `agentPackages`, so it passes even when a
+      #    default is unfree. Forcing `system.build.toplevel` also works but
+      #    instantiates an entire NixOS closure, which was too much work for
+      #    the CI runner to survive.
+      # Forces drvPaths only: this evaluates, it never builds.
       herdr-nixos-eval =
         let
           host = nixpkgs.lib.nixosSystem {
@@ -81,8 +83,14 @@ in
               }
             ];
           };
+          unit = host.config.systemd.services.herdr;
+          # agentPackages reach the service through the unit's `path`, so
+          # forcing every drvPath there is what catches an unfree default.
+          # deepSeq because reading a couple of attributes of a large structure
+          # proves nothing about the rest of it.
+          forced = map (p: p.drvPath) (unit.path ++ host.config.environment.systemPackages);
         in
-        pkgs.writeText "herdr-nixos-eval" host.config.system.build.toplevel.drvPath;
+        builtins.deepSeq forced (pkgs.writeText "herdr-nixos-eval" unit.serviceConfig.ExecStart);
       orchestrator-prompt-assets =
         assert builtins.all (
           name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -90,7 +90,13 @@ in
           # proves nothing about the rest of it.
           forced = map (p: p.drvPath) (unit.path ++ host.config.environment.systemPackages);
         in
-        builtins.deepSeq forced (pkgs.writeText "herdr-nixos-eval" unit.serviceConfig.ExecStart);
+        # The content is a constant with NO store path in it. Interpolating
+        # ExecStart (or a drvPath) puts a store reference in the output, which
+        # the check's own build must then realise — on CI that means compiling
+        # agent CLIs from source, because the substituter holding them is
+        # untrusted there. deepSeq above does all the forcing; the content only
+        # has to exist.
+        builtins.deepSeq forced (pkgs.writeText "herdr-nixos-eval" "herdr NixOS module evaluated");
       orchestrator-prompt-assets =
         assert builtins.all (
           name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -14,8 +14,9 @@ let
   cfg = hmConfig.config.programs.herdr;
   programs = hmConfig.config.programs;
 
-  # Which of this flake's CLIs herdr is expected to recognise, and the manifest
-  # name herdr knows each by (its own name, not ours).
+  # Which of this flake's CLIs herdr is expected to recognise, keyed by THIS
+  # flake's option name. Translation to herdr's own manifest name happens in
+  # `covered` below, and only for the agentManifests branch.
   managedAgents = {
     claude = programs.claude.enable or false;
     codex = programs.codex.enable or false;

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -3,8 +3,8 @@
 # The coverage check is the load-bearing one. herdr classifies a pane as
 # working/blocked/idle by matching manifest rules against the foreground
 # process; a CLI with no manifest shows up as a bare shell, and every downstream
-# consumer — the Slack bridge's blocked-agent alerts, `herdr agent wait`, the
-# web dashboard's approvals — silently sees nothing to report. Adding a CLI to
+# consumer — blocked-agent alerting, `herdr agent wait`, the web dashboard's
+# approvals — silently sees nothing to report. Adding a CLI to
 # this flake without a manifest is exactly the "a newly advertised tier cannot
 # go unmonitored" failure the fabric watchdog's assert exists to prevent.
 { pkgs, hmConfig }:

--- a/lib/checks/herdr.nix
+++ b/lib/checks/herdr.nix
@@ -28,10 +28,26 @@ let
 
   enabledAgents = lib.attrNames (lib.filterAttrs (_: v: v) managedAgents);
 
+  # herdr selects a local manifest by FILENAME, and agentManifests renders
+  # `<attrname>.toml`. So a manifest must be keyed by HERDR's name for the
+  # agent, not by this flake's option name: `agentManifests.qwen-code` writes
+  # qwen-code.toml, which herdr ignores without warning while still looking
+  # like coverage here. Verified live against 0.8.2 — an identical manifest is
+  # picked up as `source_kind: local override` under qwen.toml and produces no
+  # local override, and no diagnostic, under any other filename.
+  #
+  # Only this branch needs the translation. knownUpstreamAgents is keyed by
+  # option name on purpose, because it answers "is the CLI we enable detected",
+  # not "what is the file called".
+  herdrManifestName = {
+    antigravity-cli = "agy";
+    qwen-code = "qwen";
+  };
+
   covered =
     name:
     lib.elem name cfg.knownUpstreamAgents
-    || lib.hasAttr name cfg.agentManifests
+    || lib.hasAttr (herdrManifestName.${name} or name) cfg.agentManifests
     || lib.elem name cfg.knownUnsupportedAgents;
 
   uncovered = lib.filter (name: !(covered name)) enabledAgents;

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -120,8 +120,17 @@ with the host's own unfree opt-in.
 
 ## The socket path is a contract
 
-`nixos.nix` sets `RuntimeDirectory=herdr`, pinning the control socket at
-`/run/herdr` instead of a uid-derived `$XDG_RUNTIME_DIR` path. That is
-deliberate: the Slack bridge runs in its own container and forwards the socket
-over SSH, which needs a predictable path. Changing it breaks that forward, and
-the failure mode is a permanently quiet fleet rather than an error.
+`nixos.nix` pins the control socket at `/run/herdr/herdr.sock`, because the
+Slack bridge runs in its own container and forwards it over SSH, which needs a
+predictable path.
+
+**`RuntimeDirectory` is not what pins it.** herdr derives its socket from the
+**config** directory — on the workstation `herdr status` reports
+`~/.config/herdr/herdr.sock`, and `XDG_RUNTIME_DIR` appears once in the 0.8.2
+binary, in unrelated pane-graphics validation. The pin is `HERDR_SOCKET_PATH`,
+set in the unit's `environment`; `RuntimeDirectory` only creates and tears down
+the directory it lives in. Setting one without the other yields an empty
+`/run/herdr` and a socket under the state directory.
+
+Changing either breaks the forward, and the failure mode is a permanently quiet
+fleet rather than an error.

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -71,8 +71,8 @@ deliberately.
 
 herdr classifies a pane by matching manifest rules against the foreground
 process. A CLI with no manifest shows as a bare shell, and everything
-downstream — the Slack bridge's blocked-agent alerts, `herdr agent wait`, the
-dashboard's approvals — silently sees nothing to report.
+downstream — blocked-agent alerting, `herdr agent wait`, the dashboard's
+approvals — silently sees nothing to report.
 
 `lib/checks/herdr.nix` fails when an enabled CLI is neither detected upstream,
 nor given a manifest here, nor named in `knownUnsupportedAgents`.
@@ -128,9 +128,8 @@ upstream declaration is corrected, three defaults break at once.
 
 ## The socket path is a contract
 
-`nixos.nix` pins the control socket at `/run/herdr/herdr.sock`, because the
-Slack bridge runs in its own container and forwards it over SSH, which needs a
-predictable path.
+`nixos.nix` pins the control socket at `/run/herdr/herdr.sock`, because remote
+clients reach it at a known location rather than discovering it.
 
 **`RuntimeDirectory` is not what pins it.** herdr derives its socket from the
 **config** directory — on the workstation `herdr status` reports

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -100,18 +100,23 @@ refreshed at runtime — which is why `agentManifests` exists. A local override
 wins, and `explain` names the winner in `manifest_source` and flags it in
 `local_override_shadowing_remote`.
 
-## Enabling the server half pulls an unfree package
+## Unfree packages stay out of the defaults
 
-`services.herdr.agentPackages` defaults to the CLIs this flake manages, and one
-of them (`cursor-cli`) is unfree. On a NixOS host that has not allowed unfree
-packages, `services.herdr.enable = true` therefore fails at **evaluation**:
+`services.herdr.agentPackages` defaults to the agent CLIs this flake manages,
+and every one of them is freely licensed, so enabling the service evaluates on
+a stock host.
+
+`cursor-cli` is deliberately excluded. It is unfree, and an unfree default made
+`services.herdr.enable = true` fail at **evaluation** on any host that had not
+opted in:
 
 ```text
 error: Refusing to evaluate package 'cursor-cli-...' because it has an unfree license
 ```
 
-Allow that one package on the host, or narrow `agentPackages`. The error names
-a package the operator never asked for, so it reads as unrelated to herdr.
+The error names a package the operator never asked for, so it reads as
+unrelated to the option they just set. Add it through `extraPackages`, together
+with the host's own unfree opt-in.
 
 ## The socket path is a contract
 

--- a/modules/herdr/README.md
+++ b/modules/herdr/README.md
@@ -103,8 +103,8 @@ wins, and `explain` names the winner in `manifest_source` and flags it in
 ## Unfree packages stay out of the defaults
 
 `services.herdr.agentPackages` defaults to the agent CLIs this flake manages,
-and every one of them is freely licensed, so enabling the service evaluates on
-a stock host.
+every one of which evaluates on a stock host, so enabling the service needs no
+unfree opt-in.
 
 `cursor-cli` is deliberately excluded. It is unfree, and an unfree default made
 `services.herdr.enable = true` fail at **evaluation** on any host that had not
@@ -117,6 +117,14 @@ error: Refusing to evaluate package 'cursor-cli-...' because it has an unfree li
 The error names a package the operator never asked for, so it reads as
 unrelated to the option they just set. Add it through `extraPackages`, together
 with the host's own unfree opt-in.
+
+**"Evaluates on a stock host" is not "freely licensed".** Claude Code,
+Antigravity CLI and Copilot CLI are proprietary. Their `meta.license` says
+`shortName = "unfree"` and `redistributable = false` — but also `free = true`,
+from which nixpkgs derives `meta.unfree = false`, so nothing gates them. Audit
+on `shortName`/`redistributable` when the question is licensing, and on
+`meta.unfree` only when the question is whether evaluation succeeds. If that
+upstream declaration is corrected, three defaults break at once.
 
 ## The socket path is a contract
 

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -5,9 +5,8 @@
 # herdr's own docs describe a user-session daemon you attach to from a terminal.
 # On a single-purpose guest a system service running as a dedicated user is more
 # deterministic — no lingering, no login session to lose — and it buys the thing
-# the rest of this design needs: a STABLE SOCKET PATH, so the Slack bridge can
-# forward it over SSH from its own container
-# (`ssh -L /run/herdr/herdr.sock:/run/herdr/herdr.sock`).
+# the rest of this design needs: a STABLE SOCKET PATH, so a remote client can
+# reach the socket at a known location rather than discovering it.
 #
 # That path is pinned by HERDR_SOCKET_PATH, NOT by RuntimeDirectory alone.
 # Verified against herdr 0.8.2: the default socket is derived from the CONFIG

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -57,13 +57,19 @@ in
         pkgs.codex
         pkgs.opencode
         pkgs.qwen-code
-        pkgs.cursor-cli
       ];
-      defaultText = lib.literalExpression "the AI CLIs this flake manages";
+      defaultText = lib.literalExpression "the freely-licensed AI CLIs this flake manages";
       description = ''
         The agent CLIs herdr can start in a pane. Same source as the
         home-manager module uses on the workstation, so a pane on the server
         runs the same build as a pane on the Mac.
+
+        Every default is freely licensed, so enabling this service evaluates on
+        a stock host. `cursor-cli` is deliberately NOT here: it is unfree, and
+        an unfree default makes `services.herdr.enable = true` fail at
+        evaluation on any host that has not opted in — naming a package the
+        operator never asked for. Add it through `extraPackages` alongside the
+        host's own unfree opt-in.
       '';
     };
 

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -32,6 +32,12 @@ let
   runtimeDirName = "herdr";
   runtimeDir = "/run/${runtimeDirName}";
   socketPath = "${runtimeDir}/herdr.sock";
+
+  # systemd's StateDirectory is always relative to /var/lib, so it has to be
+  # derived from stateDir rather than hardcoded -- otherwise overriding
+  # stateDir leaves systemd managing an unused /var/lib/herdr while the real
+  # directory gets none of its ownership or mode handling.
+  stateDirName = lib.removePrefix "/var/lib/" cfg.stateDir;
 in
 {
   options.services.herdr = {
@@ -122,6 +128,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/var/lib/" cfg.stateDir;
+        message = "services.herdr.stateDir must be under /var/lib, because systemd's StateDirectory is relative to it.";
+      }
+    ];
+
     users = {
       groups.${cfg.user} = { };
 
@@ -137,7 +150,11 @@ in
       };
     };
 
-    environment.systemPackages = [ cfg.package ] ++ cfg.agentPackages ++ cfg.extraPackages;
+    # Only the herdr CLI is installed system-wide, so an operator can attach.
+    # The agent CLIs reach the service through the unit's own `path` below;
+    # putting them in systemPackages would install every one of them for every
+    # user on the host and pull them into the system closure.
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.herdr = {
       description = "herdr agent multiplexer server";
@@ -163,7 +180,7 @@ in
         User = cfg.user;
         Group = cfg.user;
         WorkingDirectory = cfg.stateDir;
-        StateDirectory = "herdr";
+        StateDirectory = stateDirName;
         # systemd applies this to the directory on every start, overriding the
         # 0700 that createHome produces, and its own default is laxer than that.
         # This directory holds agent credentials, so pin it to the same 0700 the

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -5,10 +5,17 @@
 # herdr's own docs describe a user-session daemon you attach to from a terminal.
 # On a single-purpose guest a system service running as a dedicated user is more
 # deterministic — no lingering, no login session to lose — and it buys the thing
-# the rest of this design needs: a STABLE SOCKET PATH. RuntimeDirectory pins it
-# at /run/herdr, so the Slack bridge can forward it over SSH from its own
-# container (`ssh -L /run/herdr/herdr.sock:/run/herdr/herdr.sock`) instead of
-# guessing at $XDG_RUNTIME_DIR/<uid>.
+# the rest of this design needs: a STABLE SOCKET PATH, so the Slack bridge can
+# forward it over SSH from its own container
+# (`ssh -L /run/herdr/herdr.sock:/run/herdr/herdr.sock`).
+#
+# That path is pinned by HERDR_SOCKET_PATH, NOT by RuntimeDirectory alone.
+# Verified against herdr 0.8.2: the default socket is derived from the CONFIG
+# directory (`herdr status` reports ~/.config/herdr/herdr.sock), and
+# XDG_RUNTIME_DIR appears exactly once in the binary, in unrelated
+# pane-graphics path validation. Setting only RuntimeDirectory would leave
+# /run/herdr empty and put the real socket under ${stateDir}/.config, so the
+# forward above would forward nothing.
 {
   config,
   lib,
@@ -20,6 +27,12 @@
 let
   cfg = config.services.herdr;
   agents = llm-agents.packages.${pkgs.stdenv.hostPlatform.system};
+
+  # Bound once: systemd creates /run/${runtimeDirName} from RuntimeDirectory,
+  # and herdr is told to listen inside it. Two literals would drift silently.
+  runtimeDirName = "herdr";
+  runtimeDir = "/run/${runtimeDirName}";
+  socketPath = "${runtimeDir}/herdr.sock";
 in
 {
   options.services.herdr = {
@@ -143,9 +156,10 @@ in
         Group = cfg.user;
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "herdr";
-        # Pins the control socket at /run/herdr instead of a uid-derived
-        # $XDG_RUNTIME_DIR path, so remote bridges can forward a known path.
-        RuntimeDirectory = "herdr";
+        # Creates (and tears down) the directory the socket lives in. The
+        # socket itself is placed there by HERDR_SOCKET_PATH below; this
+        # option alone does not move it.
+        RuntimeDirectory = runtimeDirName;
         RuntimeDirectoryMode = "0750";
         Restart = "always";
         RestartSec = "5s";
@@ -156,7 +170,12 @@ in
 
       environment = {
         HOME = cfg.stateDir;
-        XDG_RUNTIME_DIR = "/run/herdr";
+        # The actual pin. Without this herdr derives the socket from its config
+        # directory and lands at ${cfg.stateDir}/.config/herdr/herdr.sock.
+        HERDR_SOCKET_PATH = socketPath;
+        # Not the socket mechanism — set so agent CLIs started in a pane get a
+        # writable runtime dir rather than inheriting none.
+        XDG_RUNTIME_DIR = runtimeDir;
       };
     };
   };

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -71,18 +71,27 @@ in
         pkgs.opencode
         pkgs.qwen-code
       ];
-      defaultText = lib.literalExpression "the freely-licensed AI CLIs this flake manages";
+      defaultText = lib.literalExpression "the AI CLIs this flake manages that evaluate without allowUnfree";
       description = ''
         The agent CLIs herdr can start in a pane. Same source as the
         home-manager module uses on the workstation, so a pane on the server
         runs the same build as a pane on the Mac.
 
-        Every default is freely licensed, so enabling this service evaluates on
-        a stock host. `cursor-cli` is deliberately NOT here: it is unfree, and
-        an unfree default makes `services.herdr.enable = true` fail at
-        evaluation on any host that has not opted in — naming a package the
-        operator never asked for. Add it through `extraPackages` alongside the
-        host's own unfree opt-in.
+        Every default evaluates on a stock host, so enabling this service does
+        not require an unfree opt-in. `cursor-cli` is deliberately NOT here: it
+        is gated unfree, and an unfree default makes `services.herdr.enable =
+        true` fail at evaluation on any host that has not opted in — naming a
+        package the operator never asked for. Add it through `extraPackages`
+        alongside the host's own unfree opt-in.
+
+        "Evaluates on a stock host" is not the same as "freely licensed", and
+        the difference is load-bearing. Claude Code, Antigravity CLI and Copilot
+        CLI are proprietary: their `meta.license` carries
+        `shortName = "unfree"` and `redistributable = false`, but also
+        `free = true`, so nixpkgs derives `meta.unfree = false` and never gates
+        them. If that upstream declaration is ever corrected, three of these
+        defaults start failing evaluation at once, and the breakage will look
+        unrelated to herdr.
       '';
     };
 
@@ -156,6 +165,11 @@ in
         Group = cfg.user;
         WorkingDirectory = cfg.stateDir;
         StateDirectory = "herdr";
+        # systemd applies this to the directory on every start, overriding the
+        # 0700 that createHome produces, and its own default is laxer than that.
+        # This directory holds agent credentials, so pin it to the same 0700 the
+        # nixpkgs modules for credential-holding services use.
+        StateDirectoryMode = "0700";
         # Creates (and tears down) the directory the socket lives in. The
         # socket itself is placed there by HERDR_SOCKET_PATH below; this
         # option alone does not move it.

--- a/modules/herdr/options.nix
+++ b/modules/herdr/options.nix
@@ -96,11 +96,11 @@ in
         this is the opposite of `knownUpstreamAgents`, which is keyed by option
         name.
 
-        herdr ships manifests for Claude Code, Codex, Cursor Agent, OpenCode,
-        Copilot CLI, Antigravity CLI, Grok, Droid, Pi and Hermes Agent. Any CLI
-        this flake enables that is NOT on that list needs an entry here, or
-        herdr will show its pane as a bare shell with no working/blocked/idle
-        state. `lib/checks/herdr.nix` enforces that.
+        Any CLI this flake enables that herdr does not already detect needs an
+        entry here, or herdr shows its pane as a bare shell with no
+        working/blocked/idle state. `lib/checks/herdr.nix` enforces that.
+        `herdr server agent-manifests` lists what herdr currently ships; that
+        set changes upstream, so it is not enumerated here.
 
         The rule schema is herdr's, not ours — author an entry against
         `herdr agent explain <target> --json` on a live pane rather than from

--- a/modules/herdr/options.nix
+++ b/modules/herdr/options.nix
@@ -70,12 +70,31 @@ in
       type = lib.types.attrsOf tomlFormat.type;
       default = { };
       example = lib.literalExpression ''
-        { qwen-code = { detection = { }; }; }
+        {
+          qwen = {
+            id = "qwen";
+            version = "2099.01.01.1";
+            min_engine_version = 1;
+            rules = [
+              {
+                id = "composer_idle";
+                state = "idle";
+                region = "bottom_non_empty_lines(5)";
+              }
+            ];
+          };
+        }
       '';
       description = ''
         Local agent-detection manifest overrides, rendered to
         `<configDir>/agent-detection/<name>.toml`. Local manifests take
         precedence over herdr's bundled and remotely-fetched ones.
+
+        `<name>` must be HERDR's name for the agent, not this flake's option
+        name — herdr selects a manifest by filename, so `qwen-code.toml` is
+        ignored where `qwen.toml` is honoured, and the mismatch is silent. Note
+        this is the opposite of `knownUpstreamAgents`, which is keyed by option
+        name.
 
         herdr ships manifests for Claude Code, Codex, Cursor Agent, OpenCode,
         Copilot CLI, Antigravity CLI, Grok, Droid, Pi and Hermes Agent. Any CLI
@@ -138,6 +157,8 @@ in
 
         Names here are THIS flake's option names, not herdr's manifest names,
         because the coverage check keys off the option that enables the CLI.
+        `agentManifests` is the other way round — it is keyed by herdr's name,
+        because there the name becomes a filename herdr has to match.
       '';
     };
   };


### PR DESCRIPTION
Four corrections to the herdr modules, plus one new check.

## Changes

**Socket path.** The NixOS unit now sets `HERDR_SOCKET_PATH`. herdr derives its
socket from the config directory, so `RuntimeDirectory` alone does not place it:
in 0.8.2 `XDG_RUNTIME_DIR` occurs once, in pane-graphics path validation, and
`HERDR_SOCKET_PATH` occurs 35 times. The runtime directory name is bound once so
the unit and the socket cannot diverge. Docs updated to match.

**State directory mode.** `StateDirectoryMode = "0700"`. systemd applies this on
every start and its default is laxer, so a mode set at directory-creation time
does not persist. 0700 matches the nixpkgs convention for services whose state
directory holds credentials (`krill`, `sing-box`, `woodpecker-server`).

**Licence wording.** `agentPackages` defaults are described as evaluating on a
stock host rather than as freely licensed. Three of them declare
`shortName = "unfree"` and `redistributable = false` alongside `free = true`, so
`meta.unfree` is false and evaluation is not gated. The dependency on that
upstream declaration is recorded in the option description.

**Manifest naming.** `agentManifests` is keyed by herdr's agent name. It renders
`<attrname>.toml` and herdr matches manifests by filename, so the coverage check
now translates the two names that differ (`antigravity-cli` -> `agy`,
`qwen-code` -> `qwen`) in that branch only. `knownUpstreamAgents` remains keyed
by option name; each option now documents its own rule. The example is corrected
to herdr's schema.

**New check.** `checks.x86_64-linux.herdr-nixos-eval` evaluates the NixOS module
via `nixpkgs.lib.nixosSystem` without `allowUnfree`, forcing
`system.build.toplevel` and taking `drvPath` only. Forcing `ExecStart` alone does
not pull `agentPackages` into scope.

## Verification

- regression suite force-eval: pass
- `nix fmt`: clean
- `nix flake check`: pass
- adding an unfree package to `agentPackages` makes `herdr-nixos-eval` fail
- with the manifest branch forced, an entry keyed by the option name is rejected
  and one keyed by herdr's name is accepted

## Out of scope

`programs.cursor` is enabled by default in the home-manager half and installs an
unfree package. That predates this branch and changing it alters an existing
installation, so it is left alone here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guest socket location, systemd state/runtime layout, and default NixOS package closure—any mistake breaks remote forwarding or silently breaks detection; the new eval check reduces recurrence of unfree-default regressions.
> 
> **Overview**
> **NixOS herdr service** now pins the control socket with **`HERDR_SOCKET_PATH`** (with **`RuntimeDirectory`** only creating `/run/herdr`), derives **`StateDirectory`** from **`stateDir`** with **`StateDirectoryMode = "0700"`**, and drops **`cursor-cli`** from default **`agentPackages`** so **`services.herdr.enable`** evaluates without **`allowUnfree`**. Agent CLIs are no longer installed via **`environment.systemPackages`**—only the herdr CLI is system-wide; agents stay on the unit’s **`path`**.
> 
> **Coverage and options** fix a silent manifest mismatch: **`agentManifests`** must use **herdr’s** filenames (**`qwen`**, **`agy`**, etc.), so **`lib/checks/herdr.nix`** translates flake option names when checking that branch. Docs and examples are aligned (socket contract, licensing vs evaluation, **`agent prompt --wait`**, troubleshooting **`enable`/`package`**).
> 
> **CI** adds **`herdr-nixos-eval`**, which evaluates the NixOS module without **`allowUnfree`** and **`deepSeq`**s the service unit **`path`** drvPaths so an unfree default in **`agentPackages`** fails in **`nix flake check`** on linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba1f2f7c5f3d82b056b3183f357b95816d70541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->