### PR TITLE
feat(herdr): make the herdr guests deployable and run the hail bridge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,3 +14,42 @@ jobs:
     uses: dryvist/.github/.github/workflows/_release-please.yml@main
     secrets:
       GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}
+
+  # The LXC template tofu-proxmox's `nixos_ct_template_url` points at. Built
+  # here rather than in CI because a release is the only thing that gives the
+  # tarball a stable URL and a publishable sha256; nothing else consumes it.
+  publish-lxc-template:
+    name: Publish herdr LXC template
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@527f17dd63d2d60d3e5552934bc84b9a33a14d11 # v3
+
+      - name: Build the template
+        run: nix build .#herdr-lxc-template --out-link result --print-build-logs
+
+      # `nix build` succeeding is not evidence the artifact exists: the tarball
+      # derivation's internal layout is not part of any contract we own, so
+      # locate the file and fail loudly on zero or several rather than
+      # uploading whatever `find` happened to print first.
+      - name: Upload to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mapfile -t found < <(find -L result -type f -name '*.tar.xz' | sort)
+          if [ "${#found[@]}" -ne 1 ]; then
+            printf 'expected exactly one .tar.xz under result/, found %d:\n' "${#found[@]}" >&2
+            printf '  %s\n' "${found[@]}" >&2
+            exit 1
+          fi
+          tag="$(gh release view --json tagName --jq .tagName)"
+          sha256sum "${found[0]}"
+          gh release upload "$tag" "${found[0]}#nixos-herdr-lxc.tar.xz" --clobber

--- a/docs/architecture/plugin-scoping.md
+++ b/docs/architecture/plugin-scoping.md
@@ -160,4 +160,3 @@ problem and its own gate: `programs.agentSkills.groups` +
 Definitions belong in this repo (or in data merged from the instruction SSOT
 input); host configs (nix-darwin) only choose `activeGroups`. Regression
 coverage: `lib/checks/agent-skills.nix` (`agent-skills-groups`).
-

--- a/flake.lock
+++ b/flake.lock
@@ -504,6 +504,23 @@
         "type": "github"
       }
     },
+    "herdr-remote-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1788249624,
+        "narHash": "sha256-mTHcGe806gLnDdBo/K4QJlIDA8IkFWk2LYbQeuaELig=",
+        "owner": "dcolinmorgan",
+        "repo": "herdr-remote",
+        "rev": "1f5bd32b5121af92c21c9a3b123b10d508f29365",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dcolinmorgan",
+        "repo": "herdr-remote",
+        "rev": "1f5bd32b5121af92c21c9a3b123b10d508f29365",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -886,6 +903,7 @@
         "context-engineering-kit": "context-engineering-kit",
         "dashmotion": "dashmotion",
         "fabric-src": "fabric-src",
+        "herdr-remote-src": "herdr-remote-src",
         "home-manager": "home-manager",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",
         "karpathy-skills": "karpathy-skills",

--- a/flake.lock
+++ b/flake.lock
@@ -504,6 +504,23 @@
         "type": "github"
       }
     },
+    "herdr-hail-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784424997,
+        "narHash": "sha256-OSHT5D3RhZku0ktBCYyu/XZvlw/6WsYnI5UTdx4pJF8=",
+        "owner": "natori-hrj",
+        "repo": "herdr-hail",
+        "rev": "9f7120be96cfcc511548eb446ee4ca8b52519b31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "natori-hrj",
+        "repo": "herdr-hail",
+        "rev": "9f7120be96cfcc511548eb446ee4ca8b52519b31",
+        "type": "github"
+      }
+    },
     "herdr-remote-src": {
       "flake": false,
       "locked": {
@@ -903,6 +920,7 @@
         "context-engineering-kit": "context-engineering-kit",
         "dashmotion": "dashmotion",
         "fabric-src": "fabric-src",
+        "herdr-hail-src": "herdr-hail-src",
         "herdr-remote-src": "herdr-remote-src",
         "home-manager": "home-manager",
         "jacobpevans-cc-plugins": "jacobpevans-cc-plugins",

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,15 @@
       flake = false;
     };
 
+    # herdr-hail: the Slack/Discord bridge, an upstream herdr PLUGIN rather
+    # than a service of its own. Packaged here so it can run on the herdr
+    # guest against the local socket; pinned by rev for the same reason as
+    # herdr-remote-src above.
+    herdr-hail-src = {
+      url = "github:natori-hrj/herdr-hail/9f7120be96cfcc511548eb446ee4ca8b52519b31";
+      flake = false;
+    };
+
     # AI Assistant Instructions - source of truth for AI agent configuration.
     ai-assistant-instructions = {
       url = "github:JacobPEvans/ai-assistant-instructions";
@@ -219,6 +228,7 @@
       vct-cribl-cli,
       vct-splunk-cli,
       herdr-remote-src,
+      herdr-hail-src,
       ...
     }:
     let
@@ -273,7 +283,9 @@
       # System-level modules. herdr is the first thing this flake manages that
       # runs as a service on a Linux guest rather than a launchd agent on the
       # Mac, so this output is new — see flake/nixos-modules.nix.
-      nixosModules = import ./flake/nixos-modules.nix { inherit llm-agents herdr-remote-src; };
+      nixosModules = import ./flake/nixos-modules.nix {
+        inherit llm-agents herdr-remote-src herdr-hail-src;
+      };
 
       # Whole-guest configurations. `nixosModules` above are importable but not
       # deployable; ansible-proxmox-ai's nixos_deploy role dereferences
@@ -281,7 +293,7 @@
       # only — see flake/nixos-configurations.nix.
       nixosConfigurations = import ./flake/nixos-configurations.nix {
         inherit nixpkgs llm-agents;
-        nixosModules = self.nixosModules;
+        inherit (self) nixosModules;
       };
 
       # Extracted to flake/checks.nix to stay under the 12KB file-size gate.
@@ -307,8 +319,8 @@
           vct-cribl-cli
           vct-splunk-cli
           ;
-        nixosConfigurations = self.nixosConfigurations;
-        inherit herdr-remote-src;
+        inherit (self) nixosConfigurations;
+        inherit herdr-remote-src herdr-hail-src;
       };
 
       devShells = forAllSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,16 @@
       flake = false;
     };
 
