### PR TITLE
fix(mlx): clear the wedge streak on a tick with no healthy sibling

### DIFF
--- a/lib/checks/mlx-watchdog.nix
+++ b/lib/checks/mlx-watchdog.nix
@@ -87,6 +87,19 @@ in
     export MLX_WATCHDOG_PROBE_MODELS_JSON='["tool-calling"]'
     export MLX_WATCHDOG_BRAIN_MODEL=tool-calling
     export MLX_WATCHDOG_BUSY_GRACE=900
+    # This check's subject is the busy-grace ladder, and check_wedge sits ahead
+    # of that ladder with its own `exit 0` on a confirmed wedge. The scenarios
+    # below drive exactly the shape check_wedge scores as suspect (fast 429s,
+    # flat brain steps), so by the third invocation it would short-circuit and
+    # the ladder under test would never be reached.
+    #
+    # Raise its threshold out of range rather than omitting wedge-detect.sh
+    # from the assembly. Omitting it is what this check used to do, and the
+    # result was `check_wedge: command not found` on every invocation, swallowed
+    # by the `if` as "no wedge" -- a check of the shipped script that quietly
+    # ran a script that does not ship. The wedge path has its own coverage in
+    # mlx-wedge-detect.nix and mlx-wedge-metricsfree.nix.
+    export MLX_WATCHDOG_WEDGE_CONSECUTIVE=999999
     export MLX_WATCHDOG_COOLDOWN=90
     export MLX_WATCHDOG_CONFIG="$TMPDIR/llama-swap.json"
     export MLX_WATCHDOG_MARKER="$TMPDIR/last-kick"

--- a/lib/checks/mlx-watchdog.nix
+++ b/lib/checks/mlx-watchdog.nix
@@ -107,7 +107,11 @@ in
     # only exists once llama-swap-reap.sh is ahead of mlx-watchdog.sh in one
     # script (nix-ai#1423).
     combined="$TMPDIR/mlx-watchdog-combined.sh"
-    cat ${src}/modules/mlx/scripts/llama-swap-reap.sh ${src}/modules/mlx/scripts/mlx-watchdog.sh > "$combined"
+    cat ${
+      pkgs.lib.concatMapStringsSep " " (f: "${src}/modules/mlx/scripts/${f}") (
+        import ../../modules/mlx/watchdog-parts.nix
+      )
+    } > "$combined"
 
     printf '%s\n' '{"models":{"brain-physical":{"aliases":["tool-calling"]},"other-physical":{"aliases":["coding"]}}}' > "$MLX_WATCHDOG_CONFIG"
     printf 'busy\n' > "$FAKE_MODE_FILE"

--- a/lib/checks/mlx-wedge-detect.nix
+++ b/lib/checks/mlx-wedge-detect.nix
@@ -119,7 +119,11 @@ in
     # mlx_reap_orphan_ports once llama-swap-reap.sh is ahead of that
     # (nix-ai#1423).
     combined="$TMPDIR/mlx-watchdog-combined.sh"
-    cat ${src}/modules/mlx/scripts/llama-swap-reap.sh ${src}/modules/mlx/scripts/wedge-detect.sh ${src}/modules/mlx/scripts/mlx-watchdog.sh > "$combined"
+    cat ${
+      pkgs.lib.concatMapStringsSep " " (f: "${src}/modules/mlx/scripts/${f}") (
+        import ../../modules/mlx/watchdog-parts.nix
+      )
+    } > "$combined"
 
     printf '%s\n' '{"models":{"brain-physical":{"aliases":["tool-calling"]}}}' > "$MLX_WATCHDOG_CONFIG"
     printf '1\n' > "$MLX_WATCHDOG_MARKER"

--- a/lib/checks/mlx-wedge-detect.nix
+++ b/lib/checks/mlx-wedge-detect.nix
@@ -72,6 +72,17 @@ in
     ];
   } "bash ${src}/tests/test-wedge-classify.sh && touch $out";
 
