### PR TITLE
docs(mlx): state gpuMemoryUtilization's two bases, and fix an inverted rationale

### DIFF
--- a/modules/mlx/catalog-assertions.nix
+++ b/modules/mlx/catalog-assertions.nix
@@ -1,0 +1,51 @@
+# Catalog assertions, split out of options-catalog.nix.
+#
+# Extracted for the 12 KB per-file gate, and the split is along a real seam:
+# these four are the catalog's CONTRACT (what a selection may not do), while
+# what remains in options-catalog.nix is the option schema and the config it
+# generates. Nothing here reads anything the caller does not pass.
+{
+  lib,
+  cfg,
+  residentWeightGb,
+  selectedRoles,
+  residents,
+}:
+[
+  {
+    assertion = residentWeightGb <= cfg.residentWeightBudgetGb;
+    message = ''
+      programs.mlx.catalog: resident-class weights sum to ${toString residentWeightGb} GB,
+      exceeding residentWeightBudgetGb = ${toString cfg.residentWeightBudgetGb}.
+      Demote an entry to class = "swap" or raise the budget deliberately.
+    '';
+  }
+  {
+    assertion = lib.length selectedRoles == lib.length (lib.unique selectedRoles);
+    message = "programs.mlx.catalog: each logical role may be assigned to only one enabled catalog entry.";
+  }
+  {
+    # ttl is lifecycle for on-demand models; residents ignore it (they
+    # follow proxy.idleTtl), so a resident ttl tweak would be a silent
+    # no-op misconfiguration.
+    assertion = lib.all (name: residents.${name}.tweaks.ttl == null) (lib.attrNames residents);
+    message = ''
+      programs.mlx.catalog: tweaks.ttl is only meaningful on class = "swap"
+      entries — resident-class models follow programs.mlx.proxy.idleTtl.
+      Remove the ttl tweak from the resident entr(y/ies) or demote them.
+    '';
+  }
+  {
+    # Bound kept; its stated reason was wrong until 2026-09-01. It cited the
+    # cache-clear trip, which raising util moves further OUT of reach, not
+    # into serving load. The bound buys a ceiling on the allocation CAP —
+    # the half that protects anything. Bases: ./options-cache.nix.
+    assertion = cfg.gpuMemoryUtilization == null || cfg.gpuMemoryUtilization <= 0.85;
+    message = ''
+      programs.mlx.gpuMemoryUtilization must stay <= 0.85 on catalog hosts —
+      the per-worker allocation cap is gpuMemoryUtilization *
+      max_recommended_working_set_size, and above 0.85 a single worker may
+      claim almost the whole wired ceiling.
+    '';
+  }
+]

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -40,9 +40,15 @@
     };
 
     # gpuMemoryUtilization — a device fraction, NOT the share of the host given
-    # to inference (that is appleSiliconTunables.wiredLimitMb). It both caps each
-    # worker and places the engine's emergency KV-clear trip point, so it is
-    # coupled to the host ceiling and the two must be changed together.
+    # to inference (that is appleSiliconTunables.wiredLimitMb). It both caps
+    # each worker and places the engine's emergency KV-clear trip point.
+    #
+    # It is NOT, however, in a fixed relationship with the host ceiling. This
+    # header used to say the two "must be changed together", which implied the
+    # trip tracks the ceiling by a known margin. It does not: the cap and the
+    # trip are computed on different bases, so raising the ceiling moves one
+    # and not the other. Changing either still warrants looking at both — but
+    # re-derive the two numbers below rather than assuming a margin.
     #
     # THE CAP AND THE TRIP ARE COMPUTED ON DIFFERENT BASES. This is the single
     # most misread thing about this option, and the description below said
@@ -71,8 +77,12 @@
     # A third consumer (worker.py) sizes KV availability from hw.memsize * util
     # * 0.5, a third base again. Any reasoning about this option that names only
     # one base is reasoning about one third of the behaviour.
-    # Sizing rules, the invariant, and the re-derivation formula:
+    # Sizing rules and the re-derivation formula:
     # https://docs.jacobpevans.com/local-llm/memory-ceilings
+    # (That page states the invariant as footprint < trip < ceiling. With the
+    # bases above, the aggregate form of that invariant is unsatisfiable for
+    # any worker count, because the +0.05 offset is per worker and multiplies.
+    # Treat the cap as the protection until the page is corrected.)
     #
     # This is the per-worker enforcement layer that HardResourceLimits could not
     # provide (see launchd.nix) because it acts inside the worker process itself.