+    # herdr-remote's relay (the web/phone dashboard half of herdr). Upstream
+    # ships no flake and no nixpkgs entry, so this is a source pin that
+    # modules/herdr-remote/package.nix builds. Pinned by REV, never a branch:
+    # this is a third-party repo and a branch ref would silently redeploy
+    # whatever landed upstream between converges.
+    herdr-remote-src = {
+      url = "github:dcolinmorgan/herdr-remote/1f5bd32b5121af92c21c9a3b123b10d508f29365";
+      flake = false;
+    };
+
     # AI Assistant Instructions - source of truth for AI agent configuration.
     ai-assistant-instructions = {
       url = "github:JacobPEvans/ai-assistant-instructions";
@@ -208,6 +218,7 @@
       awesome-claude-skills,
       vct-cribl-cli,
       vct-splunk-cli,
+      herdr-remote-src,
       ...
     }:
     let
@@ -262,7 +273,16 @@
       # System-level modules. herdr is the first thing this flake manages that
       # runs as a service on a Linux guest rather than a launchd agent on the
       # Mac, so this output is new — see flake/nixos-modules.nix.
-      nixosModules = import ./flake/nixos-modules.nix { inherit llm-agents; };
+      nixosModules = import ./flake/nixos-modules.nix { inherit llm-agents herdr-remote-src; };
+
+      # Whole-guest configurations. `nixosModules` above are importable but not
+      # deployable; ansible-proxmox-ai's nixos_deploy role dereferences
+      # `nixosConfigurations.<host>`, which is what this provides. x86_64-linux
+      # only — see flake/nixos-configurations.nix.
+      nixosConfigurations = import ./flake/nixos-configurations.nix {
+        inherit nixpkgs llm-agents;
+        nixosModules = self.nixosModules;
+      };
 
       # Extracted to flake/checks.nix to stay under the 12KB file-size gate.
       # Still x86_64-linux-scoped; see that file for why.
@@ -273,6 +293,7 @@
           home-manager
           nixAiLib
           ai-llm-prompts
+          herdr-remote-src
           ;
         src = ./.;
       };
@@ -286,6 +307,8 @@
           vct-cribl-cli
           vct-splunk-cli
           ;
+        nixosConfigurations = self.nixosConfigurations;
+        inherit herdr-remote-src;
       };
 
       devShells = forAllSystems (

--- a/flake.nix
+++ b/flake.nix
@@ -336,23 +336,8 @@
         }
       );
 
-      # Default overlay — injects every flake-exported package into pkgs.
-      # Consumers register this via:
-      #   nixpkgs.overlays = [ nix-ai.overlays.default ];
-      # Required when importing this flake's homeManagerModules, since those
-      # modules reference pkgs.<name> (e.g. modules/cecli/packages.nix uses
-      # pkgs.cecli). Any package added to `packages` above is automatically
-      # available — consumers do not need to enumerate package names.
-      #
-      # Use prev.stdenv.hostPlatform.system (not prev.system). The bare
-      # `system` attribute is a deprecated alias in nixpkgs whose
-      # warnAlias machinery triggers infinite recursion when evaluated
-      # inside an overlay during home-manager's _module.args.pkgs path.
-      # The stdenv check guards against the empty attrsets the
-      # flake schema validator passes (`overlay {} {}`).
-      overlays.default =
-        _final: prev:
-        if prev ? stdenv then self.packages.${prev.stdenv.hostPlatform.system} or { } else { };
+      # Extracted to flake/overlays.nix to stay under the 12KB file-size gate.
+      overlays = import ./flake/overlays.nix { inherit self; };
 
       # Formatter
       formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt-tree);

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -13,6 +13,7 @@
   home-manager,
   nixAiLib,
   ai-llm-prompts,
+  herdr-remote-src,
   src,
 }:
 let
@@ -97,6 +98,69 @@ in
         # untrusted there. deepSeq above does all the forcing; the content only
         # has to exist.
         builtins.deepSeq forced (pkgs.writeText "herdr-nixos-eval" "herdr NixOS module evaluated");
