### PR TITLE
fix(litellm-local): derive each local rung's context window from the mlx catalog

### DIFF
--- a/lib/checks-fixtures.nix
+++ b/lib/checks-fixtures.nix
@@ -239,11 +239,19 @@ rec {
           contextWindow = 131072;
         }
         {
+          # contextWindow OMITTED on purpose: this rung exercises the derivation
+          # from `programs.mlx.modelContextWindows` below. Without a rung that
+          # leaves it null, the suite could only ever prove the hand-written
+          # path and would pass unchanged if the derivation were deleted.
           name = "subagent-local2";
           id = "test-local/tiny-4bit";
-          contextWindow = 32768;
         }
       ];
+      # The catalog side of that derivation. Keyed by physical model id, the
+      # same shape options-catalog.nix builds from real entries.
+      programs.mlx.modelContextWindows = {
+        "test-local/tiny-4bit" = 32768;
+      };
       services.aiStack = {
         llmEndpoint = "router";
         llmRouterEndpoint = "https://llm.example.invalid/v1";

--- a/lib/checks-fixtures.nix
+++ b/lib/checks-fixtures.nix
@@ -227,30 +227,33 @@ rec {
   # and a typo in one of them would pass CI.
   hmConfigLitellmLocal = mkHmConfig [
     {
-      programs.litellmLocal.enable = true;
-      # Local rungs are what give the subagent tier real depth: this host's own
-      # models first, the shared router appended automatically as the terminal
-      # rung. Declared here so the fallback-tier check asserts against the
-      # shape a real host uses, not against an empty chain.
-      programs.litellmLocal.localModels = [
-        {
-          name = "subagent";
-          id = "test-local/small-4bit";
-          contextWindow = 131072;
-        }
-        {
-          # contextWindow OMITTED on purpose: this rung exercises the derivation
-          # from `programs.mlx.modelContextWindows` below. Without a rung that
-          # leaves it null, the suite could only ever prove the hand-written
-          # path and would pass unchanged if the derivation were deleted.
-          name = "subagent-local2";
-          id = "test-local/tiny-4bit";
-        }
-      ];
-      # The catalog side of that derivation. Keyed by physical model id, the
-      # same shape options-catalog.nix builds from real entries.
-      programs.mlx.modelContextWindows = {
-        "test-local/tiny-4bit" = 32768;
+      programs = {
+        litellmLocal.enable = true;
+        # Local rungs are what give the subagent tier real depth: this host's own
+        # models first, the shared router appended automatically as the terminal
+        # rung. Declared here so the fallback-tier check asserts against the
+        # shape a real host uses, not against an empty chain.
+        litellmLocal.localModels = [
+          {
+            name = "subagent";
+            id = "test-local/small-4bit";
+            contextWindow = 131072;
+          }
+          {
+            # contextWindow OMITTED on purpose: this rung exercises the
+            # derivation from `mlx.modelContextWindows` below. Without a rung
+            # that leaves it null, the suite could only ever prove the
+            # hand-written path and would pass unchanged if the derivation were
+            # deleted.
+            name = "subagent-local2";
+            id = "test-local/tiny-4bit";
+          }
+        ];
+        # The catalog side of that derivation. Keyed by physical model id, the
+        # same shape options-catalog.nix builds from real entries.
+        mlx.modelContextWindows = {
+          "test-local/tiny-4bit" = 32768;
+        };
       };
       services.aiStack = {
         llmEndpoint = "router";

--- a/lib/checks/litellm-local-fallbacks.nix
+++ b/lib/checks/litellm-local-fallbacks.nix
@@ -56,6 +56,14 @@ let
   # Declared as data and folded once below, rather than a run of
   # `assert x || throw ...` lines. One list is easier to extend, and the
   # failure message comes from the same place the condition does.
+  # The deployment for the rung whose contextWindow is derived, not declared.
+  derivedWindow =
+    let
+      hit = lib.findFirst (d: d.model_name == "subagent-local2") null (rendered.model_list or [ ]);
+    in
+    if hit == null then null else hit.model_info.max_input_tokens or null;
+  derivedWindowLanded = derivedWindow == 32768;
+
   fallbackTierChecks = [
     {
       ok = fallbackEntries != [ ];
@@ -80,6 +88,20 @@ let
     {
       ok = retriesConfigured;
       msg = "litellm_settings.num_retries must be greater than zero so a transient upstream failure is retried before it spends a fallback";
+    }
+    {
+      # The fixture declares `subagent-local2` with NO contextWindow, so the
+      # only way 32768 reaches the rendered config is the derivation from
+      # `programs.mlx.modelContextWindows` in modules/litellm-local/default.nix.
+      # Delete that derivation and this fails -- which is the point: without it
+      # the suite could only ever prove the hand-written path.
+      ok = derivedWindowLanded;
+      msg =
+        "the local rung declaring no contextWindow must inherit one from "
+        + "programs.mlx.modelContextWindows: without it LiteLLM cannot detect "
+        + "an overflow, and an oversized request is truncated by the local "
+        + "model instead of escaping to the shared router. Got: "
+        + builtins.toJSON derivedWindow;
     }
     {
       ok = mainTierNotInFallbacks;

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -58,9 +58,30 @@ let
   # Fallback chain for the subagent tier: this host's own models first, the
   # shared router as the terminal rung. Its own file to stay under the
   # .file-size.yml ceiling; see that file for why no cloud model is named here.
+  # Every local rung's serving window comes from the mlx catalog by default,
+  # never from a number typed at the call site.
+  # `programs.mlx.modelContextWindows` is already derived from the catalog entry
+  # that decides what this host actually serves, so the window exists in exactly
+  # one place. A second, hand-written copy would be free to disagree with the
+  # server, and the direction it would disagree in is the dangerous one: an
+  # OVER-declared window never trips the context-window escape, so an oversized
+  # request is truncated locally instead of reaching the router -- precisely the
+  # silent truncation the escape hatch exists to prevent. (The weights' own
+  # `max_position_embeddings` is the wrong number for this: it states what the
+  # architecture permits, not what this host's KV budget serves.)
+  #
+  # An id the catalog does not serve resolves to null and trips
+  # fallback-tier.nix's contextWindow assertion. That is intended -- naming a
+  # model this host does not serve is a build error, not a runtime 404.
+  mlxWindows = config.programs.mlx.modelContextWindows or { };
+  resolvedLocalModels = map (m: {
+    inherit (m) name id;
+    contextWindow = if m.contextWindow != null then m.contextWindow else mlxWindows.${m.id} or null;
+  }) cfg.localModels;
+
   fallbackTier = import ./fallback-tier.nix {
     inherit lib;
-    inherit (cfg) localModels;
+    localModels = resolvedLocalModels;
   };
 
   # Reuses the maintainer profile's single traces endpoint rather than adding a

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -146,11 +146,19 @@ rec {
       message = "litellm-local: fallback-tier rung names must be unique.";
     }
     {
-      assertion = lib.all (m: m ? contextWindow && m.contextWindow > 0) localModels;
+      # `!= null` FIRST, and Nix's `&&` short-circuits: a null contextWindow
+      # reaching `> 0` throws an opaque type error from deep in the module
+      # system instead of this message, which is precisely the case an operator
+      # is most likely to hit (a model id the mlx catalog does not serve).
+      assertion = lib.all (m: (m.contextWindow or null) != null && m.contextWindow > 0) localModels;
       message =
-        "litellm-local: every local rung must declare contextWindow. Without "
-        + "it LiteLLM cannot detect an overflow, and an oversized request is "
-        + "truncated by the model instead of escaping to the terminal rung.";
+        "litellm-local: every local rung needs a contextWindow, and one rung "
+        + "has none. It is normally DERIVED from programs.mlx.modelContextWindows, "
+        + "so the usual cause is naming an `id` the mlx catalog does not serve "
+        + "-- check the id, or set contextWindow explicitly for a model served "
+        + "outside the catalog. Without it LiteLLM cannot detect an overflow, "
+        + "and an oversized request is truncated by the model instead of "
+        + "escaping to the terminal rung.";
     }
     {
       # THE DRY GUARD. This is the assertion that keeps the duplication from

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -95,8 +95,23 @@ in
               description = "Model id as this host's own server serves it.";
             };
             contextWindow = lib.mkOption {
-              type = lib.types.ints.positive;
-              description = "Real serving window in tokens. Required: it is what lets LiteLLM detect an overflow and escape to the shared router instead of letting the model truncate silently.";
+              type = lib.types.nullOr lib.types.ints.positive;
+              default = null;
+              description = ''
+                Real serving window in tokens -- what lets LiteLLM detect an
+                overflow and escape to the shared router instead of letting the
+                model truncate silently.
+
+                Null (the default) DERIVES it from `programs.mlx.modelContextWindows`,
+                which the mlx catalog already computes for the model this host
+                serves. Leave it null: the catalog is the single source, and a
+                number written here is free to drift above the real window,
+                which silently disables the escape.
+
+                Set it only for a model served by something other than the mlx
+                catalog. An id the catalog does not serve and that carries no
+                explicit value fails the build.
+              '';
             };
           };
         }


### PR DESCRIPTION
## What changed

A local rung in `programs.litellmLocal.localModels` required a hand-written
`contextWindow`. `programs.mlx.modelContextWindows` already derives the same
value from the catalog entry that decides what the host serves.

`contextWindow` becomes `nullOr`, defaulting to the catalog lookup. An explicit
value stays available for a model served outside the catalog. An id the catalog
does not serve, carrying no explicit value, fails the build.

## Why the direction of drift matters

Two copies of one limit are free to disagree, and the disagreement is
asymmetric. An over-declared window never trips the context-window escape, so an
oversized request is truncated by the local model instead of escaping to the
shared router — the silent truncation the escape hatch exists to prevent.

The weights' own `max_position_embeddings` is not the right number either: it
states what the architecture permits, not what the host's KV budget serves.

## Test

A fixture rung now omits `contextWindow`, so the derivation is exercised rather
than only the hand-written path. A new check asserts the derived value reaches
the rendered config.

Verified in both directions:

- removing the derivation fails the build
- pointing the catalog at a different value fails the new check, naming the
  wrong value

`nix fmt` clean; the `lib/checks/` suite passes via the `nix eval` form
(`nix flake check` on darwin does not run it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how context-window limits reach LiteLLM for local subagent fallbacks; incorrect derivation or overrides could still allow silent local truncation instead of router escape, though build-time assertions and new checks mitigate that.
> 
> **Overview**
> **Local LiteLLM fallback rungs no longer require a hand-written `contextWindow`.** `programs.litellmLocal.localModels[].contextWindow` is now optional (`null` by default) and, when unset, is filled from `programs.mlx.modelContextWindows` keyed by the rung’s model `id` before the fallback tier is rendered. Explicit values remain for models outside the mlx catalog; missing catalog entries with no override still fail the build via updated `fallback-tier.nix` assertions and clearer operator messaging.
> 
> **Regression coverage** extends the litellm-local fixture with a rung that omits `contextWindow` plus catalog metadata, and adds a fallback-tier check that the rendered `subagent-local2` entry exposes `max_input_tokens` **32768**—so CI would fail if the derivation were removed or pointed at the wrong window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67eb17947d4677994db213dd41bbea348a7889f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->