--- a/modules/mlx/options-cache.nix
+++ b/modules/mlx/options-cache.nix
@@ -43,6 +43,34 @@
     # to inference (that is appleSiliconTunables.wiredLimitMb). It both caps each
     # worker and places the engine's emergency KV-clear trip point, so it is
     # coupled to the host ceiling and the two must be changed together.
+    #
+    # THE CAP AND THE TRIP ARE COMPUTED ON DIFFERENT BASES. This is the single
+    # most misread thing about this option, and the description below said
+    # "device_mem" for both until 2026-09-01, which is not what the engine does.
+    # Read from the installed vllm-mlx source, not its docs:
+    #
+    #   cap  = max_recommended_working_set_size * util   (engine/batched.py)
+    #   trip = memory_size * min(util + 0.05, 0.99)      (engine_core.py)
+    #
+    # max_recommended_working_set_size tracks iogpu.wired_limit_mb exactly when
+    # that sysctl is set; memory_size is PHYSICAL RAM. On a 128 GiB host wired
+    # to 100 GiB those bases differ by 28 GiB, so the trip is not 5% above the
+    # cap -- at util 0.8 the cap is 80 GiB and the trip is 108.8 GiB.
+    #
+    # CONSEQUENCE, and it holds at this option's own default: a trip above the
+    # wired ceiling can never fire. The emergency clear is reachable only while
+    #
+    #   (util + 0.05) * memory_size < wired ceiling
+    #
+    # which on that host means util < 0.7315. At the default 0.8 the valve is
+    # inert. Treat the CAP as the protection and the trip as absent until this
+    # is fixed properly -- and note the trip reads mx.get_active_memory(), which
+    # is per PROCESS, so it could never bound two resident workers in aggregate
+    # regardless of where it sits.
+    #
+    # A third consumer (worker.py) sizes KV availability from hw.memsize * util
+    # * 0.5, a third base again. Any reasoning about this option that names only
+    # one base is reasoning about one third of the behaviour.
     # Sizing rules, the invariant, and the re-derivation formula:
     # https://docs.jacobpevans.com/local-llm/memory-ceilings
     #
@@ -52,7 +80,7 @@
     gpuMemoryUtilization = lib.mkOption {
       type = lib.types.nullOr (lib.types.numbers.between 0.05 1.0);
       default = 0.8;
-      description = "Fraction of device memory each worker may allocate via Metal (vllm-mlx --gpu-memory-utilization), also used as the emergency cache-clear trip point at device_mem*(util+0.05). Coupled to the host wired ceiling — the invariant is footprint < trip < ceiling, so override this only together with appleSiliconTunables.wiredLimitMb. Null = upstream default (0.90). Override DOWN for a host that needs interactive desktop headroom.";
+      description = "Fraction each worker may allocate via Metal (vllm-mlx --gpu-memory-utilization). The allocation cap is max_recommended_working_set_size*util; the emergency cache-clear trip is a DIFFERENT base, memory_size*(util+0.05), so the trip can sit above the wired ceiling and never fire — see the comment above before changing this. Null = upstream default (0.90). Override DOWN for a host that needs interactive desktop headroom.";
     };
 
     # bufferCacheLimitGb — per-worker cap on MLX's RETAINED free-buffer cache

