### PR TITLE
feat(claude): trim the per-session surface — eighteen unused plugins, duplicate and unreachable MCP servers

### DIFF
--- a/lib/checks/agent-skills.nix
+++ b/lib/checks/agent-skills.nix
@@ -17,7 +17,7 @@ let
         root = "agents";
         groups.core = [
           "autoresearch"
-          "kaizen"
+          "premium-agent-orchestration"
           "not-a-real-skill"
         ];
         activeGroups = [ "core" ];
@@ -144,18 +144,11 @@ in
     assert
       builtins.elem ".codex/skills/premium-agent-orchestration" managedSkillEntries
       || throw "premium-agent-orchestration skill not discovered from the direct plugin input";
+    # Discovery follows the plugin flag: a disabled plugin's skills must not
+    # deploy, or disabling a plugin would trim the listing but not the tree.
     assert
-      builtins.elem ".codex/skills/browser-use" managedSkillEntries
-      || throw "browser-use skill not discovered from the enabled Browser Use plugin";
-    assert
-      builtins.elem ".codex/skills/why" managedSkillEntries
-      || throw "why skill not discovered from the context-engineering-kit input";
-    assert
-      builtins.elem ".codex/skills/kaizen" managedSkillEntries
-      || throw "kaizen skill not discovered from the context-engineering-kit input";
-    assert
-      builtins.elem ".codex/skills/managing-dependencies" managedSkillEntries
-      || throw "managing-dependencies skill not discovered from its flake input";
+      !(builtins.elem ".codex/skills/browser-use" managedSkillEntries)
+      || throw "browser-use skill deployed although its plugin is disabled";
     assert
       builtins.elem ".codex/skills/langfuse" managedSkillEntries
       || throw "langfuse skill not discovered from langfuse-skills input";
@@ -212,16 +205,16 @@ in
       builtins.elem ".agents/skills/autoresearch" groupedSkillEntries
       || throw "group gating dropped a core-group skill (autoresearch)";
     assert
-      builtins.elem ".agents/skills/kaizen" groupedSkillEntries
-      || throw "group gating dropped a core-group skill (kaizen)";
+      builtins.elem ".agents/skills/premium-agent-orchestration" groupedSkillEntries
+      || throw "group gating dropped a core-group skill (premium-agent-orchestration)";
     assert
-      !(builtins.elem ".agents/skills/why" groupedSkillEntries)
-      || throw "group gating deployed a skill outside the active groups (why)";
+      !(builtins.elem ".agents/skills/writing-clearly-and-concisely" groupedSkillEntries)
+      || throw "group gating deployed a skill outside the active groups (writing-clearly-and-concisely)";
     assert
       builtins.length groupedSkillEntries == 2
       || throw "group gating must deploy exactly the active groups' skills, got ${builtins.toJSON groupedSkillEntries}";
     assert
-      builtins.match ".*[^-]why.*" groupedIndex == null
-      || throw "INDEX.md lists a skill the group gate excluded (why)";
+      builtins.match ".*writing-clearly-and-concisely.*" groupedIndex == null
+      || throw "INDEX.md lists a skill the group gate excluded (writing-clearly-and-concisely)";
     helpers.mkMarker "check-agent-skills-groups" "Agent Skills group gating: ${toString (builtins.length groupedSkillEntries)} skills from active groups only";
 }

--- a/lib/checks/mcp.nix
+++ b/lib/checks/mcp.nix
@@ -6,8 +6,6 @@ let
   expectedGlobalServers = [
     "codex"
     "fabric"
-    "huggingface"
-    "splunk"
     "time"
     "zammad"
   ]

--- a/modules/claude/plugins/01-official.nix
+++ b/modules/claude/plugins/01-official.nix
@@ -43,7 +43,7 @@ _:
     # in 04-community.nix (codebase-cleanup, tdd-workflows, code-refactoring all ship
     # a code-reviewer agent that we disable there).
     "code-review@claude-plugins-official" = true;
-    "pr-review-toolkit@claude-plugins-official" = true;
+    "pr-review-toolkit@claude-plugins-official" = false;
 
     # Feature Development — provides feature-dev:code-reviewer (high-confidence
     # filter variant, complementary to pr-review-toolkit:code-reviewer).
@@ -53,12 +53,12 @@ _:
     "security-guidance@claude-plugins-official" = true;
 
     # Plugin Development (user maintains claude-code-plugins repo)
-    "plugin-dev@claude-plugins-official" = true;
+    "plugin-dev@claude-plugins-official" = false;
     "hookify@claude-plugins-official" = true;
 
     # Setup & Management
     "claude-code-setup@claude-plugins-official" = true;
-    "claude-md-management@claude-plugins-official" = true;
+    "claude-md-management@claude-plugins-official" = false;
 
     # Frontend Design — standalone single-skill plugin. The bundled
     # variant inside anthropic-agent-skills now ships under the kept
@@ -66,14 +66,14 @@ _:
     # standalone is retained because its description text differs from
     # the bundled variant; loaders that match on description benefit
     # from both being present.