+      # herdr-remote's dependency list is TRANSCRIBED into
+      # modules/herdr-remote/package.nix from a PEP 723 block in upstream's
+      # herdr_relay.py, because upstream ships no lockfile and is run with
+      # `uv run`, which resolves from the network at start time — something a
+      # guest built from a pinned flake must not do.
+      #
+      # A transcription with nothing checking it is the whole problem: a new
+      # upstream import fails at RUNTIME on the guest with ModuleNotFoundError,
+      # long after the closure was built and copied. This re-parses that block
+      # from the pinned source and compares it to the list the package
+      # actually installs, so the drift fails the build on the controller.
+      #
+      # It asserts set EQUALITY, not "every declared dep is present" — the
+      # weaker form passes when upstream ADDS one, which is exactly the
+      # direction that breaks.
+      herdr-remote-pep723-deps =
+        let
+          inherit (nixpkgs) lib;
+          text = builtins.readFile "${herdr-remote-src}/relay/herdr_relay.py";
+          depLines = builtins.filter (l: lib.hasInfix "dependencies = [" l) (
+            lib.splitString "\n" text
+          );
+          # A missing block means upstream restructured the header. Fail loudly
+          # rather than silently comparing against an empty list, which would
+          # pass only when our own list was empty too.
+          # A missing block means upstream restructured the header. Fail loudly
+          # rather than silently comparing against an empty list, which would
+          # pass only when our own list was empty too.
+          depLine =
+            if depLines == [ ] then
+              throw "herdr-remote: no PEP 723 `dependencies = [` line in relay/herdr_relay.py -- upstream restructured its header; re-check modules/herdr-remote/package.nix by hand."
+            else
+              builtins.head depLines;
+          # Split on the quote character and keep the odd indices: those are
+          # exactly the quoted requirement strings. Deliberately NOT a bracket
+          # regex -- `[^]]` is valid POSIX but libstdc++'s ERE engine, which is
+          # what builtins.match uses, rejects it outright.
+          quoted = builtins.genList (
+            i: builtins.elemAt (lib.splitString "\"" depLine) (i * 2 + 1)
+          ) ((builtins.length (lib.splitString "\"" depLine) - 1) / 2);
+          # "websockets>=14.0" -> "websockets": keep the distribution name,
+          # drop every PEP 440 comparator.
+          nameOf =
+            req:
+            let
+              m = builtins.match "([A-Za-z0-9_.-]+).*" req;
+            in
+            if m == null then null else builtins.head m;
+          upstream = lib.sort (a: b: a < b) (
+            builtins.filter (x: x != null) (map nameOf quoted)
+          );
+          ours = lib.sort (a: b: a < b) self.packages.${system}.herdr-remote-relay.pep723Deps;
+        in
+        if upstream == ours then
+          pkgs.writeText "herdr-remote-pep723-deps" "matched: ${lib.concatStringsSep " " ours}"
+        else
+          throw ''
+            herdr-remote dependency drift.
+              upstream relay/herdr_relay.py PEP 723: ${lib.concatStringsSep " " upstream}
+              modules/herdr-remote/package.nix:      ${lib.concatStringsSep " " ours}
+            Reconcile package.nix's pep723Deps with upstream, then re-run.
+          '';
+
       orchestrator-prompt-assets =
         assert builtins.all (
           name: builtins.pathExists (ai-llm-prompts + "/applications/${name}.md")

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -117,9 +117,7 @@ in
         let
           inherit (nixpkgs) lib;
           text = builtins.readFile "${herdr-remote-src}/relay/herdr_relay.py";
-          depLines = builtins.filter (l: lib.hasInfix "dependencies = [" l) (
-            lib.splitString "\n" text
-          );
+          depLines = builtins.filter (l: lib.hasInfix "dependencies = [" l) (lib.splitString "\n" text);
           # A missing block means upstream restructured the header. Fail loudly
           # rather than silently comparing against an empty list, which would
           # pass only when our own list was empty too.
@@ -135,9 +133,9 @@ in
           # exactly the quoted requirement strings. Deliberately NOT a bracket
           # regex -- `[^]]` is valid POSIX but libstdc++'s ERE engine, which is
           # what builtins.match uses, rejects it outright.
-          quoted = builtins.genList (
-            i: builtins.elemAt (lib.splitString "\"" depLine) (i * 2 + 1)
-          ) ((builtins.length (lib.splitString "\"" depLine) - 1) / 2);
+          quoted = builtins.genList (i: builtins.elemAt (lib.splitString "\"" depLine) (i * 2 + 1)) (
+            (builtins.length (lib.splitString "\"" depLine) - 1) / 2
+          );
           # "websockets>=14.0" -> "websockets": keep the distribution name,
           # drop every PEP 440 comparator.
           nameOf =
@@ -146,9 +144,7 @@ in
               m = builtins.match "([A-Za-z0-9_.-]+).*" req;
             in
             if m == null then null else builtins.head m;
-          upstream = lib.sort (a: b: a < b) (
-            builtins.filter (x: x != null) (map nameOf quoted)
-          );
+          upstream = lib.sort (a: b: a < b) (builtins.filter (x: x != null) (map nameOf quoted));
           ours = lib.sort (a: b: a < b) self.packages.${system}.herdr-remote-relay.pep723Deps;
         in
         if upstream == ours then

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -121,9 +121,6 @@ in
           # A missing block means upstream restructured the header. Fail loudly
           # rather than silently comparing against an empty list, which would
           # pass only when our own list was empty too.
-          # A missing block means upstream restructured the header. Fail loudly
-          # rather than silently comparing against an empty list, which would
-          # pass only when our own list was empty too.
           depLine =
             if depLines == [ ] then
               throw "herdr-remote: no PEP 723 `dependencies = [` line in relay/herdr_relay.py -- upstream restructured its header; re-check modules/herdr-remote/package.nix by hand."

--- a/flake/nixos-configurations.nix
+++ b/flake/nixos-configurations.nix
@@ -1,0 +1,127 @@
+# Whole-guest NixOS configurations for the herdr estate.
+#
+# WHY THIS EXISTS. nixosModules.herdr is a module — importable, but not
+# deployable on its own. ansible-proxmox-ai's `nixos_deploy` role runs
+# `nixos-rebuild --flake github:dryvist/nix-ai#<host> --target-host ...`, and
+# that dereferences `nixosConfigurations.<host>`. Without this file the flake
+# exports the module and nothing can deploy it, which is the state the herdr
+# work was in: a module with no consumer and a role with no attribute.
+#
+# WHY x86_64-linux ONLY. These are Proxmox LXC guests on amd64 nodes. There is
+# no aarch64 node in the estate, and the workstation that orchestrates the
+# deploy is aarch64-darwin — it evaluates these fine but cannot BUILD them, so
+# the closure is built on the target or in CI. Same scoping as flake/checks.nix.
+#
+# WHY proxmox-lxc.nix RATHER THAN nixos-generators. nixpkgs ships the profile
+# itself (nixos/modules/virtualisation/proxmox-lxc.nix) and it produces
+# `config.system.build.tarball`, which is exactly the vztmpl Proxmox wants.
+# nixos-generators was deprecated in NixOS 25.05 and archived; depending on it
+# would add an input to replace something nixpkgs already does.
+{
+  nixpkgs,
+  llm-agents,
+  nixosModules,
+}:
+
+let
+  system = "x86_64-linux";
+
+  # Shared by every herdr guest. Kept minimal on purpose: everything that makes
+  # a guest DIFFERENT belongs in that guest's own module below, and everything
+  # the estate does uniformly (users, DNS, time) is Ansible's job, not this
+  # flake's. The rule this repo holds to is that nix owns the software and
+  # Ansible owns the orchestration.
+  base =
+    { lib, modulesPath, ... }:
+    {
+      imports = [ "${modulesPath}/virtualisation/proxmox-lxc.nix" ];
+
+      # An unprivileged LXC has no say over its own network, clock or kernel;
+      # Proxmox supplies all three. Declaring them here would produce units
+      # that fail on every boot for structural reasons.
+      proxmoxLXC = {
+        manageNetwork = false;
+        privileged = false;
+      };
+
+      # NOT set here: networking.useDHCP and networking.hostName. With
+      # manageNetwork/manageHostName false, proxmox-lxc.nix pins useDHCP to
+      # false and hostName to `mkForce ""` so the hypervisor owns both — which
+      # is why every guest's system derivation is named `...-unnamed-lxc-...`
+      # and why the estate's hostname lives in deployment.json, not here.
+      # Declaring either would be dead config that reads as intent.
+
+      # The guest is reached over SSH — both by `nixos-rebuild --target-host`
+      # pushing a closure and by `herdr --remote` shelling out. Passwords are
+      # off: the estate authenticates with certificates minted from the OpenBao
+      # SSH CA, and a password path would be a second, weaker way in.
+      services.openssh = {
+        enable = true;
+        settings = {
+          PasswordAuthentication = false;
+          KbdInteractiveAuthentication = false;
+        };
+      };
+
+      # nixos-rebuild --target-host copies a closure and activates it as root.
+      users.users.root.openssh.authorizedKeys.keys = lib.mkDefault [ ];
+
+      # Flakes, because the deploy IS a flake reference. A guest that cannot
+      # evaluate a flake cannot be re-converged from itself if the controller
+      # is ever unavailable.
+      nix.settings.experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+
+      # Pinned to the release these guests are first built against. Never
+      # advance this to "follow latest" — it is a compatibility declaration,
+      # not a version, and moving it silently migrates state formats.
+      system.stateVersion = "26.05";
+    };
+
+  mkGuest =
+    { modules }:
+    nixpkgs.lib.nixosSystem {
+      inherit system;
+      # hostName is the ATTRIBUTE name, not networking.hostName (forced empty
+      # above). `nixos-rebuild --flake ...#<hostName>` is what selects a guest,
+      # and ansible's nixos_deploy defaults that attribute to the inventory
+      # hostname — so these keys must match the guest hostnames in
+      # deployment.json exactly.
+      modules = [ base ] ++ modules;
+      specialArgs = { inherit llm-agents; };
+    };
+in
+{
+  # The runtime. Owns the terminals every coding agent runs in, and the only
+  # guest whose state (/var/lib/herdr — agent credentials, worktrees, session
+  # state) does not rebuild from the flake.
+  herdr = mkGuest {
+    modules = [
+      nixosModules.herdr
+      {
+        services.herdr = {
+          enable = true;
+          # Ansible writes this at 0600 out of band; the unit loads it with a
+          # leading `-`, so a first converge starts inert rather than failing.
+          environmentFile = "/var/lib/herdr/.env";
+        };
+      }
+    ];
+  };
+
+  # The web and phone dashboard. Drives the runtime over SSH via HERDR_REMOTES,
+  # so it holds no agent state of its own and is disposable by design.
+  herdr-ui = mkGuest {
+    modules = [
+      nixosModules.herdr-remote
+      {
+        services.herdr-remote = {
+          enable = true;
+          environmentFile = "/var/lib/herdr-remote/.env";
+        };
+      }
+    ];
+  };
+}

--- a/flake/nixos-modules.nix
+++ b/flake/nixos-modules.nix
@@ -9,12 +9,23 @@
 # modules through `_module.args`, never as function parameters.
 {
   llm-agents,
+  herdr-remote-src,
 }:
 {
   herdr = {
     imports = [ ../modules/herdr/nixos.nix ];
     _module.args = {
       inherit llm-agents;
+    };
+  };
+
+  # The dashboard half. Separate module because it is a separate guest with a
+  # separate blast radius: it holds no agent state and drives runtimes over
+  # SSH, so it never needs herdr's control socket.
+  herdr-remote = {
+    imports = [ ../modules/herdr-remote/nixos.nix ];
+    _module.args = {
+      inherit herdr-remote-src;
     };
   };
 }

--- a/flake/nixos-modules.nix
+++ b/flake/nixos-modules.nix
@@ -10,12 +10,13 @@
 {
   llm-agents,
   herdr-remote-src,
+  herdr-hail-src,
 }:
 {
   herdr = {
     imports = [ ../modules/herdr/nixos.nix ];
     _module.args = {
-      inherit llm-agents;
+      inherit llm-agents herdr-hail-src;
     };
   };
 

--- a/flake/overlays.nix
+++ b/flake/overlays.nix
@@ -1,0 +1,19 @@
+# Default overlay — injects every flake-exported package into pkgs.
+#
+# Consumers register this via:
+#   nixpkgs.overlays = [ nix-ai.overlays.default ];
+# Required when importing this flake's homeManagerModules, since those modules
+# reference pkgs.<name> (e.g. modules/cecli/packages.nix uses pkgs.cecli). Any
+# package added to `packages` is automatically available — consumers do not
+# need to enumerate package names.
+{ self }:
+{
+  # Use prev.stdenv.hostPlatform.system (not prev.system). The bare `system`
+  # attribute is a deprecated alias in nixpkgs whose warnAlias machinery
+  # triggers infinite recursion when evaluated inside an overlay during
+  # home-manager's _module.args.pkgs path. The stdenv check guards against the
+  # empty attrsets the flake schema validator passes (`overlay {} {}`).
+  default =
+    _final: prev:
+    if prev ? stdenv then self.packages.${prev.stdenv.hostPlatform.system} or { } else { };
+}

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -4,6 +4,8 @@
   fabric-src,
   vct-cribl-cli,
   vct-splunk-cli,
+  nixosConfigurations,
+  herdr-remote-src,
 }:
 
 forAllSystems (
@@ -24,5 +26,28 @@ forAllSystems (
     cecli = cecliPkg;
     inherit (cecliPkg.passthru) mcp;
     inherit (vctCliPkgs) vct-cribl-cli vct-splunk-cli;
+  }
+  // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
+    # The vztmpl tofu-proxmox downloads onto every commissioned node
+    # (modules/proxmox-stack/ct_templates.tf pins its URL and sha256).
+    #
+    # x86_64-linux ONLY, and that is not a portability oversight: the estate's
+    # nodes are amd64, and the workstation that drives the deploy is
+    # aarch64-darwin with no Linux builder — it cannot build this at all. CI
+    # builds it; exposing the attribute on darwin would only produce a
+    # confusing failure at build time instead of a clear absence at eval time.
+    #
+    # Built from the `herdr` guest so the template already carries the runtime
+    # closure: a guest created from it boots usable rather than needing a
+    # converge before it can do anything.
+    herdr-lxc-template = nixosConfigurations.herdr.config.system.build.tarball;
+
+    # Exposed as a package, not only as a module default, for two reasons: it
+    # gives CI something to actually BUILD (a module default is only ever
+    # evaluated), and it is where the herdr-remote-pep723-deps check reads
+    # `passthru.pep723Deps` from.
+    herdr-remote-relay = pkgs.callPackage ../modules/herdr-remote/package.nix {
+      src = herdr-remote-src;
+    };
   }
 )

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -6,6 +6,7 @@
   vct-splunk-cli,
   nixosConfigurations,
   herdr-remote-src,