+  # The sibling-control streak rule (stuck_busy_action, stuck-busy-streak.sh).
+  # Its own derivation rather than another line in the one above: the two
+  # functions answer different questions (is this a wedge / may this tick's
+  # evidence count), and a failure should name which contract broke.
+  mlx-stuck-busy-streak = pkgs.runCommand "check-mlx-stuck-busy-streak" {
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.coreutils
+    ];
+  } "bash ${src}/tests/test-stuck-busy-streak.sh && touch $out";
+
   mlx-wedge-recovery = pkgs.runCommand "check-mlx-wedge-recovery" { } ''
     export PATH=${fakeCurl}/bin:${fakeDate}/bin:${fakeSleep}/bin:${pkgs.bash}/bin:${pkgs.coreutils}/bin:${pkgs.gawk}/bin:${pkgs.jq}/bin:${pkgs.gnugrep}/bin
     export HOME="$TMPDIR/home"

--- a/lib/checks/mlx-wedge-metricsfree.nix
+++ b/lib/checks/mlx-wedge-metricsfree.nix
@@ -99,7 +99,11 @@ in
     export FAKE_LATENCY_S_FILE="$TMPDIR/latency"
 
     combined="$TMPDIR/mlx-watchdog-combined.sh"
-    cat ${src}/modules/mlx/scripts/llama-swap-reap.sh ${src}/modules/mlx/scripts/wedge-detect.sh ${src}/modules/mlx/scripts/mlx-watchdog.sh > "$combined"
+    cat ${
+      pkgs.lib.concatMapStringsSep " " (f: "${src}/modules/mlx/scripts/${f}") (
+        import ../../modules/mlx/watchdog-parts.nix
+      )
+    } > "$combined"
 
     printf '%s\n' '{"models":{"brain-physical":{"aliases":["tool-calling"]}}}' > "$MLX_WATCHDOG_CONFIG"
     printf '1\n' > "$MLX_WATCHDOG_MARKER"

--- a/modules/mlx/mlx-watchdog-pkg.nix
+++ b/modules/mlx/mlx-watchdog-pkg.nix
@@ -17,10 +17,9 @@ pkgs.writeShellApplication {
     gawk
     jq
   ];
-  text = lib.concatStringsSep "\n" [
-    (builtins.readFile ./scripts/llama-swap-reap.sh)
-    (builtins.readFile ./scripts/wedge-detect.sh)
-    (builtins.readFile ./scripts/stuck-busy-streak.sh)
-    (builtins.readFile ./scripts/mlx-watchdog.sh)
-  ];
+  # Parts and their order come from ./watchdog-parts.nix so the shipped script
+  # and the script every check exercises cannot drift apart.
+  text = lib.concatMapStringsSep "\n" (f: builtins.readFile (./scripts + "/${f}")) (
+    import ./watchdog-parts.nix
+  );
 }

--- a/modules/mlx/mlx-watchdog-pkg.nix
+++ b/modules/mlx/mlx-watchdog-pkg.nix
@@ -20,6 +20,7 @@ pkgs.writeShellApplication {
   text = lib.concatStringsSep "\n" [
     (builtins.readFile ./scripts/llama-swap-reap.sh)
     (builtins.readFile ./scripts/wedge-detect.sh)
+    (builtins.readFile ./scripts/stuck-busy-streak.sh)
     (builtins.readFile ./scripts/mlx-watchdog.sh)
   ];
 }

--- a/modules/mlx/scripts/mlx-watchdog.sh
+++ b/modules/mlx/scripts/mlx-watchdog.sh
@@ -454,7 +454,13 @@ fi
 # worker is never torn down on a guess, and this does not loosen it: it adds
 # evidence, not a restart path. Converting a day of silence into a page within
 # minutes is the whole requirement; the restart is optional and stays gated.
