### PR TITLE
fix(mlx): add the wheel hashes for the pinned mlx version

### DIFF
--- a/modules/mlx/python-overlay.nix
+++ b/modules/mlx/python-overlay.nix
@@ -77,9 +77,18 @@ let
   # "3.14" -> "cp314", the wheel's interpreter/ABI tag.
   cpTag = "cp" + (pkgs.lib.replaceStrings [ "." ] [ "" ] py.pythonVersion);
 
-  # Hashes are per (version, platform). Both wheels move together with the mlx
-  # pin in lib/versions.nix; bumping the pin without updating these fails the
-  # build loudly rather than silently resolving something else.
+  # Keyed by mlx VERSION ONLY, and valid for the default wheelPlatform above.
+  # A caller that overrides wheelPlatform fetches a different wheel while this
+  # map still hands back the default platform's hash, so the fetch fails on a
+  # hash mismatch. That is loud, not silent — nix verifies the hash — but it is
+  # a mismatch error rather than a message about the override, so: overriding
+  # wheelPlatform means supplying hashes for that platform too. No platform
+  # dimension is modelled here because every host this serves resolves the same
+  # target; add one when that stops being true rather than in advance.
+  #
+  # Both wheels move together with the mlx pin in lib/versions.nix; bumping the
+  # pin without updating these fails the build loudly rather than silently
+  # resolving something else.
   #
   # THE PIN AND THIS TABLE ARE UPDATED BY DIFFERENT HANDS. Renovate moves
   # versions.mlx on its own and knows nothing about this map, so an automated
@@ -108,6 +117,8 @@ let
     };
   };
 
+  # The message names the platform actually in effect, so an override that
+  # needs its own hashes says which target to prefetch for.
   hashes =
     wheelHashes.${versions.mlx}
       or (throw "python-overlay.nix: no wheel hashes for mlx ${versions.mlx}. Add them to wheelHashes (nix-prefetch-url the cp${cpTag}/${wheelPlatform} wheels from PyPI).");

--- a/modules/mlx/python-overlay.nix
+++ b/modules/mlx/python-overlay.nix
@@ -80,10 +80,31 @@ let
   # Hashes are per (version, platform). Both wheels move together with the mlx
   # pin in lib/versions.nix; bumping the pin without updating these fails the
   # build loudly rather than silently resolving something else.
+  #
+  # THE PIN AND THIS TABLE ARE UPDATED BY DIFFERENT HANDS. Renovate moves
+  # versions.mlx on its own and knows nothing about this map, so an automated
+  # bump lands a version with no entry here and every aarch64-darwin build
+  # stops at the throw below. That is the designed behaviour, not a surprise --
+  # but it means a renovate mlx PR is not complete until someone adds the row.
+  #
+  # To add one, take the version from lib/versions.nix and prefetch both wheels
+  # for this file's cpTag and wheelPlatform:
+  #
+  #   nix-prefetch-url --type sha256 <pypi url for mlx-<v>-cp314-cp314-<plat>.whl>
+  #   nix-prefetch-url --type sha256 <pypi url for mlx_metal-<v>-py3-none-<plat>.whl>
+  #   nix hash convert --hash-algo sha256 --to sri <each result>
+  #
+  # Superseded versions are kept rather than replaced: the map is keyed by the
+  # pin, so there is no ambiguity about which row is live, and keeping them
+  # means rolling the pin back does not also require re-deriving hashes.
   wheelHashes = {
     "0.32.0" = {
       mlx = "sha256-I+g8jnSiMVZpbp+ZBdFqF7fSe1pZbBvA9yCpjfHFqt8=";
       mlxMetal = "sha256-OvdqSY2EgE9mEZgASZ+dFD19/7CHig3Q18KEblhWX9c=";
+    };
+    "0.32.2" = {
+      mlx = "sha256-NQNhfjqmqOQR31MjbVvKA5/MqXVW8a3hxOXMimTeUtI=";
+      mlxMetal = "sha256-5qvqyaxSZYMMnBVBtvlum+N6hcJEZ2OkatRmxjo4N6s=";
     };
   };
 


### PR DESCRIPTION
## The defect

`lib/versions.nix` pins mlx `0.32.2`, but `wheelHashes` in
`modules/mlx/python-overlay.nix` only had a row for `0.32.0`. Any
aarch64-darwin build that reaches this overlay therefore stops at:

```
error: python-overlay.nix: no wheel hashes for mlx 0.32.2.
```

Found while building a darwin system closure against the current release — the
build cannot complete on Apple silicon until this row exists.

## Why it happened, and why it will happen again

The pin and the table are moved by different hands. Renovate bumps
`versions.mlx` and knows nothing about this map, so an automated mlx PR lands a
version with no entry and the next Apple-silicon build fails.

That failure is the designed behaviour — the file already says bumping the pin
without updating these "fails the build loudly rather than silently resolving
something else", and it did exactly that. The gap is that nothing says a
renovate mlx PR is incomplete until someone adds the row, so the next one will
land the same way.

The file now says so, and records the two prefetch commands that derive a row.

## Superseded rows are kept, not replaced

The map is keyed by the pin, so there is no ambiguity about which row is live,
and keeping the old one means rolling the pin back does not also require
re-deriving hashes.

## Validation

Both hashes were derived by prefetching the published wheels for this file's
`cpTag` and `wheelPlatform`, then converting to SRI. Verified by rebuilding the
darwin system closure that previously failed at the throw.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Nix fetch-hash and comment-only changes for Apple-silicon MLX wheels; no runtime logic beyond supplying verified wheel digests.
> 
> **Overview**
> Unblocks **aarch64-darwin** builds where `versions.mlx` is **0.32.2** but `wheelHashes` only knew **0.32.0**, which triggered the intentional `throw` during PyPI wheel fetch.
> 
> Adds SRI hashes for the **mlx** and **mlx_metal** wheels at that version (default `cpTag` / `macosx_26_0_arm64`), keeps the **0.32.0** row for rollback, and expands inline docs: hashes are version-keyed only, **Renovate** can bump the pin without updating this table, and the exact **nix-prefetch-url** steps to add a row. The missing-hash error message now references the active **`wheelPlatform`** when prefetching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6bff996db3acaa219d775ec58ecbcbac92eeb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->