+  herdr-hail-src,
 }:
 
 forAllSystems (
@@ -23,6 +24,14 @@ forAllSystems (
   in
   {
     fabric-ai = pkgs.callPackage ../modules/fabric/package.nix { inherit fabric-src; };
+
+    # All systems, unlike the two linux-only entries below: hail is portable
+    # node and the point of exposing it is that CI can BUILD it. A module
+    # default is only ever evaluated, and an npm lockfile hash that has never
+    # been fetched is one that is wrong without anything saying so.
+    herdr-hail = pkgs.callPackage ../modules/herdr-hail/package.nix {
+      src = herdr-hail-src;
+    };
     cecli = cecliPkg;
     inherit (cecliPkg.passthru) mcp;
     inherit (vctCliPkgs) vct-cribl-cli vct-splunk-cli;

--- a/modules/herdr-hail/package.nix
+++ b/modules/herdr-hail/package.nix
@@ -1,0 +1,77 @@
+# herdr-hail — the Slack/Discord bridge for herdr.
+#
+# Upstream (natori-hrj/herdr-hail) ships this as a herdr PLUGIN: a
+# `herdr-plugin.toml` manifest declaring one `[[panes]]` entrypoint, installed
+# with `herdr plugin install` and opened with `herdr plugin pane open
+# hail/bridge`. That is an interactive workflow — the manifest declares no
+# `[[startup]]` hook, so registering the plugin does NOT make the bridge run.
+#
+# The guest wants it running unattended, so modules/herdr/nixos.nix runs
+# dist/index.js as its own unit rather than going through the plugin host. The
+# bridge needs exactly two things from herdr, and both are plain environment
+# variables a unit can set itself:
+#
+#   HERDR_SOCKET_PATH        the control socket        (src/herdr.ts)
+#   HERDR_PLUGIN_CONFIG_DIR  directory of config.json  (src/config.ts)
+#
+# Nothing else the plugin host provides is load-bearing here, which is why this
+# is a package plus a unit instead of a plugin registration.
+{
+  lib,
+  buildNpmPackage,
+  nodejs,
+  makeWrapper,
+  src,
+}:
+
+buildNpmPackage {
+  pname = "herdr-hail";
+  # package.json says 0.1.0 and upstream cuts no tags, so the date of the
+  # pinned rev is the only thing that distinguishes two builds of it.
+  version = "0.1.0-unstable-2026-07-19";
+  inherit src;
+
+  # `prefetch-npm-deps package-lock.json` at the pinned rev. Moves only when
+  # the lockfile does, which is the reason the input is pinned by rev.
+  npmDepsHash = "sha256-DTS0Wcfq32/1kV3E/jMvEHOrkcfeavUQZaGeSzfXWZg=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # `npm run build` is bare `tsc` — the same command the manifest's [[build]]
+  # block runs when herdr installs from GitHub. Running it here is what makes
+  # the plugin host unnecessary at runtime.
+
+  # npm's own install would link dist/index.js as `bin/herdr-hail`, but tsc
+  # emits it without a shebang or the executable bit, so the link is unusable.
+  # Install by hand and wrap instead.
+  dontNpmInstall = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/herdr-hail
+    cp -r dist node_modules package.json $out/lib/herdr-hail/
+    # Not used by the unit, but shipping it keeps
+    # `herdr plugin link <out>/lib/herdr-hail` working for anyone who does
+    # want the interactive pane.
+    cp herdr-plugin.toml $out/lib/herdr-hail/
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/herdr-hail \
+      --add-flags $out/lib/herdr-hail/dist/index.js
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    # Path suffix to hand `herdr plugin link`, for the interactive pane route.
+    pluginSubdir = "lib/herdr-hail";
+  };
+
+  meta = {
+    description = "Two-way Slack and Discord bridge for the herdr agent multiplexer";
+    homepage = "https://github.com/natori-hrj/herdr-hail";
+    license = lib.licenses.asl20;
+    mainProgram = "herdr-hail";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/modules/herdr-remote/nixos.nix
+++ b/modules/herdr-remote/nixos.nix
@@ -1,0 +1,156 @@
+# herdr-remote — NixOS service module. Exported as nixosModules.herdr-remote.
+#
+# The relay and web dashboard half of herdr: live agent timelines, one-tap
+# approvals, terminal interaction from a browser or phone.
+#
+# It holds NO agent state and never touches herdr's control socket. It drives
+# each runtime over SSH, named in HERDR_REMOTES, so this guest is disposable —
+# the opposite of the runtime guest, whose /var/lib/herdr is the one path in
+# the estate worth backing up.
+{
+  config,
+  lib,
+  pkgs,
+  herdr-remote-src,
+  ...
+}:
+
+let
+  cfg = config.services.herdr-remote;
+  stateDirName = lib.removePrefix "/var/lib/" cfg.stateDir;
+  loopback = [
+    "127.0.0.1"
+    "localhost"
+    "::1"
+  ];
+in
+{
+  options.services.herdr-remote = {
+    enable = lib.mkEnableOption "the herdr-remote relay and web dashboard";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { src = herdr-remote-src; };
+      defaultText = lib.literalExpression "the pinned herdr-remote relay";
+      description = "herdr-remote relay package to run.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "herdr-remote";
+      description = "User the relay runs as.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/herdr-remote";
+      description = "Home, log and push-subscription directory. Rebuildable; not worth backing up.";
+    };
+
+    bindHost = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        Address the relay's WebSocket binds. Left on loopback by default: this
+        guest sits behind the estate's Traefik ingress and the Authelia gate,
+        so the relay itself never needs to be reachable directly.
+      '';
+    };
+
+    bindPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8375;
+      description = ''
+        WebSocket port. 8375 is upstream's default and is the value
+        tofu-proxmox pins as `herdr_relay_ws` for the ingress route; changing
+        it here alone produces a route to a closed port.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/var/lib/herdr-remote/.env";
+      description = ''
+        systemd EnvironmentFile carrying HERDR_RELAY_TOKEN, HERDR_REMOTES and
+        the VAPID push keys. Written out of band at 0600; never in the Nix
+        store, which is world-readable. Loaded with a leading `-`, so a missing
+        file leaves the unit inert rather than crash-looping.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/var/lib/" cfg.stateDir;
+        message = "services.herdr-remote.stateDir must be under /var/lib, because systemd's StateDirectory is relative to it.";
+      }
+      {
+        # Upstream refuses to start when RELAY_HOST is non-loopback with no
+        # AUTH_TOKEN (herdr_relay.py raises SystemExit). Nix cannot check the
+        # token itself — it lives in environmentFile, read at runtime — so this
+        # asserts the one half that IS visible at build time: a non-loopback
+        # bind must at least have a file that could carry the token. Necessary,
+        # not sufficient. The sufficient check is upstream's own refusal.
+        #
+        # Deliberately NOT written as `<cond> -> true`, which is a tautology
+        # that reads like a guard and can never fire.
+        assertion = builtins.elem cfg.bindHost loopback || cfg.environmentFile != null;
+        message = ''
+          services.herdr-remote.bindHost is ${cfg.bindHost}, which is not
+          loopback, but no environmentFile is set — so HERDR_RELAY_TOKEN cannot
+          reach the unit and upstream will refuse to start. Set an
+          environmentFile carrying the token, or bind loopback and let the
+          ingress terminate.
+        '';
+      }
+    ];
+
+    users = {
+      groups.${cfg.user} = { };
+      users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.user;
+        home = cfg.stateDir;
+        createHome = true;
+      };
+    };
+
+    systemd.services.herdr-remote = {
+      description = "herdr-remote relay and web dashboard";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.getExe cfg.package;
+        User = cfg.user;
+        Group = cfg.user;
+        WorkingDirectory = cfg.stateDir;
+        StateDirectory = stateDirName;
+        # Holds HERDR_RELAY_TOKEN-authenticated push subscriptions and agent
+        # transcripts read off the runtimes. Same 0700 as the runtime guest.
+        StateDirectoryMode = "0700";
+        Restart = "always";
+        RestartSec = "5s";
+      }
+      // lib.optionalAttrs (cfg.environmentFile != null) {
+        EnvironmentFile = "-${cfg.environmentFile}";
+      };
+
+      unitConfig = {
+        StartLimitIntervalSec = 300;
+        StartLimitBurst = 5;
+      };
+
+      environment = {
+        HOME = cfg.stateDir;
+        HERDR_RELAY_HOST = cfg.bindHost;
+        HERDR_RELAY_PORT = toString cfg.bindPort;
+        HERDR_LOG_DIR = cfg.stateDir;
+      };
+    };
+  };
+}

