### PR TITLE
docs(claude): update tier comments for disabled plugins

### DIFF
--- a/modules/claude/plugins/04-community.nix
+++ b/modules/claude/plugins/04-community.nix
@@ -56,11 +56,11 @@ _:
     # has the most direct name match for general unit-testing work.
     "unit-testing@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by the Tier 1 code-review plugin)
+    # DISABLED — code-reviewer (DUP, superseded by Tier 1 code-review@claude-plugins-official)
     #            tdd-orchestrator (DUP — keeper backend-development:tdd-orchestrator).
     "tdd-workflows@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by the Tier 1 code-review plugin)
+    # DISABLED — code-reviewer (DUP, superseded by Tier 1 code-review@claude-plugins-official)
     #            legacy-modernizer (rarely used).
     "code-refactoring@claude-code-workflows" = false;
 

--- a/modules/claude/plugins/04-community.nix
+++ b/modules/claude/plugins/04-community.nix
@@ -56,11 +56,11 @@ _:
     # has the most direct name match for general unit-testing work.
     "unit-testing@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by Tier 1 pr-review-toolkit:code-reviewer)
+    # DISABLED — code-reviewer (DUP, superseded by the Tier 1 code-review plugin)
     #            tdd-orchestrator (DUP — keeper backend-development:tdd-orchestrator).
     "tdd-workflows@claude-code-workflows" = false;
 
-    # DISABLED — code-reviewer (DUP, superseded by Tier 1 pr-review-toolkit:code-reviewer)
+    # DISABLED — code-reviewer (DUP, superseded by the Tier 1 code-review plugin)
     #            legacy-modernizer (rarely used).
     "code-refactoring@claude-code-workflows" = false;
 

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -97,7 +97,8 @@ _:
     # Single skill: karpathy-guidelines. Behavioral rules for LLM coding:
     # Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution.
     # Complements Tier 1 code-review; focuses on pre-coding discipline rather than review.
-    # Also flows to ~/.agents/skills/ automatically via agent-skills auto-discovery.
+    # Off: no recorded use. Enabling it here is what deploys the skill to
+    # ~/.agents/skills/ for every harness (agent-skills discovery follows this flag).
     "andrej-karpathy-skills@karpathy-skills" = false;
 
     # ========================================================================


### PR DESCRIPTION
Comment-only: the code-reviewer duplicate notes now name the enabled Tier 1 plugin, and the Karpathy block states the plugin is off and that enabling it is what deploys the skill to every harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment edits with no runtime or configuration behavior changes.
> 
> **Overview**
> **Comment-only** updates in community and specialty plugin Nix configs; no `enabledPlugins` values change.
> 
> In `04-community.nix`, duplicate **code-reviewer** notes for disabled `tdd-workflows` and `code-refactoring` now point at the active Tier 1 replacement **`code-review@claude-plugins-official`** instead of the outdated `pr-review-toolkit:code-reviewer` label.
> 
> In `05-specialty.nix`, the **Karpathy** block clarifies that the plugin stays off (no recorded use) and that flipping **`andrej-karpathy-skills@karpathy-skills`** to `true` is what deploys the skill via agent-skills discovery to `~/.agents/skills/` across harnesses—not an automatic side effect while disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8cb29800e9020895bfd569b9754e8078461984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->