-    "frontend-design@claude-plugins-official" = true;
+    "frontend-design@claude-plugins-official" = false;
 
     # Code transformation skills — refactoring + simplification for docs
     # work and general code maintenance.
     # code-modernization: DISABLED (legacy/mainframe uplift; 0 real use per
     # Splunk). Import per-repo via packs.nix `modernization` when needed.
     "code-modernization@claude-plugins-official" = false;
-    "code-simplifier@claude-plugins-official" = true;
+    "code-simplifier@claude-plugins-official" = false;
 
     # Dev kits — Agent SDK + MCP server scaffolding. DISABLED (0 real use per
     # Splunk). Import per-repo via packs.nix `mcp-dev` when building MCP/SDK apps.

--- a/modules/claude/plugins/01-official.nix
+++ b/modules/claude/plugins/01-official.nix
@@ -63,9 +63,8 @@ _:
     # Frontend Design — standalone single-skill plugin. The bundled
     # variant inside anthropic-agent-skills now ships under the kept
     # document-skills plugin only (example-skills disabled below). This
-    # standalone is retained because its description text differs from
-    # the bundled variant; loaders that match on description benefit
-    # from both being present.
+    # standalone is off: no recorded use, and the bundled variant covers
+    # the same ground. Re-enable here, never in user settings.
     "frontend-design@claude-plugins-official" = false;
 
     # Code transformation skills — refactoring + simplification for docs

--- a/modules/claude/plugins/02-vendors.nix
+++ b/modules/claude/plugins/02-vendors.nix
@@ -42,7 +42,7 @@ _:
     "greptile@claude-plugins-official" = false; # Removed 2026-03-20: not worth cost
 
     # Documentation & Context
-    "context7@claude-plugins-official" = true; # CONTEXT7_API_KEY optional
+    "context7@claude-plugins-official" = false; # duplicated by the hosted connector # CONTEXT7_API_KEY optional
 
     # Backend & Infrastructure
     "firebase@claude-plugins-official" = false;

--- a/modules/claude/plugins/03-personal.nix
+++ b/modules/claude/plugins/03-personal.nix
@@ -46,5 +46,7 @@ in
   enabledPlugins = jacobpevansPlugins // {
     # Per-plugin overrides go here (e.g., to disable a specific plugin):
     # "<plugin-name>@jacobpevans-cc-plugins" = false;
+    # Both of its skills are marked deprecated; permissions live in nix-claude-code.
+    "config-management@jacobpevans-cc-plugins" = false;
   };
 }

--- a/modules/claude/plugins/04-community.nix
+++ b/modules/claude/plugins/04-community.nix
@@ -45,16 +45,16 @@ _:
     "backend-development@claude-code-workflows" = false;
 
     # Agents: django-pro, fastapi-pro, python-pro (all unique).
-    "python-development@claude-code-workflows" = true;
+    "python-development@claude-code-workflows" = false;
 
     # Agents: monorepo-architect (unique).
-    "developer-essentials@claude-code-workflows" = true;
+    "developer-essentials@claude-code-workflows" = false;
 
     # Testing (selective)
     # Agents: debugger (unique), test-automator (KEEPER for this role).
     # Best-judgement keeper among 5 community test-automator dups: this one
     # has the most direct name match for general unit-testing work.
-    "unit-testing@claude-code-workflows" = true;
+    "unit-testing@claude-code-workflows" = false;
 
     # DISABLED — code-reviewer (DUP, superseded by Tier 1 pr-review-toolkit:code-reviewer)
     #            tdd-orchestrator (DUP — keeper backend-development:tdd-orchestrator).
@@ -78,19 +78,19 @@ _:
 
     # Orchestration & Observability (kept — unique agents)
     # Agents: context-manager (unique).
-    "agent-orchestration@claude-code-workflows" = true;
+    "agent-orchestration@claude-code-workflows" = false;
 
     # Agents: database-optimizer (unique), network-engineer (unique),
     #         observability-engineer (unique), performance-engineer (KEEPER
     #         for this role across 4 community variants — best domain fit).
-    "observability-monitoring@claude-code-workflows" = true;
+    "observability-monitoring@claude-code-workflows" = false;
 
     # Cloud / DevOps
     # Agents: cloud-architect (unique), deployment-engineer (KEEPER — keeper
     #         for this role; full-stack-orchestration variant disabled above),
     #         devops-troubleshooter, kubernetes-architect, terraform-specialist
     #         (all unique).
-    "cicd-automation@claude-code-workflows" = true;
+    "cicd-automation@claude-code-workflows" = false;
 
     # ========================================================================
     # superpowers-marketplace — obra/superpowers-marketplace (925★)
@@ -121,10 +121,10 @@ _:
     # Essential issue analysis + worktree creation utilities (unique to this marketplace).
     # analyze-issue: DISABLED (0 real use per Splunk) — packs.nix `devtools`.
     "analyze-issue@cc-marketplace" = false;
