### PR TITLE
feat(mlx): make vllm-mlx selectable so a batched lane can exist

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -105,6 +105,7 @@ in
 // (import ./checks/mlx-warmup.nix { inherit pkgs src; })
 // (import ./checks/mlx-model-extra-args.nix { inherit pkgs; })
 // (import ./checks/mlx-catalog.nix { inherit pkgs hmConfigCatalog; })
+// (import ./checks/mlx-backend-selection.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/mlx-proxy-logging.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/mlx-default-model.nix { inherit pkgs hmConfigDefaultModel; })
 // (import ./checks/mlx-catalog-roles.nix {

--- a/lib/checks/mlx-backend-selection.nix
+++ b/lib/checks/mlx-backend-selection.nix
@@ -1,0 +1,37 @@
+# Backend-selection contract for the MLX serving catalog.
+#
+# Split out of ./mlx-catalog.nix to stay under the .file-size.yml ceiling, the
+# same reason mlx-wedge-metricsfree.nix is its own file. The split is by
+# responsibility: this file asserts WHICH backend may be selected and on what
+# terms; mlx-catalog.nix asserts what the selected backend then compiles to.
+{ pkgs, hmConfigCatalog }:
+let
+  helpers = import ./helpers.nix { inherit pkgs; };
+in
+{
+  mlx-backend-selection =
+    let
+      c = hmConfigCatalog.config.programs.mlx;
+    in
+    # These two used to pin the backend to mlx-lm and forbid vllm-mlx outright.
+    # Both are now coherence checks rather than a policy pin, because the policy
+    # changed: measured at 4-way concurrency on 2026-09-01 the mlx-lm tier
+    # queued and stalled rather than batching (16.8s / 21.1s / 79.1s against a
+    # ~12s serial baseline, one request never returning), and a stalled request
+    # never releases llama-swap's admission slot. Which backend a host runs is
+    # that host's decision; what must hold either way is that the selection is
+    # coherent.
+    assert
+      builtins.elem c.modelServerBackend c.enabledBackends
+      || throw "catalog: the selected modelServerBackend must be listed in enabledBackends";
+    # NOT asserted here, deliberately, and worth knowing why:
+    # programs.mlx.continuousBatching DEFAULTS TO TRUE while the mlx-lm flag
+    # builder emits no --continuous-batching at all. So today's config reads as
+    # "batching on" against a backend that cannot batch, and nothing surfaces
+    # the discrepancy -- which is how a serial tier gets mistaken for Lane A.
+    # A guard rejecting that combination fails every current mlx-lm host, so it
+    # belongs with the fix (make the default backend-aware), not with the change
+    # that merely lifts the vllm-mlx deny. Tracked separately.
+    helpers.mkMarker "check-mlx-backend-selection"
+      "MLX backend selection: the selected backend is enabled, and the batching-default gap is documented where a reader will hit it";
+}

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -83,12 +83,25 @@ in
     assert
       c.modelContextWindows.${qwen36} == 65536
       || throw "catalog: Qwen3.6 must advertise its 65536-token declared window";
+    # These two used to pin the backend to mlx-lm and forbid vllm-mlx outright.
+    # Both are now coherence checks rather than a policy pin, because the policy
+    # changed: measured at 4-way concurrency on 2026-09-01 the mlx-lm tier
+    # queued and stalled rather than batching (16.8s / 21.1s / 79.1s against a
+    # ~12s serial baseline, one request never returning), and a stalled request
+    # never releases llama-swap's admission slot. Which backend a host runs is
+    # that host's decision; what must hold either way is that the selection is
+    # coherent.
     assert
-      c.modelServerBackend == "mlx-lm"
-      || throw "catalog: the goal judge must use the selected mlx_lm.server deployment path";
-    assert
-      c.enabledBackends == [ "mlx-lm" ]
-      || throw "catalog: official mlx-lm must be the only enabled backend; vllm-mlx must remain preserved but disabled";
+      builtins.elem c.modelServerBackend c.enabledBackends
+      || throw "catalog: the selected modelServerBackend must be listed in enabledBackends";
+    # NOT asserted here, deliberately, and worth knowing why:
+    # programs.mlx.continuousBatching DEFAULTS TO TRUE while the mlx-lm flag
+    # builder emits no --continuous-batching at all. So today's config reads as
+    # "batching on" against a backend that cannot batch, and nothing surfaces
+    # the discrepancy -- which is how a serial tier gets mistaken for Lane A.
+    # A guard rejecting that combination fails every current mlx-lm host, so it
+    # belongs with the fix (make the default backend-aware), not with the change
+    # that merely lifts the vllm-mlx deny. Tracked separately.
     # The watchdog is the only thing that notices a proxy that is up but not
     # serving, so on a host with a resident set it MUST be running. This used
     # to assert the opposite — that it stay disabled — back when its busy

