### PR TITLE
feat(claude): enable Claude Swap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,6 +310,23 @@
         "type": "github"
       }
     },
+    "claude-swap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786474943,
+        "narHash": "sha256-BDfwyH7h7Ii7QYaunHDnf0Epk5nUEd8OdOH3QCf1CJU=",
+        "owner": "realiti4",
+        "repo": "claude-swap",
+        "rev": "9f625064763d3fb04cbe31e90a7f3f9ef123df99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "realiti4",
+        "ref": "v0.25.0",
+        "repo": "claude-swap",
+        "type": "github"
+      }
+    },
     "context-engineering-kit": {
       "flake": false,
       "locked": {
@@ -701,6 +718,7 @@
         "claude-cookbooks": "claude-cookbooks",
         "claude-plugins-official": "claude-plugins-official",
         "claude-skills": "claude-skills",
+        "claude-swap": "claude-swap",
         "dryvist-github": "dryvist-github",
         "fabric-src": [
           "fabric-src"
@@ -726,11 +744,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1788152415,
-        "narHash": "sha256-EaSyKDKcxN5IbP8Ol/gQM0/4F2VrzvlP0YW/Gl3R/zI=",
+        "lastModified": 1788266794,
+        "narHash": "sha256-a9XMTnvU4MW6PBffwOcdrvo3trvbSsaXv4KqWUSdcmk=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "4c743aca6b838f88ac3197edad52a81c6ff191db",
+        "rev": "537ca45e3381893e72843a1734af0e5023815f3c",
         "type": "github"
       },
       "original": {

--- a/lib/checks/claude.nix
+++ b/lib/checks/claude.nix
@@ -42,6 +42,7 @@ in
         "settings"
         "showTurnDuration"
         "skills"
+        "swap"
         "statusline"
         "teammateMode"
         "trustedProjectDirs"
@@ -155,6 +156,11 @@ in
         name = "apiKeyHelper.enable";
         actual = cfg.apiKeyHelper.enable;
         expected = true;
+      }
+      {
+        name = "swap.disabled";
+        actual = cfg.swap.disabled;
+        expected = false;
       }
     ];
   };

--- a/modules/claude-config.nix
+++ b/modules/claude-config.nix
@@ -116,6 +116,10 @@ in
     programs.claude = {
       enable = true;
 
+      # nix-claude-code keeps account switching disabled by default. This
+      # workstation stack opts into its manual switch and parallel-session CLI.
+      swap.disabled = false;
+
       # Binary comes from llm-agents.nix, which packages claude-code for
       # aarch64-darwin AND x86_64-linux. It used to be the claude-code@latest
       # Homebrew cask, which is why nothing but the Mac could run this stack.


### PR DESCRIPTION
Enables the default-disabled Claude Swap module in the shared Claude configuration and extends the Claude option regression checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables account/credential switching for Claude Code, which can affect which API identity sessions use; changes are config and dependency pins rather than custom auth code.
> 
> **Overview**
> **Turns on Claude Swap** for this Home Manager stack by setting `programs.claude.swap.disabled = false`, overriding nix-claude-code’s default-off behavior so manual account switching and the parallel-session CLI are available.
> 
> The lockfile **pulls in `claude-swap` (v0.25.0)** and **bumps `nix-claude-code`** to a revision that wires that integration. **Regression checks** now expect a `swap` option on `programs.claude` and assert `swap.disabled` stays `false` like the other workstation overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46db9e2c9c88f928077d6c8e2fe156c69cfd9f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->