--- a/modules/herdr-remote/package.nix
+++ b/modules/herdr-remote/package.nix
@@ -1,0 +1,80 @@
+# herdr-remote's relay, packaged.
+#
+# Upstream (dcolinmorgan/herdr-remote) ships no setup.py, no lockfile and no
+# nixpkgs entry — it is run as `uv run relay/herdr_relay.py`, with dependencies
+# declared in a PEP 723 inline block at the top of that file. uv resolves them
+# from the network at start time, which a guest built from a pinned flake must
+# not do. So the dependency list is transcribed here from that block and
+# supplied by nixpkgs instead:
+#
+#   requires-python = ">=3.10"
+#   dependencies = ["websockets>=14.0", "zeroconf>=0.80.0",
+#                   "pywebpush>=2.0.0", "py-vapid>=1.9.0"]
+#
+# A TRANSCRIBED LIST ROTS. If upstream adds a dependency the relay fails at
+# RUNTIME with ModuleNotFoundError — on the guest, after the closure is already
+# deployed. The `herdr-remote-pep723-deps` check in flake/checks.nix re-parses
+# the block from the pinned source and fails the build when the two disagree,
+# so the drift surfaces on the controller instead.
+#
+# The whole relay/ directory is installed, not just herdr_relay.py: the script
+# loads agent_state.py and transcript.py by path relative to its own __file__,
+# with an importlib fallback that would silently pick up the wrong copy if the
+# siblings were missing.
+{
+  lib,
+  stdenvNoCC,
+  python3,
+  openssh,
+  makeWrapper,
+  src,
+}:
+
+let
+  # Transcribed from the PEP 723 block above. Declared ONCE, here, and re-used
+  # by the herdr-remote-pep723-deps check in flake/checks.nix, which re-parses
+  # that block from the pinned source and fails if the two disagree. Every
+  # name happens to be identical in nixpkgs; if upstream ever adds one that is
+  # not, map it here and the check will point at the mismatch.
+  pep723Deps = [
+    "websockets"
+    "zeroconf"
+    "pywebpush"
+    "py-vapid"
+  ];
+
+  pythonEnv = python3.withPackages (ps: map (n: ps.${n}) pep723Deps);
+in
+stdenvNoCC.mkDerivation {
+  pname = "herdr-remote-relay";
+  version = "0-unstable-2026-09-01";
+  inherit src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec/herdr-remote
+    cp -r relay/. $out/libexec/herdr-remote/
+
+    # ssh is on PATH because the relay drives every herdr runtime over SSH —
+    # it never speaks to a socket directly. Without it the dashboard renders an
+    # empty fleet rather than erroring, which is the failure this whole guest
+    # is supposed to make visible.
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/herdr-remote-relay \
+      --add-flags $out/libexec/herdr-remote/herdr_relay.py \
+      --prefix PATH : ${lib.makeBinPath [ openssh ]}
+
+    runHook postInstall
+  '';
+
+  passthru = { inherit pep723Deps; };
+
+  meta = {
+    description = "Relay and web dashboard for driving herdr runtimes over SSH";
+    homepage = "https://github.com/dcolinmorgan/herdr-remote";
+    mainProgram = "herdr-remote-relay";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/modules/herdr/hail.nix
+++ b/modules/herdr/hail.nix
@@ -1,0 +1,165 @@
+# herdr-hail — the Slack/Discord bridge, as a companion unit on the herdr guest.
+#
+# Imported by modules/herdr/nixos.nix; not exported as a module of its own,
+# because it is meaningless without a herdr server on the same host.
+#
+# WHY A UNIT AND NOT A PLUGIN REGISTRATION. Upstream ships hail as a herdr
+# plugin, but that route runs nothing unattended: the manifest declares one
+# `[[panes]]` entrypoint and no `[[startup]]` hook, so a registered plugin sits
+# idle until somebody opens `herdr plugin pane open hail/bridge`. The bridge
+# reads exactly two variables — HERDR_SOCKET_PATH (src/herdr.ts) and
+# HERDR_PLUGIN_CONFIG_DIR (src/config.ts) — both of which a unit can set.
+#
+# An earlier design read "plugin" as "separate service", gave it its own guest
+# and forwarded the socket over SSH. Avoid that: hail's advantage over
+# herdr-remote is "no tunnel, no relay", true only when it runs local.
+{
+  config,
+  lib,
+  pkgs,
+  herdr-hail-src,
+  ...
+}:
+
+let
+  cfg = config.services.herdr;
+  inherit (cfg) hail;
+
+  # Read-only and world-readable on purpose: hail never writes to disk (nothing
+  # in the upstream tree calls writeFile), and every secret arrives through
+  # environmentFile, so nothing rendered here is sensitive.
+  configDir = "/etc/herdr-hail";
+
+  # Upstream's own DEFAULTS (src/config.ts), restated so `settings` can
+  # override one field without naming the rest, and so the assertions below
+  # read the EFFECTIVE value rather than only what the operator typed.
+  settings = lib.recursiveUpdate {
+    notifyOn = [
+      "blocked"
+      "done"
+    ];
+    pollIntervalMs = 1500;
+    contextSource = "visible";
+    contextLines = 12;
+    slack = {
+      enabled = false;
+      allowedUsers = [ ];
+    };
+    discord = {
+      enabled = false;
+      allowedUsers = [ ];
+      messageContent = false;
+    };
+  } hail.settings;
+in
+{
+  options.services.herdr.hail = {
+    enable = lib.mkEnableOption "the herdr-hail Slack/Discord bridge alongside the server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ../herdr-hail/package.nix { src = herdr-hail-src; };
+      defaultText = lib.literalExpression "pkgs.callPackage ../herdr-hail/package.nix { src = herdr-hail-src; }";
+      description = "herdr-hail package to run.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          slack = {
+            enabled = true;
+            channel = "C0123456789";
+            allowedUsers = [ "U0123456789" ];
+          };
+        }
+      '';
+      description = ''
+        Non-secret half of hail's config.json, rendered into /etc/herdr-hail
+        and merged over upstream's defaults, so only differing fields need
+        naming. Tokens do NOT belong here — this lands in the world-readable
+        Nix store. Use `environmentFile`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/var/lib/herdr/hail.env";
+      description = ''
+        systemd EnvironmentFile holding hail's tokens. Upstream fixes the
+        names, and they win over config.json: SLACK_BOT_TOKEN, SLACK_APP_TOKEN,
+        SLACK_CHANNEL, SLACK_ALLOWED_USERS, DISCORD_BOT_TOKEN,
+        DISCORD_CHANNEL_ID, DISCORD_ALLOWED_USERS.
+
+        There is no env override for the per-channel `enabled` flag, so an env
+        file alone cannot switch a channel on — see the assertion below.
+      '';
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && hail.enable) {
+    assertions = [
+      {
+        # hail computes `enabled = enabled && hasTokens` and exposes no env
+        # override for the flag itself. A guest with perfect tokens and no
+        # `enabled` here starts, connects, polls, and notifies nobody — a
+        # healthy unit over a silent fleet, which reads exactly like a quiet
+        # one. Fail at evaluation instead of at 3am.
+        assertion = (settings.slack.enabled or false) || (settings.discord.enabled or false);
+        message = ''
+          services.herdr.hail is enabled but neither settings.slack.enabled nor
+          settings.discord.enabled is true. herdr-hail has no environment
+          override for those flags, so the bridge would run and deliver nothing.
+        '';
+      }
+      {
+        assertion = hail.environmentFile != null;
+        message = ''
+          services.herdr.hail needs an environmentFile: its tokens must not go
+          in `settings`, which is rendered into the world-readable Nix store.
+        '';
+      }
+    ];
+
+    environment.etc."herdr-hail/config.json".source = pkgs.writeText "herdr-hail-config.json" (
+      builtins.toJSON settings
+    );
+
+    systemd.services.herdr-hail = {
+      description = "herdr-hail Slack/Discord bridge";
+      wantedBy = [ "multi-user.target" ];
+      # BindsTo, not merely After: the bridge's only job is watching panes over
+      # herdr's socket, so it is meaningless without the server and should stop
+      # with it rather than restart-loop against a socket that is not there.
+      bindsTo = [ "herdr.service" ];
+      after = [ "herdr.service" ];
+
+      unitConfig = {
+        StartLimitIntervalSec = 300;
+        StartLimitBurst = 5;
+      }
+      // lib.optionalAttrs (cfg.onFailureUnit != null) { OnFailure = cfg.onFailureUnit; };
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.getExe hail.package;
+        # Same user as the server: the runtime directory is 0750 and owned by
+        # it, and hail is a client of that socket, not a separate trust domain.
+        User = cfg.user;
+        Group = cfg.user;
+        WorkingDirectory = cfg.stateDir;
+        Restart = "always";
+        RestartSec = "5s";
+        EnvironmentFile = "-${hail.environmentFile}";
+      };
+
+      environment = {
+        HOME = cfg.stateDir;
+        HERDR_SOCKET_PATH = cfg.socketPath;
+        HERDR_PLUGIN_CONFIG_DIR = configDir;
+      };
+    };
+  };
+}