--- a/lib/checks/mlx-catalog.nix
+++ b/lib/checks/mlx-catalog.nix
@@ -83,25 +83,6 @@ in
     assert
       c.modelContextWindows.${qwen36} == 65536
       || throw "catalog: Qwen3.6 must advertise its 65536-token declared window";
-    # These two used to pin the backend to mlx-lm and forbid vllm-mlx outright.
-    # Both are now coherence checks rather than a policy pin, because the policy
-    # changed: measured at 4-way concurrency on 2026-09-01 the mlx-lm tier
-    # queued and stalled rather than batching (16.8s / 21.1s / 79.1s against a
-    # ~12s serial baseline, one request never returning), and a stalled request
-    # never releases llama-swap's admission slot. Which backend a host runs is
-    # that host's decision; what must hold either way is that the selection is
-    # coherent.
-    assert
-      builtins.elem c.modelServerBackend c.enabledBackends
-      || throw "catalog: the selected modelServerBackend must be listed in enabledBackends";
-    # NOT asserted here, deliberately, and worth knowing why:
-    # programs.mlx.continuousBatching DEFAULTS TO TRUE while the mlx-lm flag
-    # builder emits no --continuous-batching at all. So today's config reads as
-    # "batching on" against a backend that cannot batch, and nothing surfaces
-    # the discrepancy -- which is how a serial tier gets mistaken for Lane A.
-    # A guard rejecting that combination fails every current mlx-lm host, so it
-    # belongs with the fix (make the default backend-aware), not with the change
-    # that merely lifts the vllm-mlx deny. Tracked separately.
     # The watchdog is the only thing that notices a proxy that is up but not
     # serving, so on a host with a resident set it MUST be running. This used
     # to assert the opposite — that it stay disabled — back when its busy

--- a/lib/checks/mlx-mtp-reachable.nix
+++ b/lib/checks/mlx-mtp-reachable.nix
@@ -94,9 +94,16 @@ in
     assert
       failures == [ ]
       || throw "mlx mtp: a config with an enabled modelMtpProfiles entry must satisfy every assertion, but ${toString (builtins.length failures)} failed:\n  ${failureMessages}";
+    # The pattern tracks the backend-selection assertion, whose WORDING changed
+    # on 2026-09-01 when the blanket vllm-mlx deny was replaced by a coherence
+    # guard. The INTENT this check defends is unchanged and is the reason it
+    # exists: whatever that assertion says, it must still admit a config that
+    # enables mlx-vlm-native for one model. The original exact-equality form
+    # (enabledBackends == [ "mlx-lm" ]) silently killed every MTP profile, and
+    # this check is what would catch a return to that shape.
     assert
-      assertionMatching ".*enabledBackends must not list vllm-mlx.*"
-      || throw "mlx mtp: the backend-policy assertion must admit a config enabling mlx-vlm-native for one model; back at enabledBackends == [ \"mlx-lm\" ] it has re-killed every MTP profile";
+      assertionMatching ".*must be listed in programs.mlx.enabledBackends.*"
+      || throw "mlx mtp: the backend-selection assertion must admit a config enabling mlx-vlm-native for one model; an exact-equality form re-kills every MTP profile";
     assert
       assertionMatching ".*requires the native mlx-vlm backend, a drafter.*"
       || throw "mlx mtp: the MTP profile assertion must hold for a correctly-formed profile (native backend, drafter set, matched concurrency, non-cluster)";

--- a/modules/mlx/assertions.nix
+++ b/modules/mlx/assertions.nix
@@ -16,9 +16,30 @@ in
     # modelMtpProfiles entry was rejected and the option was dead code. Same
     # intent, without forbidding the per-model overrides the OCR entry already
     # relies on. Full account in lib/checks/mlx-mtp-reachable.nix.