-    "create-worktrees@cc-marketplace" = true;
+    "create-worktrees@cc-marketplace" = false;
 
     # User actively uses Python — kept for python-expert agent (unique).
-    "python-expert@cc-marketplace" = true;
+    "python-expert@cc-marketplace" = false;
 
     # CI/CD, cloud infra, monitoring, deployment automation (unique).
     # DISABLED (0 real use per Splunk) — import per-repo via packs.nix `devtools`.
@@ -171,7 +171,7 @@ _:
     # apply to every session, so they belong at user level rather than a pack.
     # The kit's other plugins (reflexion, review, git) duplicate roles already
     # held by higher tiers and stay off.
-    "kaizen@context-engineering-kit" = true;
+    "kaizen@context-engineering-kit" = false;
 
     # ========================================================================
     # managing-dependencies — andrew/managing-dependencies
@@ -181,6 +181,6 @@ _:
     # provenance, license classification. Universal — every repo here has
     # dependencies, and the "verify it exists before suggesting it" rule guards
     # a failure mode that is not repo-specific.
-    "managing-dependencies@managing-dependencies" = true;
+    "managing-dependencies@managing-dependencies" = false;
   };
 }

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -128,9 +128,10 @@ _:
     # ========================================================================
     # browser-use-skills — browser-use/browser-use (synthetic)
     # ========================================================================
-    # Enabled globally: the upstream Browser Use CLI skill is shared with every
-    # configured harness through programs.agentSkills. This native Claude
-    # plugin remains the Claude Code entrypoint; do not maintain a forked copy.
+    # Off: no recorded use. Flipping this to true is the only way to enable
+    # it — programs.agentSkills discovery follows this flag, so a disabled
+    # plugin's skills leave every harness, not just Claude Code. Do not
+    # maintain a forked copy.
     "browser-use@browser-use-skills" = false;
 
     # ========================================================================

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -98,7 +98,7 @@ _:
     # Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution.
     # Complements Tier 1 code-review; focuses on pre-coding discipline rather than review.
     # Also flows to ~/.agents/skills/ automatically via agent-skills auto-discovery.
-    "andrej-karpathy-skills@karpathy-skills" = true;
+    "andrej-karpathy-skills@karpathy-skills" = false;
 
     # ========================================================================
     # ponytail — DietrichGebert/ponytail (minimalism / YAGNI behavioral mode)
@@ -131,7 +131,7 @@ _:
     # Enabled globally: the upstream Browser Use CLI skill is shared with every
     # configured harness through programs.agentSkills. This native Claude
     # plugin remains the Claude Code entrypoint; do not maintain a forked copy.
-    "browser-use@browser-use-skills" = true;
+    "browser-use@browser-use-skills" = false;
 
     # ========================================================================
     # vct-cribl-pack-validator-skills — private source (synthetic)

--- a/modules/mcp/catalog.nix
+++ b/modules/mcp/catalog.nix
@@ -105,6 +105,9 @@ in
   huggingface = codexMcp {
     command = "${mcpPkgs.huggingface-mcp-server}/bin/huggingface-mcp-server";
     args = [ ];
+    # The hosted connector already serves the same Hub tools; a second copy
+    # only doubles the schema every session pays for.
+    disabled = true;
   };
 
   # Fabric MCP - community-maintained (ksylvan/fabric-mcp), exposes fabric
@@ -122,6 +125,9 @@ in
   # process.
   splunk = codexMcp {
     command = "splunk-mcp-connect";
+    # Off until the launcher receives its secret-zero and the endpoint answers
+    # (tracked in the task tracker); today it fails to connect on every start.
+    disabled = true;
     # Codex forwards stdio-server environment variables only when they are
     # explicitly declared. Keep the OpenBao bootstrap scoped to this launcher.
     env_vars = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad configuration changes affect every session’s loaded plugins, skills, and MCP tools; mitigated by updated Nix checks but users who relied on now-disabled globals must re-enable via repo overrides or packs.
> 
> **Overview**
> **Shrinks the default Claude Code and shared AI harness footprint** by turning off a large batch of globally enabled plugins (official, community, specialty, and personal tiers) that were unused, duplicated elsewhere, or meant for per-repo packs—while keeping core paths like `autoresearch`, `superpowers`, and `document-skills`.
> 
> **MCP profile is slimmed** by marking `huggingface` and `splunk` as disabled in `modules/mcp/catalog.nix` (duplicate Hub tools and a broken Splunk launcher, respectively) and dropping them from the global MCP regression expectations in `lib/checks/mcp.nix`.
> 
> **Agent Skills regression tests are realigned** with the new plugin set: fixtures use `premium-agent-orchestration` instead of `kaizen`, group-gating checks use `writing-clearly-and-concisely` as the excluded skill, and discovery now asserts that **disabled** plugins such as `browser-use` do not deploy skills to every harness—matching the comment that `programs.agentSkills` discovery follows plugin flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29926bab1c43fa97ab7d1b03302bc452d967798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->