--- a/modules/herdr/nixos.nix
+++ b/modules/herdr/nixos.nix
@@ -40,8 +40,24 @@ let
   stateDirName = lib.removePrefix "/var/lib/" cfg.stateDir;
 in
 {
+  # The Slack/Discord bridge lives in its own file: this one is already close
+  # to the repo's 12KB error gate, and .file-size.yml says to split rather
+  # than grant an extended limit.
+  imports = [ ./hail.nix ];
+
   options.services.herdr = {
     enable = lib.mkEnableOption "the herdr agent-multiplexer server";
+
+    # Not settable: it is bound to RuntimeDirectory above, and the whole point
+    # of the pin is that exactly one path exists. Exposed as an option only so
+    # hail.nix (and any out-of-tree consumer) can read it instead of restating
+    # the literal and drifting from it silently.
+    socketPath = lib.mkOption {
+      type = lib.types.path;
+      readOnly = true;
+      default = socketPath;
+      description = "Absolute path of the control socket, pinned by HERDR_SOCKET_PATH.";
+    };
 
     package = lib.mkOption {
       type = lib.types.package;

--- a/modules/mlx/mlx-lm-patch/server-harmony.patch
+++ b/modules/mlx/mlx-lm-patch/server-harmony.patch
@@ -7,8 +7,8 @@
 +from .tool_parsers.harmony import HarmonyStream as _HarmonyStream
 +from .tool_parsers.harmony import parse_tool_call as _harmony_parse_tool_call
  from .utils import _parse_size, load, sharded_load
- 
- 
+
+
 +def _make_harmony_stream(cli_args, ctx):
 +    """HarmonyStream for this completion, or None when harmony must stay out.
 +
@@ -49,8 +49,8 @@
      return f"{__version__}-{mx.__version__}-{platform.platform()}-{gpu_arch}"
 @@ -91,6 +128,46 @@
          return result
- 
- 
+
+
 +class _LoudToolCallFormatter(ToolCallFormatter):
 +    """ToolCallFormatter that never silently drops a tool call.
 +
@@ -96,7 +96,7 @@
          "system_prompt": (
 @@ -1437,7 +1514,12 @@
              logging.debug("Starting completion:")
- 
+
          # Tool call formatter
 -        tool_formatter = ToolCallFormatter(ctx.tool_parser, request.tools, self.stream)
 +        harmony_stream = _make_harmony_stream(self.response_generator.cli_args, ctx)
@@ -105,7 +105,7 @@
 +            request.tools,
 +            self.stream,
 +        )
- 
+
          # Variables to save the generated text, tokens, logprobs, tools etc
          prev_state = None
 @@ -1466,7 +1548,15 @@
@@ -122,7 +122,7 @@
 +                        if delta.tool_calls:
 +                            tool_calls.extend(delta.tool_calls)
 +                            made_tool_call = True
- 
+
                  # Add the tokens and logprobs to the vars.
                  tokens.append(gen.token)
 @@ -1480,10 +1570,12 @@
@@ -142,7 +142,7 @@
 @@ -1501,14 +1593,28 @@
                  tool_calls.append(tool_text)
                  made_tool_call = True
- 
+
 -            if finish_reason == "stop" and made_tool_call:
 +            if harmony_stream is not None:
 +                delta = harmony_stream.finish()
@@ -160,7 +160,7 @@
 +
 +            if finish_reason == "stop" and made_tool_call and tool_formatter.emitted:
                  finish_reason = "tool_calls"
- 
+
              if self.stream:
                  resp = self.generate_response(
                      text,


### PR DESCRIPTION
## What

Makes the herdr half of this flake deployable, and adds the Slack bridge.

Until now `nixosModules.herdr` was importable but nothing dereferenced it, so
`nixos-rebuild --flake ...#herdr` had no attribute to resolve and there was no
LXC template to create a guest from. Two consumer PRs are written against
outputs that did not exist.

- `nixosConfigurations.herdr` and `.herdr-ui` on the nixpkgs `proxmox-lxc`
  profile — the exact attribute a deploy dereferences.
- `packages.x86_64-linux.herdr-lxc-template`, the guest's
  `system.build.tarball`, plus a release job that builds and uploads it as
  `nixos-herdr-lxc.tar.xz`.
- `modules/herdr-remote/` — packages the relay, which is third-party Python
  with a PEP 723 dependency block and no lockfile.
- `modules/herdr-hail/` + `modules/herdr/hail.nix` — packages the Slack/Discord
  bridge and runs it as a companion unit.

## Why the bridge is a unit and not a plugin registration

Upstream ships hail as a herdr plugin. That route runs nothing unattended: the
manifest declares one `[[panes]]` entrypoint and no `[[startup]]` hook, so a
registered plugin idles until somebody opens the pane. The bridge reads exactly
two variables from its environment — the control socket path and the directory
holding its `config.json` — and a unit can set both, so the plugin host is not
load-bearing here. The packaged output still ships the manifest, so
`herdr plugin link` remains available for the interactive pane.

Reading "plugin" as "separate service" is also what makes a socket forward look
necessary. It is not: the bridge is a client of a socket on the same host.

## Two failure modes with no runtime symptom

Both are assertions rather than comments, because neither shows up in a health
check:

- **The bridge can run and deliver nothing.** Its per-channel `enabled` flag has
  no environment override, so credentials alone cannot switch a channel on. A
  correct token file with no flag yields a running unit over a silent fleet,
  which is indistinguishable from a quiet one.
- **Tokens in `settings` would be published.** `settings` renders into the Nix
  store, which is world-readable, so an `environmentFile` is required.

A third guard is a check, not an assertion: the relay declares its dependencies
only in a PEP 723 block with no lockfile, so the check re-parses that block on
every evaluation and fails if it diverges from the list the package transcribes.
It asserts set equality, not a subset — an upstream *addition* is the direction
that breaks at runtime.

## Verification

Run on this branch:

| Check | Result |
| --- | --- |
| `nix eval .#nixosConfigurations.herdr.…toplevel.drvPath` | resolves |
| `nix eval .#nixosConfigurations.herdr-ui.…toplevel.drvPath` | resolves |
| `nix eval .#packages.x86_64-linux.herdr-lxc-template.drvPath` | resolves to a `tarball.drv` |
| `nix build .#herdr-hail` | builds; the wrapper runs, reads the rendered config, and reaches Slack (`invalid_auth` on a deliberately bogus token) |
| both new assertions | tested in both directions — the valid case evaluates, each negative control fails |
| `pre-commit run --all-files` | all hooks pass |

`nix build .#herdr-lxc-template` needs an x86_64-linux builder and is left to
CI; the attribute is guarded to that system so it is a clear absence on darwin
rather than a confusing build failure.

Enabling nothing changes nothing: with `services.herdr.hail` off, the `herdr`
configuration's derivation path is byte-identical to before this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new deployable NixOS guests, release-published LXC artifacts, and third-party source pins with transcribed Python deps; hail/remote secrets and ingress assumptions must be configured correctly outside the store.
> 
> **Overview**
> **Makes herdr deployable end-to-end** by exporting `nixosConfigurations.herdr` and `herdr-ui` (Proxmox LXC profile), wiring pinned third-party sources for **herdr-remote** (relay/dashboard) and **herdr-hail** (Slack/Discord bridge), and exposing `packages.x86_64-linux.herdr-lxc-template` plus a **release-please** job that builds and uploads `nixos-herdr-lxc.tar.xz` when a release is cut.
> 
> The **runtime guest** gains optional `services.herdr.hail` as a **systemd companion** to `herdr` (not plugin registration), with eval-time guards for channel `enabled` flags and secrets via `environmentFile`. The **UI guest** is a separate `nixosModules.herdr-remote` module with loopback bind defaults and relay packaging that transcribes PEP 723 deps; a new **`herdr-remote-pep723-deps`** flake check fails on dependency drift. Flake structure is split (`nixos-configurations.nix`, `overlays.nix`) to stay under size limits.
> 
> **Separately**, the **mlx-lm `server-harmony.patch`** adds gpt-oss harmony channel handling (`HarmonyStream`, `--harmony-tool-parser`), routes tool parsing correctly when harmony is active, and uses `_LoudToolCallFormatter` so failed parses surface as content instead of empty silent responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb99a0627cff53a2c205207504476d3162bfcfd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->