--- a/modules/mlx/options-catalog.nix
+++ b/modules/mlx/options-catalog.nix
@@ -184,38 +184,15 @@ in
 
   config = lib.mkIf (cfg.enable && enabled != { }) {
     programs.mlx.modelContextWindows = catalogContextWindows;
-    assertions = [
-      {
-        assertion = residentWeightGb <= cfg.residentWeightBudgetGb;
-        message = ''
-          programs.mlx.catalog: resident-class weights sum to ${toString residentWeightGb} GB,
-          exceeding residentWeightBudgetGb = ${toString cfg.residentWeightBudgetGb}.
-          Demote an entry to class = "swap" or raise the budget deliberately.
-        '';
-      }
-      {
-        assertion = lib.length selectedRoles == lib.length (lib.unique selectedRoles);
-        message = "programs.mlx.catalog: each logical role may be assigned to only one enabled catalog entry.";
-      }
-      {
-        # ttl is lifecycle for on-demand models; residents ignore it (they
-        # follow proxy.idleTtl), so a resident ttl tweak would be a silent
-        # no-op misconfiguration.
-        assertion = lib.all (name: residents.${name}.tweaks.ttl == null) (lib.attrNames residents);
-        message = ''
-          programs.mlx.catalog: tweaks.ttl is only meaningful on class = "swap"
-          entries — resident-class models follow programs.mlx.proxy.idleTtl.
-          Remove the ttl tweak from the resident entr(y/ies) or demote them.
-        '';
-      }
-      {
-        assertion = cfg.gpuMemoryUtilization == null || cfg.gpuMemoryUtilization <= 0.85;
-        message = ''
-          programs.mlx.gpuMemoryUtilization must stay <= 0.85 on catalog hosts —
-          above that the Metal cache-clear trip sits inside normal serving load.
-        '';
-      }
-    ];
+    assertions = import ./catalog-assertions.nix {
+      inherit
+        lib
+        cfg
+        residentWeightGb
+        selectedRoles
+        residents
+        ;
+    };
 
     programs.mlx = {
       # Registry models (residents + role-registered swaps) read


### PR DESCRIPTION
## What was wrong

`gpuMemoryUtilization` was documented as placing both the per-worker allocation
cap and the emergency cache-clear trip at one `device_mem` fraction. The engine
uses two different bases:

```
cap  = max_recommended_working_set_size * util
trip = memory_size * min(util + 0.05, 0.99)
```

A third consumer sizes KV availability from physical memory again. So one knob
drives three consumers across two denominators.

`max_recommended_working_set_size` tracks `iogpu.wired_limit_mb` when that
sysctl is set; `memory_size` is physical RAM. Where those differ, the trip is
not a small margin above the cap — on a 128 GiB machine wired to 100 GiB, a
0.8 fraction gives an 80 GiB cap and a 108.8 GiB trip, i.e. a trip above the
ceiling, which can never fire.

The trip also reads per-process active memory, so it cannot bound several
resident workers in aggregate regardless of where it sits.

## What this changes

Documentation and one assertion message. **No numeric defaults are changed.**

- Write out both bases and the condition under which the trip is reachable,
  so a reader can check it instead of assuming a 5% margin.
- The catalog assertion capping the fraction at 0.85 cited the trip as its
  reason, which is inverted — a larger fraction moves the trip further out of
  reach. The bound is kept; its real value is a ceiling on the allocation cap,
  and the failure message now says that.

## Split

`options-catalog.nix` sat just under the per-file gate, so any edit crossed it.
Split along a real seam: the catalog's contract (its assertions) versus its
option schema and generated config. The new file takes everything it needs as
arguments and reads nothing implicitly.

## Validation

- `nix fmt` — no drift
- `nix flake check` — exit 0
- `lib/checks/` regression via `nix eval --raw .#checks.x86_64-linux` — exit 0
- All three touched files under the gate (10908 / 2170 / 8407 bytes)
- **Falsified after the split**: making the moved bound impossible fails
  evaluation with the expected message; restoring it returns exit 0. The
  assertion did not become inert by moving.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No default or runtime value changes—only Nix comments, option descriptions, assertion messages, and a mechanical assertion split validated by flake checks.
> 
> **Overview**
> **Documentation-only** for `gpuMemoryUtilization` in `options-cache.nix`: the option no longer implies a single `device_mem` fraction or that the wired ceiling and emergency trip move together. Comments and the mkOption description now spell out separate engine formulas (cap on `max_recommended_working_set_size`, trip on physical `memory_size`, plus a third KV sizing path), when the trip can be unreachable above the wired ceiling, and that the **allocation cap** should be treated as the real guardrail.
> 
> The catalog **≤ 0.85** check is unchanged numerically but its failure text is corrected—it previously blamed the cache-clear trip (higher `util` pushes the trip *away*, not into serving load). The message now states the bound limits per-worker cap vs the wired ceiling.
> 
> To stay under a per-file size gate, the four catalog assertions move into new `catalog-assertions.nix` and are imported from `options-catalog.nix` with explicit arguments; behavior is the same aside from the updated assertion wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93b0bc443b27b8304eceb85dfcaa0e4c035f8e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->