### PR TITLE
fix(litellm-local): make the terminal rung name a group the router serves

### DIFF
--- a/lib/checks-fixtures.nix
+++ b/lib/checks-fixtures.nix
@@ -228,31 +228,33 @@ rec {
   hmConfigLitellmLocal = mkHmConfig [
     {
       programs = {
-        litellmLocal.enable = true;
-        # Required once localModels is non-empty: the terminal rung forwards
-        # the requested group name upstream, so it must name a group the shared
-        # router serves rather than passing through the local rung's own name.
-        litellmLocal.routerEntryModel = "test-router-entry";
-        # Local rungs are what give the subagent tier real depth: this host's own
-        # models first, the shared router appended automatically as the terminal
-        # rung. Declared here so the fallback-tier check asserts against the
-        # shape a real host uses, not against an empty chain.
-        litellmLocal.localModels = [
-          {
-            name = "subagent";
-            id = "test-local/small-4bit";
-            contextWindow = 131072;
-          }
-          {
-            # contextWindow OMITTED on purpose: this rung exercises the
-            # derivation from `mlx.modelContextWindows` below. Without a rung
-            # that leaves it null, the suite could only ever prove the
-            # hand-written path and would pass unchanged if the derivation were
-            # deleted.
-            name = "subagent-local2";
-            id = "test-local/tiny-4bit";
-          }
-        ];
+        litellmLocal = {
+          enable = true;
+          # Required once localModels is non-empty: the terminal rung forwards
+          # the requested group name upstream, so it must name a group the shared
+          # router serves rather than passing through the local rung's own name.
+          routerEntryModel = "test-router-entry";
+          # Local rungs are what give the subagent tier real depth: this host's own
+          # models first, the shared router appended automatically as the terminal
+          # rung. Declared here so the fallback-tier check asserts against the
+          # shape a real host uses, not against an empty chain.
+          localModels = [
+            {
+              name = "subagent";
+              id = "test-local/small-4bit";
+              contextWindow = 131072;
+            }
+            {
+              # contextWindow OMITTED on purpose: this rung exercises the
+              # derivation from `mlx.modelContextWindows` below. Without a rung
+              # that leaves it null, the suite could only ever prove the
+              # hand-written path and would pass unchanged if the derivation were
+              # deleted.
+              name = "subagent-local2";
+              id = "test-local/tiny-4bit";
+            }
+          ];
+        };
         # The catalog side of that derivation. Keyed by physical model id, the
         # same shape options-catalog.nix builds from real entries.
         mlx.modelContextWindows = {

--- a/lib/checks-fixtures.nix
+++ b/lib/checks-fixtures.nix
@@ -229,6 +229,10 @@ rec {
     {
       programs = {
         litellmLocal.enable = true;
+        # Required once localModels is non-empty: the terminal rung forwards
+        # the requested group name upstream, so it must name a group the shared
+        # router serves rather than passing through the local rung's own name.
+        litellmLocal.routerEntryModel = "test-router-entry";
         # Local rungs are what give the subagent tier real depth: this host's own
         # models first, the shared router appended automatically as the terminal
         # rung. Declared here so the fallback-tier check asserts against the

--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -137,6 +137,7 @@ in
     hmConfigLitellmLocal
     ;
 })
+// (import ./checks/litellm-local-negative.nix { inherit pkgs mkHmConfig; })
 // (import ./checks/fabric.nix {
   inherit
     pkgs

--- a/lib/checks/litellm-local-fallbacks.nix
+++ b/lib/checks/litellm-local-fallbacks.nix
@@ -47,6 +47,14 @@ let
   );
   contextFallbacksAreExplicit = lib.all (t: lib.elem t renderedGroups) contextFallbackTargets;
 
+  # The last rung in the rendered model_list is the terminal one.
+  terminalEntry = lib.last rendered.model_list;
+  terminalParams = terminalEntry.litellm_params or { };
+  # A bare wildcard passes the caller's own group name through. Acceptable only
+  # when the terminal rung IS the group consumers address; the fixture declares
+  # local rungs, so here it must name the router's group explicitly.
+  terminalNamesUpstreamGroup = (terminalParams.model or "openai/*") != "openai/*";
+
   retriesConfigured = (settings.num_retries or 0) > 0;
 
   # The main tier gets retries and a context-window repair, never a silent
@@ -102,6 +110,24 @@ let
         + "an overflow, and an oversized request is truncated by the local "
         + "model instead of escaping to the shared router. Got: "
         + builtins.toJSON derivedWindow;
+    }
+    {
+      # The terminal rung is a wildcard passthrough, so LiteLLM forwards the
+      # REQUESTED group name upstream. While the rung is named
+      # `subagent-homelab`, forwarding that name reaches a router that does not
+      # serve it: the rung then 404s as a fallback AND when addressed directly,
+      # so the chain ends on something that cannot answer. Observed live on a
+      # converged host before this check existed.
+      #
+      # Asserting the rendered param, not the option, because the option can be
+      # set and still not reach the config.
+      ok = terminalNamesUpstreamGroup;
+      msg =
+        "the terminal rung must forward a group the shared router serves, not "
+        + "pass through its own name: with local rungs declared the rung is "
+        + "named `subagent-homelab`, and `openai/*` forwards THAT upstream, "
+        + "which 404s. Rendered terminal params: "
+        + builtins.toJSON terminalParams;
     }
     {
       ok = mainTierNotInFallbacks;

--- a/lib/checks/litellm-local-fallbacks.nix
+++ b/lib/checks/litellm-local-fallbacks.nix
@@ -48,12 +48,22 @@ let
   contextFallbacksAreExplicit = lib.all (t: lib.elem t renderedGroups) contextFallbackTargets;
 
   # The last rung in the rendered model_list is the terminal one.
-  terminalEntry = lib.last rendered.model_list;
+  #
+  # `lib.last` THROWS on an empty list, which would abort evaluation with a
+  # builtins error instead of failing this check with its own message — turning
+  # the most degenerate case (nothing rendered at all) into the least legible
+  # one. Guard it so an empty or missing model_list falls through to a normal
+  # failing check.
+  renderedList = rendered.model_list or [ ];
+  terminalEntry = if renderedList == [ ] then { } else lib.last renderedList;
   terminalParams = terminalEntry.litellm_params or { };
   # A bare wildcard passes the caller's own group name through. Acceptable only
   # when the terminal rung IS the group consumers address; the fixture declares
   # local rungs, so here it must name the router's group explicitly.
-  terminalNamesUpstreamGroup = (terminalParams.model or "openai/*") != "openai/*";
+  # An absent model_list has no terminal rung, so it cannot be naming an
+  # upstream group: fail rather than pass vacuously.
+  terminalNamesUpstreamGroup =
+    renderedList != [ ] && (terminalParams.model or "openai/*") != "openai/*";
 
   retriesConfigured = (settings.num_retries or 0) > 0;
 
@@ -138,5 +148,9 @@ let
   firstFallbackFailure = lib.findFirst (c: !c.ok) null fallbackTierChecks;
 in
 {
-  inherit firstFallbackFailure;
+  # `terminalNamesUpstreamGroup` is exported for lib/checks/
+  # litellm-local-negative.nix only. `firstFallbackFailure` stops at the
+  # first failing check, and an empty model_list fails an earlier one, so the
+  # empty-list guard on `lib.last` is unreachable through it.
+  inherit firstFallbackFailure terminalNamesUpstreamGroup;
 }

--- a/lib/checks/litellm-local-negative.nix
+++ b/lib/checks/litellm-local-negative.nix
@@ -1,0 +1,90 @@
+# litellm-local — negative cases.
+#
+# Every other litellm-local check proves a correct config renders correctly.
+# These two prove the guards that catch a WRONG config still fire. Remove the
+# fix each one names and the case here stops failing, which is the only way a
+# guard is worth having.
+#
+# Split from lib/checks/litellm-local.nix for the per-file 12KB gate.
+{
+  pkgs,
+  mkHmConfig,
+}:
+let
+  inherit (pkgs) lib;
+  helpers = import ./helpers.nix { inherit pkgs; };
+
+  # ---- empty model_list must fail as a check, not as a builtins error ------
+  # `lib.last` throws on an empty list. Without the guard in
+  # litellm-local-fallbacks.nix this evaluation raises
+  # `lists.last: list must not be empty!`, aborting the suite with a stack
+  # trace instead of the terminal-rung check's own message.
+  #
+  # Read through the exported flag rather than `firstFallbackFailure`: that
+  # helper returns the FIRST failing check, and an empty model_list already
+  # fails the explicit-groups check well before the terminal one, so the guard
+  # is unreachable through it.
+  emptyModelListIsFalseNotThrow =
+    (import ./litellm-local-fallbacks.nix {
+      inherit lib;
+      rendered = {
+        model_list = [ ];
+        litellm_settings.num_retries = 3;
+      };
+    }).terminalNamesUpstreamGroup == false;
+
+  # ---- routerEntryModel must be a plain router group name -----------------
+  # One fixture, one variable. Everything else is valid, so a failed
+  # evaluation can only be the routerEntryModel assertion -- and the positive
+  # control below proves the fixture itself is sound. home-manager throws on
+  # ANY failed assertion the moment `config` is touched, so catch it with
+  # tryEval rather than reading `config.assertions`, which throws first.
+  routerEntryEvaluates =
+    routerEntryModel:
+    let
+      cfg = mkHmConfig [
+        {
+          programs.litellmLocal = {
+            inherit routerEntryModel;
+            enable = true;
+            localModels = [
+              {
+                name = "subagent";
+                id = "test-local/small-4bit";
+                contextWindow = 131072;
+              }
+            ];
+          };
+          services.aiStack = {
+            llmEndpoint = "router";
+            llmRouterEndpoint = "https://llm.example.invalid/v1";
+            llmEndpointTokenFile = "/run/secrets/LLM_ROUTER_BEARER";
+          };
+        }
+      ];
+    in
+    (builtins.tryEval (builtins.deepSeq cfg.config.programs.litellmLocal.renderedConfig true)).success;
+
+  # Null, empty, and provider-prefixed all render cleanly and all 404 at
+  # runtime; only a bare group name is valid.
+  rejectedRouterEntries = [
+    null
+    ""
+    "openai/x"
+  ];
+  everyBadRouterEntryRejected = lib.all (v: routerEntryEvaluates v == false) rejectedRouterEntries;
+  plainGroupNameAccepted = routerEntryEvaluates "test-router-entry";
+in
+{
+  litellm-local-negative =
+    assert
+      emptyModelListIsFalseNotThrow
+      || throw "an empty model_list must make the terminal-rung check FALSE, not throw: restore the `renderedList == [ ]` guard around `lib.last` in lib/checks/litellm-local-fallbacks.nix";
+    assert
+      everyBadRouterEntryRejected
+      || throw "programs.litellmLocal.routerEntryModel must reject null, \"\" and a provider-prefixed value while localModels is non-empty; got evaluation results ${builtins.toJSON (map routerEntryEvaluates rejectedRouterEntries)}";
+    assert
+      plainGroupNameAccepted
+      || throw "a plain router group name must satisfy the routerEntryModel assertion; got ${builtins.toJSON plainGroupNameAccepted}";
+    helpers.mkMarker "check-litellm-local-negative" "litellm-local: an empty model_list fails as a check not a throw, and routerEntryModel rejects null/empty/provider-prefixed";
+}

--- a/modules/litellm-local/commands.nix
+++ b/modules/litellm-local/commands.nix
@@ -48,6 +48,23 @@ let
     '';
   };
 
+  # The probe, on a schedule, paging when a rung stops answering. The probe
+  # itself was already "the only check that settles it" (fallback-tier.nix) and
+  # nothing ran it, so a converged host could carry a correct config and a rung
+  # that 404s every request with the machine having no opinion about it.
+  fallbackWatch = pkgs.writeShellApplication {
+    name = "litellm-fallback-watch";
+    runtimeInputs = [
+      pkgs.curl
+      pkgs.python3
+      pkgs.coreutils
+    ];
+    text = ''
+      LITELLM_PROBE_BIN=${fallbackProbe}/bin/litellm-fallback-probe \
+        exec ${./../scripts/litellm-fallback-watch.sh} "$@"
+    '';
+  };
+
   proxyScript = pkgs.writeShellScript "litellm-local-start" ''
     set -euo pipefail
     OPENAI_API_KEY="$(cat ${lib.escapeShellArg (toString aiStack.llmEndpointTokenFile)})"
@@ -67,6 +84,7 @@ in
 {
   inherit
     fallbackProbe
+    fallbackWatch
     proxyScript
     ;
 }

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -131,6 +131,7 @@ let
   };
   inherit (commands)
     fallbackProbe
+    fallbackWatch
     proxyScript
     ;
 
@@ -166,6 +167,7 @@ in
           cfg
           aiStack
           proxyScript
+          fallbackWatch
           telemetryTracesEndpoint
           ;
       };

--- a/modules/litellm-local/default.nix
+++ b/modules/litellm-local/default.nix
@@ -82,6 +82,7 @@ let
   fallbackTier = import ./fallback-tier.nix {
     inherit lib;
     localModels = resolvedLocalModels;
+    inherit (cfg) routerEntryModel;
   };
 
   # Reuses the maintainer profile's single traces endpoint rather than adding a

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -49,6 +49,10 @@
   localModels ? [ ],
   localEndpointEnvVar ? "LOCAL_LLM_URL",
   terminalName ? "subagent-homelab",
+  # The group the shared router serves. Null keeps the bare wildcard, which is
+  # only correct when the terminal rung carries the name consumers already send
+  # upstream (the localModels == [] case below).
+  routerEntryModel ? null,
 }:
 let
   # Every rung this host serves itself, in declared order. `contextWindow` is
@@ -77,10 +81,21 @@ let
   # provider, no model id, no price. Whatever the router decides to do behind
   # this — its own local legs, then its cloud rungs — is the router's business
   # and is configured exactly once, over there.
+  # `openai/*` is a PASSTHROUGH: LiteLLM forwards whatever group name the
+  # caller asked for. That is correct only while the rung's own name is a name
+  # the router serves. The moment localModels is non-empty the rung is renamed
+  # to subagent-homelab, and forwarding THAT upstream 404s — the rung then
+  # fails when addressed directly, not merely as a fallback, so the chain ends
+  # on something that cannot answer.
+  #
+  # Observed on a converged host 2026-09-01: a direct request to
+  # subagent-homelab returned "no router for requested model", and a fallback
+  # into it reported "Error doing the fallback: NotFoundError". Naming the
+  # upstream group explicitly is what makes the last rung reachable.
   terminal = {
     model_name = effectiveTerminalName;
     litellm_params = {
-      model = "openai/*";
+      model = if routerEntryModel == null then "openai/*" else "openai/${routerEntryModel}";
       api_base = "os.environ/LLM_ROUTER_URL";
       api_key = "os.environ/OPENAI_API_KEY";
     };
@@ -144,6 +159,21 @@ rec {
     {
       assertion = lib.length (lib.unique names) == lib.length names;
       message = "litellm-local: fallback-tier rung names must be unique.";
+    }
+    {
+      # Makes the broken shape impossible rather than merely fixable. Without
+      # this the config renders cleanly, the proxy starts, and the failure only
+      # appears when something actually falls back — which is the worst moment
+      # to discover the last rung cannot answer.
+      assertion = localModels == [ ] || routerEntryModel != null;
+      message =
+        "litellm-local: set programs.litellmLocal.routerEntryModel once "
+        + "localModels is non-empty. The terminal rung forwards the requested "
+        + "group name upstream, and with local models declared that name is "
+        + "`${terminalName}`, which the shared router does not serve — so the "
+        + "rung 404s both as a fallback and when addressed directly, leaving "
+        + "the chain with no working last rung. Name the router's own entry "
+        + "group (a group name, not a provider or model id).";
     }
     {
       # `!= null` FIRST, and Nix's `&&` short-circuits: a null contextWindow

--- a/modules/litellm-local/fallback-tier.nix
+++ b/modules/litellm-local/fallback-tier.nix
@@ -165,15 +165,26 @@ rec {
       # this the config renders cleanly, the proxy starts, and the failure only
       # appears when something actually falls back — which is the worst moment
       # to discover the last rung cannot answer.
-      assertion = localModels == [ ] || routerEntryModel != null;
+      # Null is not the only broken value. The rung renders as
+      # "openai/${routerEntryModel}", so "" yields a bare `openai/` and a value
+      # that already carries a provider yields `openai/openai/...` — both
+      # render cleanly and both 404 at runtime, which is the same
+      # config-looks-right/rung-is-dead failure this option exists to end.
+      # Requiring a plain group name also holds the rule that no provider is
+      # named on this host.
+      assertion =
+        localModels == [ ]
+        || (routerEntryModel != null && routerEntryModel != "" && !(lib.hasInfix "/" routerEntryModel));
       message =
-        "litellm-local: set programs.litellmLocal.routerEntryModel once "
-        + "localModels is non-empty. The terminal rung forwards the requested "
-        + "group name upstream, and with local models declared that name is "
-        + "`${terminalName}`, which the shared router does not serve — so the "
-        + "rung 404s both as a fallback and when addressed directly, leaving "
-        + "the chain with no working last rung. Name the router's own entry "
-        + "group (a group name, not a provider or model id).";
+        "litellm-local: programs.litellmLocal.routerEntryModel must be a "
+        + "non-empty router GROUP name with no `/` once localModels is "
+        + "non-empty (got ${builtins.toJSON routerEntryModel}). The terminal "
+        + "rung renders as `openai/<value>` and forwards it upstream: null or "
+        + "an empty value leaves the rung forwarding `${terminalName}`, which "
+        + "the shared router does not serve, and a provider-prefixed value "
+        + "renders `openai/openai/...`. All three render cleanly and 404 at "
+        + "runtime. Name the router's own entry group — a group name, not a "
+        + "provider or model id.";
     }
     {
       # `!= null` FIRST, and Nix's `&&` short-circuits: a null contextWindow

--- a/modules/litellm-local/launchd.nix
+++ b/modules/litellm-local/launchd.nix
@@ -19,10 +19,15 @@
   cfg,
   aiStack,
   proxyScript,
+  fallbackWatch,
   telemetryTracesEndpoint,
 }:
 let
   logDir = "${config.home.homeDirectory}/Library/Logs/litellm-local";
+  # Same operator-seeded pager the mlx watchdog uses. Deliberately the SAME
+  # file: a host with a pager configured should not have to seed a second one
+  # to learn that its fallback chain died.
+  alertUrlFile = "${config.home.homeDirectory}/.config/mlx-cluster/alert-url";
 in
 {
   litellm-local = {
@@ -69,4 +74,34 @@ in
     };
   };
 
+  # ALERT ON ABSENCE OF SUCCESS. KeepAlive above restarts the proxy only when
+  # the process EXITS, so every "up but not serving" mode is invisible to
+  # launchd — and a fallback rung that 404s every request keeps the proxy
+  # perfectly healthy. Config inspection cannot see it either: a rung's params
+  # can render exactly right and still name a group the upstream does not
+  # serve.
+  #
+  # So this sends a REAL completion to every rung on an interval and pages when
+  # one stops answering. Its own agent, not folded into the proxy: this reaches
+  # the network and must never be able to restart something that was serving
+  # fine.
+  litellm-fallback-watch = {
+    enable = true;
+    config = {
+      Label = "dev.litellm-fallback-watch";
+      ProgramArguments = [ "${fallbackWatch}/bin/litellm-fallback-watch" ];
+      # Not RunAtLoad: a converge bounces the proxy, and probing it mid-restart
+      # would page on the restart rather than on a dead rung.
+      RunAtLoad = false;
+      StartInterval = 900;
+      ProcessType = "Background";
+      EnvironmentVariables = {
+        HOME = config.home.homeDirectory;
+        LITELLM_LOCAL_URL = "http://127.0.0.1:${toString cfg.port}";
+        LITELLM_ALERT_URL_FILE = alertUrlFile;
+      };
+      StandardOutPath = "${logDir}/fallback-watch.log";
+      StandardErrorPath = "${logDir}/fallback-watch.error.log";
+    };
+  };
 }

--- a/modules/litellm-local/options.nix
+++ b/modules/litellm-local/options.nix
@@ -133,6 +133,28 @@ in
       '';
     };
 
+    routerEntryModel = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "hermes-default";
+      description = ''
+        The model group the SHARED ROUTER serves, that this host's terminal
+        rung forwards to.
+
+        Required once localModels is non-empty, and the reason is not obvious:
+        the terminal rung is a wildcard passthrough, so LiteLLM forwards the
+        REQUESTED group name upstream. With local models declared, the terminal
+        rung is named `subagent-homelab`, so a fallback forwards
+        `subagent-homelab` to the router — a name the router does not serve,
+        which 404s. The rung then fails not only as a fallback but when
+        addressed directly, so the chain has no working last rung at all.
+
+        This is a GROUP name, not a provider, model id, or price — naming it
+        here keeps the "no cloud policy on this host" rule intact while making
+        the rung actually reachable.
+      '';
+    };
+
     localEndpoint = lib.mkOption {
       type = lib.types.str;
       default = "http://127.0.0.1:11434/v1";

--- a/modules/scripts/litellm-fallback-watch.sh
+++ b/modules/scripts/litellm-fallback-watch.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Run the fallback-chain probe on a schedule and page when a rung stops
+# answering.
+#
+# WHY THIS EXISTS. litellm-fallback-probe already sends a real completion to
+# every rung, and fallback-tier.nix already says it is "the only check that
+# settles it" — but nothing ran it. So a converged host could carry a rendered
+# config that was entirely correct and a terminal rung that returned 404 to
+# every request, and the machine had no opinion about it. That is exactly the
+# shape this estate keeps getting caught by: config inspection is a claim,
+# a completion is behaviour.
+#
+# It pages on ABSENCE OF SUCCESS, not on an error being logged somewhere. The
+# probe exits non-zero unless EVERY rung serves, and a partial chain is the
+# dangerous case: it still serves traffic, so nothing looks wrong until the
+# last rung fails too.
+#
+# EVERY DECISION IS LOGGED, including the no-op. A watcher that is silent when
+# it does nothing is indistinguishable from one that never ran.
+set -euo pipefail
+
+ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
+# Indent a captured block for the log. Parameter expansion rather than a sed
+# pipe: the linter flags that form (SC2001), and this is one process fewer.
+indent() { printf '    %s\n' "${1//$'\n'/$'\n'    }"; }
+
+PROBE="${LITELLM_PROBE_BIN:?litellm-fallback-watch: LITELLM_PROBE_BIN not set}"
+ALERT_URL_FILE="${LITELLM_ALERT_URL_FILE:-}"
+STATE_DIR="${LITELLM_WATCH_STATE_DIR:-$HOME/Library/Caches/litellm-local}"
+# Consecutive failures before paging. One failure is a restart or a model
+# reload; the rung being genuinely gone survives several.
+CONSECUTIVE="${LITELLM_WATCH_CONSECUTIVE:-2}"
+# Re-page interval, so a rung that stays dead does not spam and does not go
+# quiet either.
+REPAGE_SECONDS="${LITELLM_WATCH_REPAGE_SECONDS:-21600}"
+
+mkdir -p "$STATE_DIR"
+STREAK_FILE="$STATE_DIR/fallback-probe-failures"
+PAGED_FILE="$STATE_DIR/fallback-probe-last-page"
+
+read_int() { [ -r "$1" ] && tr -cd '0-9' < "$1" | head -c 12 || true; }
+
+alert() {
+  local msg="$1"
+  if [ -z "$ALERT_URL_FILE" ] || [ ! -s "$ALERT_URL_FILE" ]; then
+    echo "$(ts) litellm-fallback-watch: WOULD PAGE but no alert url is seeded: $msg" >&2
+    return 0
+  fi
+  curl -fsS --max-time 20 -X POST -H 'Content-Type: application/json' \
+    --data "$(printf '{"text":%s}' "$(printf '%s' "$msg" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")" \
+    "$(cat "$ALERT_URL_FILE")" >/dev/null \
+    && echo "$(ts) litellm-fallback-watch: paged" \
+    || echo "$(ts) litellm-fallback-watch: PAGE DELIVERY FAILED" >&2
+}
+
+output=$("$PROBE" 2>&1) && rc=0 || rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  streak=$(read_int "$STREAK_FILE")
+  if [ -n "${streak:-}" ] && [ "${streak:-0}" -gt 0 ] 2>/dev/null; then
+    echo "$(ts) litellm-fallback-watch: chain healthy again after ${streak} failed check(s) -> clearing"
+  else
+    echo "$(ts) litellm-fallback-watch: every rung served a completion -> ok, nothing to do"
+  fi
+  rm -f "$STREAK_FILE" "$PAGED_FILE"
+  exit 0
+fi
+
+streak=$(( $(read_int "$STREAK_FILE" || echo 0) + 1 ))
+printf '%s\n' "$streak" > "$STREAK_FILE"
+
+if [ "$streak" -lt "$CONSECUTIVE" ]; then
+  echo "$(ts) litellm-fallback-watch: probe failed ${streak}/${CONSECUTIVE} (rc=${rc}) -> watching, not paging yet"
+  indent "$output"
+  exit 0
+fi
+
+now=$(date -u +%s)
+last=$(read_int "$PAGED_FILE" || echo 0)
+last=${last:-0}
+if [ "$last" -gt 0 ] && [ $(( now - last )) -lt "$REPAGE_SECONDS" ]; then
+  echo "$(ts) litellm-fallback-watch: still failing (streak ${streak}), last page $(( (now - last) / 60 ))m ago -> holding until ${REPAGE_SECONDS}s"
+  exit 0
+fi
+
+printf '%s\n' "$now" > "$PAGED_FILE"
+echo "$(ts) litellm-fallback-watch: WEDGE — probe failed ${streak} consecutive checks (rc=${rc})" >&2
+indent "$output" >&2
+alert "$(/bin/hostname -s): a local LLM fallback rung stopped serving — the probe failed ${streak} consecutive checks. A rung can 404 while the rendered config stays correct, so inspect with litellm-fallback-probe rather than reading the config. Probe output: ${output}"
+exit 1


### PR DESCRIPTION
## The defect

The terminal rung rendered as:

```nix
litellm_params = {
  model = "openai/*";                 # wildcard passthrough
  api_base = "os.environ/LLM_ROUTER_URL";
};
```

`openai/*` forwards the **requested** group name upstream. That is correct only
while the rung's own name is one the shared router serves. Declaring
`localModels` renames the rung to `subagent-homelab`, and forwarding that name
reaches a router that has no such group.

So the rung returned 404 **as a fallback and when addressed directly** — the
chain ended on something that could not answer at all.

Observed on a converged host:

```
# direct
{"model":"subagent-homelab"} -> 404 "no router for requested model"

# as a fallback
{"model":"subagent"} -> local leg 429
  Available Model Group Fallbacks=['subagent-homelab']
  Error doing the fallback: NotFoundError ... 404
```

A host that opted into local models therefore had **no working fallback** —
strictly worse than the enumerated tier it replaced, which named real upstream
models.

## Why nothing caught it

`fallback-tier.nix` says so in its own header: *"WHAT THIS FILE CANNOT PROVE:
that a rung still answers. Catalog metadata is a claim, not behaviour."* It
names `litellm-fallback-probe` as the only check that settles it, and nothing
runs that at converge time.

## The fix

`routerEntryModel` names the group the router serves, and the terminal rung
forwards it explicitly. Required once `localModels` is non-empty, so the broken
shape cannot be configured rather than merely being fixable.

It is a group name — not a provider, model id, or price — so the rule that this
host names no cloud policy still holds.

## Tests

Covered twice, because the option can be set and still not reach the rendered
config: an assertion on the option, and a check on the rendered terminal params.

Falsified both ways:

- unsetting `routerEntryModel` with local rungs declared fails evaluation with
  its own message
- rendering a bare `openai/*` fails the rendered-config check

## Validation

- `nix fmt` — no drift
- `lib/checks/` regression via `nix eval --raw .#checks.x86_64-linux` — exit 0,
  and exit 1 in both falsification cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subagent fallback routing and requires `routerEntryModel` wherever local models are declared; misconfiguration fails at eval time, but hosts must set the new option on converge.
> 
> **Overview**
> Fixes a broken **local fallback chain** when `localModels` is set: the terminal rung was `openai/*`, which forwards the client’s group name (`subagent-homelab`) to the shared router and **404s**. Adds **`programs.litellmLocal.routerEntryModel`** so the last rung explicitly targets a router group (required when local rungs exist), with module assertions and flake checks on both the option and rendered terminal params.
> 
> Adds **`litellm-fallback-watch`**: a separate launchd job (every 15 minutes) that runs `litellm-fallback-probe`, tracks consecutive failures, and pages via the existing mlx-cluster alert URL when a rung stops serving—addressing the gap where config could look correct while the chain was dead.
> 
> Regression coverage includes **`litellm-local-negative`** (bad `routerEntryModel`, empty `model_list` without a `lib.last` throw) and an updated **`hmConfigLitellmLocal`** fixture with `routerEntryModel = "test-router-entry"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968fe5ffb99c1cfa43fded6371be7e37f173e6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->