-if (( ${#busy_nonbrain[@]} > 0 )) && [[ -n "$healthy_sibling" ]]; then
+# One rule, evaluated once and used by both the accrual below and the clear
+# loop after it, so "consecutive" cannot mean two different things in the two
+# places. See scripts/stuck-busy-streak.sh for why a tick without a healthy
+# sibling must CLEAR rather than hold.
+if [[ -n "$healthy_sibling" ]]; then sibling_flag=yes; else sibling_flag=no; fi
+stuck_busy_mode="$(stuck_busy_action yes "$sibling_flag")"
+if (( ${#busy_nonbrain[@]} > 0 )) && [[ "$stuck_busy_mode" == "accrue" ]]; then
   for m in "${busy_nonbrain[@]}"; do
     marker="${stuck_busy_dir}/$(printf '%s' "$m" | tr '/:' '__')"
     streak=$(( $(read_int "$marker") + 1 ))
@@ -527,13 +533,31 @@ if (( ${#busy_nonbrain[@]} > 0 )) && [[ -n "$healthy_sibling" ]]; then
     fi
   done
 fi
-# Any model that answered healthy is not wedged -- drop its streak so a
-# recovered worker does not page on a stale count.
+# Drop the streak of every non-brain model that did NOT accrue this tick --
+# both a model that answered healthy (recovered, must not page on a stale
+# count) and a model still busy with no healthy sibling to serve as the
+# control. The second case is the one that used to freeze instead of clearing.
+# Every decision is logged, including the no-op, so a streak that never
+# advances is visible rather than silent.
 for m in "${probe_models[@]}"; do
-  if [[ "$m" != "$brain_model" ]] && ! printf '%s\n' "${busy_nonbrain[@]:-}" | grep -qxF "$m"; then
-    rm -f "${stuck_busy_dir}/$(printf '%s' "$m" | tr '/:' '__')" \
-          "${stuck_busy_dir}/$(printf '%s' "$m" | tr '/:' '__').alerted"
+  [[ "$m" == "$brain_model" ]] && continue
+  if printf '%s\n' "${busy_nonbrain[@]:-}" | grep -qxF "$m"; then
+    model_busy=yes
+  else
+    model_busy=no
   fi
+  if [[ "$(stuck_busy_action "$model_busy" "$sibling_flag")" == "accrue" ]]; then
+    continue
+  fi
+  marker="${stuck_busy_dir}/$(printf '%s' "$m" | tr '/:' '__')"
+  if [[ -s "$marker" ]]; then
+    if [[ "$model_busy" == "yes" ]]; then
+      echo "$(ts) mlx-watchdog: model ${m} still busy but no healthy sibling this tick -> clearing streak $(read_int "$marker") (no control, so the evidence cannot show a wedge)"
+    else
+      echo "$(ts) mlx-watchdog: model ${m} answered healthy -> clearing streak $(read_int "$marker")"
+    fi
+  fi
+  rm -f "$marker" "${marker}.alerted"
 done
 
 case "$brain_state" in

--- a/modules/mlx/scripts/stuck-busy-streak.sh
+++ b/modules/mlx/scripts/stuck-busy-streak.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# The sibling-control streak rule for the metrics-free wedge page.
+#
+# Split into its own file, concatenated ahead of mlx-watchdog.sh, for the same
+# reason wedge-detect.sh is: tests/test-stuck-busy-streak.sh sources this
+# directly and proves the rule without running the rest of the watchdog.
+#
+# WHY THIS IS A NAMED RULE AND NOT AN INLINE CONDITION
+#
+# The metrics-free page claims a model "refused every request for N CONSECUTIVE
+# checks while a sibling served normally", and on that claim it unloads the
+# model. Consecutive has to actually hold, because the healthy sibling is the
+# entire argument that this is a slot-accounting wedge rather than saturation.
+#
+# The first version accrued the streak only on qualifying ticks (model busy AND
+# some sibling healthy) and cleared it only for models that had stopped being
+# busy. A model that stayed busy while NO sibling was healthy therefore hit
+# neither path: the streak did not accrue, but it did not clear either -- it
+# FROZE.
+#
+# So a streak could sit across an arbitrarily long stretch of genuine host-wide
+# saturation and then reach the threshold on the next tick that happened to
+# have a healthy sibling. The page would report N consecutive checks that were
+# not consecutive, and would offer saturation-adjacent evidence as proof that
+# this was not saturation -- then unload the model on it.
+#
+# Holding is the bug. A tick with no healthy sibling has no control, so it
+# cannot support the claim; the only sound thing to do with the evidence
+# accumulated so far is discard it and start again once a control exists.
+# Clearing costs at most a delayed page on a real wedge (the streak rebuilds
+# within N ticks of a sibling being healthy), which is strictly better than an
+# unload fired on a claim that is not true.
+#
+# Args: <model_is_busy: yes|no> <a_sibling_is_healthy: yes|no>
+# Echoes: accrue | clear
+stuck_busy_action() {
+  local is_busy="${1:-no}" sibling_healthy="${2:-no}"
+  if [ "$is_busy" = "yes" ] && [ "$sibling_healthy" = "yes" ]; then
+    printf 'accrue\n'
+  else
+    printf 'clear\n'
+  fi
+}

--- a/modules/mlx/watchdog-parts.nix
+++ b/modules/mlx/watchdog-parts.nix
@@ -1,0 +1,29 @@
+# The watchdog script's assembly order, stated once.
+#
+# mlx-watchdog is not one file: it is several function-definition files
+# concatenated ahead of the driver, so each pure function can be sourced and
+# unit-tested on its own (tests/test-wedge-classify.sh,
+# tests/test-stuck-busy-streak.sh) without running the watchdog.
+#
+# That order used to be written out in four places -- mlx-watchdog-pkg.nix plus
+# three check derivations that rebuild the same script with fakes on PATH. A
+# fourth part was added to the package and not to the checks, and three checks
+# died with exit 127 on the now-undefined function. The shipped script and the
+# script the checks exercise were free to disagree, which is precisely what a
+# check of the shipped script must never be.
+#
+# So: relative filenames, in order, in one list. Consumers join them to the
+# path shape they need -- the package reads them from ./scripts, the checks
+# `cat` them out of the flake source.
+#
+# ORDER IS SIGNIFICANT. Every definition must precede its first caller:
+# reap_workers (mlx-watchdog.sh) calls mlx_reap_orphan_ports
+# (llama-swap-reap.sh), and the driver calls check_wedge (wedge-detect.sh) and
+# stuck_busy_action (stuck-busy-streak.sh). Append new parts ahead of the
+# driver, never after it.
+[
+  "llama-swap-reap.sh"
+  "wedge-detect.sh"
+  "stuck-busy-streak.sh"
+  "mlx-watchdog.sh"
+]

--- a/tests/test-stuck-busy-streak.sh
+++ b/tests/test-stuck-busy-streak.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Unit test for stuck_busy_action (modules/mlx/scripts/stuck-busy-streak.sh) —
+# the rule that decides whether the metrics-free wedge streak accrues or
+# clears on a given tick. No mocks: the function takes only scalar args and
+# does no I/O, so this sources the real shipped function directly.
+set -o errexit -o nounset -o pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+source "$repo_root/modules/mlx/scripts/stuck-busy-streak.sh"
+
+fail=0
+check() {
+  local label="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    echo "  ok   $label -> $got"
+  else
+    echo "  FAIL $label -> got '$got', want '$want'"
+    fail=1
+  fi
+}
+
+echo "only a busy model WITH a healthy control accrues:"
+check "busy + healthy sibling" accrue "$(stuck_busy_action yes yes)"
+
+echo "a recovered model clears (no stale count can page later):"
+check "not busy + healthy sibling" clear "$(stuck_busy_action no yes)"
+
+# The regression this file exists for. Before the fix this tick matched
+# neither the accrual branch nor the clear branch, so the streak FROZE: a
+# partial streak survived an arbitrarily long saturation gap and then paged
+# (and unloaded) claiming those checks had been consecutive.
+echo "busy with NO control clears rather than holding:"
+check "busy + no healthy sibling" clear "$(stuck_busy_action yes no)"
+
+echo "neither condition clears:"
+check "not busy + no healthy sibling" clear "$(stuck_busy_action no no)"
+
+echo "anything that is not an explicit yes is not a yes:"
+check "empty args" clear "$(stuck_busy_action '' '')"
+check "missing args" clear "$(stuck_busy_action)"
+check "busy spelled otherwise" clear "$(stuck_busy_action true yes)"
+
+exit "$fail"

--- a/tests/test-stuck-busy-streak.sh
+++ b/tests/test-stuck-busy-streak.sh
@@ -33,7 +33,7 @@ check "not busy + healthy sibling" clear "$(stuck_busy_action no yes)"
 echo "busy with NO control clears rather than holding:"
 check "busy + no healthy sibling" clear "$(stuck_busy_action yes no)"
 
-echo "neither condition clears:"
+echo "with neither condition met there is nothing to accrue, so it clears:"
 check "not busy + no healthy sibling" clear "$(stuck_busy_action no no)"
 
 echo "anything that is not an explicit yes is not a yes:"


### PR DESCRIPTION
## The defect

The metrics-free wedge page keeps a per-model streak. It accrued only on ticks
where the model was busy **and** some sibling model answered healthy, and it
cleared only for models that had stopped being busy.

A model that stayed busy while no sibling was healthy matched neither path. Its
streak did not advance — and did not reset. It froze.

A frozen streak survives an arbitrary gap, so a partial streak could sit
through a stretch where nothing on the host answered healthy and then reach the
threshold on the next tick that happened to have a healthy sibling. The page
reports those checks as consecutive when they were not, and the model is
unloaded on that report.

The sibling is the whole argument that the model is wedged rather than merely
saturated, so a tick without one carries no control and cannot extend the
evidence.

## The fix

The accrue-or-clear decision becomes one named rule in
`modules/mlx/scripts/stuck-busy-streak.sh`, used by both the accrual and the
clear loop so the two cannot mean different things by "consecutive". It clears
whenever the model is not accruing, including the busy-with-no-control case.

Clearing costs at most a delayed page on a real wedge — the streak rebuilds
within N ticks of a sibling being healthy — which is preferable to an unload
fired on a claim that is not true.

Both clear reasons are logged, so a streak discarded for want of a control is
visible rather than silent.

## Tests

`tests/test-stuck-busy-streak.sh` sources the shipped function directly and
covers all four input combinations plus the non-`yes` inputs. It is run by a
new `mlx-stuck-busy-streak` check derivation.

Falsified: inverting the rule's clear branch fails 6 of 7 cases, including the
busy-with-no-control case this exists for.

## Validation

- `nix fmt` — no drift
- `nix flake check` — exit 0
- `lib/checks/` regression suite via `nix eval --raw .#checks.x86_64-linux` — exit 0
- `shellcheck` on both new scripts — exit 0
- `tests/test-stuck-busy-streak.sh` run directly — exit 0

Found in review on https://github.com/dryvist/nix-ai/pull/1885.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the watchdog pages and may unload non-brain models on metrics-free hosts; behavior is intentionally stricter about streak validity but could delay alerts on real wedges until a sibling is healthy again.
> 
> **Overview**
> Fixes a bug where the **metrics-free wedge** per-model streak could **freeze** while a model stayed `busy` but no sibling answered healthy: it neither advanced nor reset, so a partial count could survive host-wide saturation and later trigger a page/unload claiming falsely **consecutive** checks with a healthy control.
> 
> The accrue-vs-clear decision is centralized in **`stuck_busy_action`** (`stuck-busy-streak.sh`), used for both streak accrual and the post-loop clear so “consecutive” is one rule. Ticks without a healthy sibling **clear** the streak (with logging); only busy + healthy sibling **accrue**.
> 
> **`watchdog-parts.nix`** defines the concatenation order once for **`mlx-watchdog-pkg.nix`** and the mlx check derivations (including the new part), avoiding drift that previously broke checks. The busy-grace check now raises **`MLX_WATCHDOG_WEDGE_CONSECUTIVE`** instead of omitting wedge detection (which caused a swallowed missing `check_wedge`). Adds **`tests/test-stuck-busy-streak.sh`** and the **`mlx-stuck-busy-streak`** Nix check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0375932a42b2590ebf03650aa3cf45498774f2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->