+    # Until 2026-09-01 this denied vllm-mlx outright ("preserved but
+    # disabled"). That posture is lifted, because the reason for it was the
+    # cost of switching and the reason against it is now measured: on
+    # 2026-09-01 the mlx-lm tier was driven at 4-way concurrency and produced
+    # 16.8s / 21.1s / 79.1s against a ~12s serial baseline, with one request
+    # never returning at all. Flat-ish latency under concurrency is what a
+    # batching server produces; that is queueing plus stalling. A stalled
+    # request also never fires llama-swap's deferred completion callback, so
+    # its admission reservation is never released -- which is the instant-429
+    # the agent fleet has been hitting.
+    #
+    # So the deny is replaced by coherence guards rather than removed: the
+    # selected backend must actually be enabled, and the vllm-only coupling
+    # assertions below still bind. Selecting vllm-mlx remains a HOST decision;
+    # nothing here changes which backend a host runs.
     {
-      assertion = cfg.modelServerBackend == "mlx-lm" && !(lib.elem "vllm-mlx" cfg.enabledBackends);
-      message = "programs.mlx.modelServerBackend must stay mlx-lm and enabledBackends must not list vllm-mlx; vllm-mlx remains preserved but disabled.";
+      assertion = lib.elem cfg.modelServerBackend cfg.enabledBackends;
+      message =
+        "programs.mlx.modelServerBackend (${cfg.modelServerBackend}) must be "
+        + "listed in programs.mlx.enabledBackends "
+        + "(${lib.concatStringsSep ", " cfg.enabledBackends}). Selecting a "
+        + "backend that was never enabled builds a launchd command against a "
+        + "server binary the closure does not contain, and fails at exec time "
+        + "rather than at evaluation.";
     }
     {
       assertion = cfg.singleModel == null || builtins.hasAttr cfg.singleModel allModels;


### PR DESCRIPTION
# Make vllm-mlx selectable so a batched lane can exist

## What changed

The catalog denied `vllm-mlx` outright ("preserved but disabled") and pinned
`modelServerBackend` to `mlx-lm`. This lifts that, replacing the blanket deny
with a coherence guard.

**Scope: this only makes the backend selectable.** No host changes backend
here, and nothing is converged.

## Why now — measured, not assumed

The deny's justification was switching cost. The case against it is now a
measurement rather than a config reading.

Driving the tier at 4-way concurrency on 2026-09-01, against a ~12s serial
baseline of the same prompt shape:

| requests | result |
| --- | --- |
| serial x6 | 200, 10.6–13.4s |
| concurrent x4 | 200 @ 16.8s, 200 @ 21.1s, 200 @ 79.1s, **one never returned** |

Flat-ish latency under concurrency is what a batching server produces. This is
queueing plus stalling.

The stall matters beyond latency: the proxy releases an admission reservation
on a deferred completion callback, so a request that never completes never
releases its slot. Leaked slots accumulate into a permanently full counter,
which presents as instant rate-limiting on an idle model — the failure the
agent fleet has been hitting.

`--continuous-batching` and `--enable-prefix-cache` are emitted only by the
`vllm-mlx` flag builder, so no batched lane can exist while the deny stands.

## The guard that replaces it

`modelServerBackend` must be listed in `enabledBackends`. That catches
selecting a server binary the closure does not contain — an exec-time failure —
at evaluation instead.

## Deliberately left out

Both are recorded as comments where a reader will hit them:

- `continuousBatching` **defaults to true** while the `mlx-lm` builder emits no
  such flag, so today's config reads as "batching on" against a backend that
  cannot batch, and nothing surfaces the discrepancy. A guard rejecting that
  combination fails every current `mlx-lm` host, so it belongs with the fix
  that makes the default backend-aware.
- `maxNumSeqs` is a hand-written `4` justified in prose, while the residency
  machinery could derive it. Changing a capacity constant needs its own review.

## Test

`mlx-mtp-reachable` pinned the old assertion's wording; its pattern now tracks
the new message. The intent it defends is unchanged and is why it exists: the
backend assertion must still admit a config enabling `mlx-vlm-native` for one
model, which the original exact-equality form silently killed.

Verified:

- the new guard **binds** — pointing the fixture at a backend absent from
  `enabledBackends` fails with the intended message
- the `lib/checks/` suite passes via the `nix eval` form (`nix flake check` on
  darwin does not run it)
- `statix` clean, `nix fmt` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MLX serving backend validation on a critical config path; impact is deferred until hosts opt into `vllm-mlx`, but misconfiguration could affect admission slots and fleet 429 behavior described in the PR.
> 
> **Overview**
> **Lifts the catalog/module policy that pinned `modelServerBackend` to `mlx-lm` and forbade `vllm-mlx` in `enabledBackends`**, so hosts can legally select a batched backend without changing any host config in this PR.
> 
> In `modules/mlx/assertions.nix`, the old deny is replaced by a **coherence guard**: `modelServerBackend` must appear in `programs.mlx.enabledBackends`, failing at evaluation instead of building a launchd command for a binary missing from the closure. **vllm-only coupling assertions (prefix cache, MTP, etc.) are unchanged.**
> 
> Catalog regression coverage is split: **`mlx-backend-selection.nix`** asserts the selected backend is enabled and documents why **`continuousBatching` default vs mlx-lm flags** is not enforced here; **`mlx-catalog.nix`** drops the mlx-lm-only backend pins. **`mlx-mtp-reachable`** now matches the new assertion wording so configs that enable **`mlx-vlm-native`** for MTP still evaluate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e88140b45489854f3ba0fc9f1a2778523142ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->