### PR TITLE
chore(deps): bump nix-claude-code for the two-line statusline layout

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -778,11 +778,11 @@
         "wakatime": "wakatime"
       },
       "locked": {
-        "lastModified": 1788266794,
-        "narHash": "sha256-a9XMTnvU4MW6PBffwOcdrvo3trvbSsaXv4KqWUSdcmk=",
+        "lastModified": 1788294873,
+        "narHash": "sha256-OoxmtGD+0bS2Jx0l2n3H9O8W4Ak/qDwTn2ygAiUo+dA=",
         "owner": "dryvist",
         "repo": "nix-claude-code",
-        "rev": "537ca45e3381893e72843a1734af0e5023815f3c",
+        "rev": "e7e825e164608b0910f87a2182df9089b18e2102",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps the `nix-claude-code` flake input to pick up the released statusline changes.

- The statusline is now **two lines** instead of one. Previously the prompt-cache widget sat at the end of a single line and was the first thing clipped by ccstatusline's line-width truncation, showing a literal `...` in place of the cache state.
- `ccstatusline` is now pinned to an exact version rather than a floating major-version range, so rendering no longer drifts between sessions.

Layout: line 1 is repo/branch → model → thinking effort → `Ctx:` length + slider bar; line 2 carries the compaction counter, session and weekly usage with their timers, and the prompt-cache widget.

## Test plan
- [x] `nix flake check` (see CI)
- [x] Verified the locked revision contains the reordered layout
- [ ] `darwin-rebuild switch` once nix-darwin's lock picks this up — that is the final step of this cascade and the first point at which the change is visible live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump affecting terminal UI configuration, with no changes to auth, data handling, or in-repo logic.
> 
> **Overview**
> Updates the locked **`nix-claude-code`** flake input (`537ca45` → `e7e825e`) so this repo picks up upstream Claude Code statusline changes.
> 
> That release switches **`ccstatusline`** to a **two-line** layout so repo/model/context stay on the first line and compaction, usage timers, and the prompt-cache widget sit on the second—avoiding width truncation that hid the cache state behind `...`. **`ccstatusline`** is also pinned to an exact version instead of a floating range so rendering stays consistent across sessions.
> 
> There are no application code changes here; behavior updates only after the flake is consumed (e.g. via `darwin-rebuild switch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31f1e363389c16d2446fe35897116d257d19e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->