### PR TITLE
fix(mlx): keep mlx-lm-only flags out of the vllm-mlx worker command

### DIFF
--- a/lib/checks.nix
+++ b/lib/checks.nix
@@ -106,6 +106,7 @@ in
 // (import ./checks/mlx-model-extra-args.nix { inherit pkgs; })
 // (import ./checks/mlx-catalog.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/mlx-backend-selection.nix { inherit pkgs hmConfigCatalog; })
+// (import ./checks/mlx-worker-flag-surface.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/mlx-proxy-logging.nix { inherit pkgs hmConfigCatalog; })
 // (import ./checks/mlx-default-model.nix { inherit pkgs hmConfigDefaultModel; })
 // (import ./checks/mlx-catalog-roles.nix {

--- a/lib/checks/mlx-worker-flag-surface.nix
+++ b/lib/checks/mlx-worker-flag-surface.nix
@@ -1,0 +1,115 @@
+# Worker flag surface: every flag in a rendered worker command must be one the
+# model's OWN backend accepts.
+#
+# The gap this closes: the other MLX checks compare config to config, so nothing
+# asserted that an emitted flag belongs to the selected backend's CLI. Catalog
+# `args` are backend-neutral, but the backends spell chat-template kwargs
+# differently and an unknown flag is fatal -- a vllm-mlx worker handed mlx_lm's
+# spelling exits at startup with "unrecognized arguments", so every worker
+# llama-swap starts dies immediately and the tier answers 500.
+{ pkgs, hmConfigCatalog }:
+let
+  inherit (pkgs) lib;
+  helpers = import ./helpers.nix { inherit pkgs; };
+in
+{
+  mlx-worker-flag-surface =
+    let
+      c = hmConfigCatalog.config.programs.mlx;
+      # Two catalog entries carrying chat-template kwargs, one per emission
+      # path: model-instances.nix appends extraArgs in two separate places
+      # (registry tier and swap tier), and covering only one ships half a fix.
+      optiq = "mlx-community/Qwen3.6-35B-A3B-OptiQ-4bit"; # resident, enable_thinking
+      gptOss = "mlx-community/gpt-oss-120b-MXFP4-Q8"; # swap, reasoning_effort
+
+      # modelBackends is cleared in both: it would otherwise pin catalog entries
+      # to the backend the fixture host selected, defeating the override.
+      mkInstances =
+        backend:
+        import ../../modules/mlx/model-instances.nix {
+          inherit lib;
+          cfg = c // {
+            modelServerBackend = backend;
+            modelBackends = { };
+          };
+          inherit (builder backend) mkModelCmd backendFor effectiveConcurrency;
+          workerEnv = _: { };
+          defaultFilters = { };
+          rolesByPhysical.${optiq} = [ "flag-surface-probe" ];
+        };
+      builder =
+        backend:
+        import ../../modules/mlx/model-server-cmd.nix {
+          inherit lib;
+          cfg = c // {
+            modelServerBackend = backend;
+            modelBackends = { };
+          };
+          mlxModelServerPkg = pkgs.writeShellScriptBin "mlx-model-server" "";
+        };
+
+      flagsOf = cmd: lib.filter (lib.hasPrefix "--") (lib.splitString " " cmd);
+
+      # Full commands as deployed: base flags plus extraArgs, one per emission
+      # path. Rendered through model-instances.nix, not mkModelCmd alone --
+      # extraArgs are appended there, the only place the bad flag can enter.
+      fullFlags =
+        backend:
+        let
+          m = mkInstances backend;
+        in
+        flagsOf m.residentModels.${optiq}.cmd ++ flagsOf m.swapModels.${gptOss}.cmd;
+      # Base commands WITHOUT extraArgs. This is the allowlist source -- derived
+      # from the builder's own vllm-mlx branch, never a hand-typed flag list, so
+      # retuning that branch cannot silently invalidate the check.
+      baseFlags =
+        backend:
+        lib.concatMap (m: flagsOf ((builder backend).mkModelCmd m)) [
+          optiq
+          gptOss
+        ];
+
+      # unique: per-path lists are concatenated, so a shared flag would
+      # otherwise be named twice in a failure message.
+      mlxLmFull = lib.unique (fullFlags "mlx-lm");
+      vllmBase = lib.unique (baseFlags "vllm-mlx");
+      vllmFull = lib.unique (fullFlags "vllm-mlx");
+
+      # Flags the mlx-lm command carries that the vllm-mlx builder never emits.
+      # Derived by set difference, so it tracks both branches automatically.
+      mlxLmOnly = lib.subtractLists vllmBase mlxLmFull;
+      # vllm-mlx spells the same JSON object under a different flag name.
+      renameTargets = [ "--default-chat-template-kwargs" ];
+      allowed = vllmBase ++ renameTargets;
+      leaked = lib.subtractLists allowed vllmFull;
+      banned = lib.intersectLists vllmFull mlxLmOnly;
+    in
+    # Liveness guard first: assertions only fire when forced, and a derived set
+    # that silently came back empty would make every assertion below vacuously
+    # true -- the failure mode CLAUDE.md warns about.
+    assert
+      lib.elem "--chat-template-args" mlxLmOnly
+      || throw "mlx-worker-flag-surface: the derived mlx-lm-only flag set has no --chat-template-args, so this check is not exercising the case it exists for -- the fixture models no longer carry chat-template args, or the render stopped including extraArgs.";
+    # Second guard: the comparison must also reach the BASE commands, not only
+    # extraArgs -- a broken base render would leave the two flag builders
+    # effectively uncompared while the check still passed.
+    assert
+      lib.subtractLists vllmBase (baseFlags "mlx-lm") != [ ]
+      || throw "mlx-worker-flag-surface: the mlx-lm base command shares every flag with the vllm-mlx base command, so the two backends' flag builders are no longer being compared.";
+    # (a) mlx-lm keeps its own spelling.
+    assert
+      lib.elem "--chat-template-args" mlxLmFull
+      || throw "mlx-worker-flag-surface: the mlx-lm worker command lost --chat-template-args, so the catalog's chat-template kwargs are no longer reaching mlx_lm.server.";
+    # (b) no mlx-lm-only flag reaches a vllm-mlx worker.
+    assert
+      banned == [ ]
+      || throw "mlx-worker-flag-surface: the vllm-mlx worker command carries mlx-lm-only flag(s) ${lib.concatStringsSep ", " banned}. vllm-mlx does not ignore an unknown flag -- it exits at startup with 'unrecognized arguments', so every worker llama-swap starts dies immediately and the tier answers 500.";
+    assert
+      leaked == [ ]
+      || throw "mlx-worker-flag-surface: the vllm-mlx worker command carries flag(s) ${lib.concatStringsSep ", " leaked} that the vllm-mlx flag builder does not emit and that are not a known rename target.";
+    # (c) the semantic survived the rename instead of being silently dropped.
+    assert
+      lib.elem "--default-chat-template-kwargs" vllmFull
+      || throw "mlx-worker-flag-surface: the vllm-mlx worker command has no --default-chat-template-kwargs, so the catalog's chat-template kwargs were dropped rather than translated.";
+    helpers.mkMarker "check-mlx-worker-flag-surface" "MLX worker flag surface: every emitted flag belongs to the model's own backend; chat-template kwargs are translated for vllm-mlx, never dropped and never passed through under the mlx-lm name";
+}

--- a/modules/mlx/default.nix
+++ b/modules/mlx/default.nix
@@ -145,6 +145,7 @@ let
         ;
     })
     mkModelCmd
+    backendFor
     effectiveConcurrency
     ;
 
@@ -188,6 +189,7 @@ let
         lib
         cfg
         mkModelCmd
+        backendFor
         effectiveConcurrency
         workerEnv
         defaultFilters

--- a/modules/mlx/model-instances.nix
+++ b/modules/mlx/model-instances.nix
@@ -13,6 +13,7 @@
   lib,
   cfg,
   mkModelCmd,
+  backendFor,
   effectiveConcurrency,
   workerEnv,
   defaultFilters,
@@ -20,6 +21,35 @@
 }:
 let
   proxyUrl = "http://127.0.0.1:\${PORT}";
+
+  # Catalog `args` (options-catalog.nix -> modelExtraArgs / models.*.extraArgs)
+  # are backend-neutral: one entry declares chat-template kwargs once and is
+  # served by whichever backend the host selected. The backends do not spell
+  # those flags the same way, and an unknown flag is not ignored -- the worker
+  # exits at startup with
+  #   vllm-mlx: error: unrecognized arguments: --chat-template-args {...}
+  # so every worker llama-swap starts dies immediately and the tier answers
+  # 500. Rename here, the one place the resolved backend and the raw arg list
+  # are both in hand.
+  #
+  # --chat-template-args (mlx_lm.server) and --default-chat-template-kwargs
+  # (vllm-mlx >= 0.4.1) take the identical JSON object, so this is a pure
+  # rename with no semantic loss; only the flag token differs.
+  #
+  # Matching on the bare token is correct for both call sites below: the swap
+  # path's args arrive already run through lib.escapeShellArg, which returns
+  # shell-safe tokens like this one unquoted.
+  extraArgRenames = {
+    vllm-mlx = {
+      "--chat-template-args" = "--default-chat-template-kwargs";
+    };
+  };
+  adaptExtraArgs =
+    modelId: args:
+    let
+      renames = extraArgRenames.${backendFor modelId} or { };
+    in
+    if renames == { } then args else map (tok: renames.${tok} or tok) args;
 
   # useModelName makes llama-swap rewrite the OpenAI-compatible request body's
   # `model` field to the physical model id before forwarding to the MLX server.
@@ -38,7 +68,7 @@ let
   registryModels = lib.mapAttrs (
     physical: roles:
     let
-      extraArgs = cfg.modelExtraArgs.${physical} or [ ];
+      extraArgs = adaptExtraArgs physical (cfg.modelExtraArgs.${physical} or [ ]);
     in
     {
       cmd =
@@ -69,7 +99,7 @@ let
       cmd =
         mkModelCmd name
         + lib.optionalString (modelCfg.extraArgs != [ ]) (
-          " " + lib.concatStringsSep " " modelCfg.extraArgs
+          " " + lib.concatStringsSep " " (adaptExtraArgs name modelCfg.extraArgs)
         );
       ttl = if modelCfg.ttl > 0 then modelCfg.ttl else cfg.proxy.idleTtl;
       env = workerEnv name;

--- a/modules/mlx/model-server-cmd.nix
+++ b/modules/mlx/model-server-cmd.nix
@@ -18,6 +18,14 @@ rec {
   # 1, and the excess came back as HTTP 429 (2026-07-24 cron kills).
   effectiveConcurrency = modelId: cfg.modelConcurrencyLimits.${modelId} or cfg.proxy.concurrencyLimit;
 
+  # Per-model backend resolution, exported so mkModelCmd and model-instances.nix
+  # share one answer: the latter needs it to decide how the catalog's
+  # backend-neutral extraArgs must be spelled for that backend, and a second
+  # copy of the `or` chain there would drift from the flag builder it must agree
+  # with. worker-env.nix and assertions.nix still inline the same expression —
+  # folding those in is a separate change, not part of this fix.
+  backendFor = modelId: cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+
   # Build the selected serving command for a given model ID.
   # Global option values may be replaced per physical model via
   # modelFlagOverrides; every override key must appear in overridableFlags —
@@ -52,7 +60,7 @@ rec {
   mkModelCmd =
     modelId:
     let
-      backend = cfg.modelBackends.${modelId} or cfg.modelServerBackend;
+      backend = backendFor modelId;
       mtp =
         cfg.modelMtpProfiles.${modelId} or {
           enable = false;


### PR DESCRIPTION
## What changed

Catalog entries declare chat-template kwargs backend-neutrally (one entry, whichever backend the host selected). The two supported LLM backends do not spell that flag the same way, and the worker command builder appended the catalog's `args` verbatim regardless of backend.

An unknown flag is fatal rather than ignored. Selecting the vllm-mlx backend produced workers that exited at startup with:

```
vllm-mlx: error: unrecognized arguments: --chat-template-args {"enable_thinking":false}
```

Every worker the proxy started died immediately, so the whole serving tier answered 500.

- `--chat-template-args` (mlx_lm.server) is now translated to `--default-chat-template-kwargs` (vllm-mlx 0.4.1) at the one point where the resolved backend and the raw arg list are both in hand. Both flags take the identical JSON object, so this is a pure rename with no semantic loss.
- Per-model backend resolution moves to a single exported `backendFor`, so the command builder and the extraArgs path cannot drift apart.

## Regression check

The existing MLX checks compare config to config, so nothing asserted that an emitted flag belongs to the selected backend's CLI. `lib/checks/mlx-worker-flag-surface.nix` renders the same catalog model's worker command under both backends and asserts:

- the mlx-lm command keeps its own spelling
- no mlx-lm-only flag reaches a vllm-mlx command
- the chat-template kwargs were translated, not silently dropped

The allowlist and the mlx-lm-only set are both derived from the builders by set difference, never hand-typed, so retuning either flag branch cannot silently invalidate the check. Two liveness assertions run first, because a derived set that came back empty would make every later assertion vacuously true.

Verified in both directions: the check passes on this branch, and fails with `the vllm-mlx worker command carries mlx-lm-only flag(s) --chat-template-args` when the translation is reverted.

## Validation

`nix fmt`, `nix flake check`, `statix check .`, and the full `lib/checks` evaluation all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how llama-swap worker commands are built for all models with catalog extraArgs on vllm-mlx; incorrect rename logic would still break startup, though a dedicated flake check targets that regression.
> 
> **Overview**
> Fixes a **serving-tier outage** when the host uses **vllm-mlx**: catalog `extraArgs` still declared chat-template kwargs as `--chat-template-args` (mlx-lm), but vllm-mlx treats unknown flags as fatal, so workers exited at startup and the proxy returned **500**.
> 
> **`model-instances.nix`** now runs catalog extra args through **`adaptExtraArgs`**, renaming `--chat-template-args` → `--default-chat-template-kwargs` for vllm-mlx on both the **resident registry** and **swap-tier** command paths (same JSON semantics, different CLI token).
> 
> **`backendFor`** is exported from **`model-server-cmd.nix`** and threaded through **`default.nix`** so extra-arg adaptation and **`mkModelCmd`** cannot drift on per-model backend resolution.
> 
> Adds **`lib/checks/mlx-worker-flag-surface.nix`** (wired in **`lib/checks.nix`**) to assert rendered worker commands: mlx-lm keeps its spelling, vllm-mlx never gets mlx-lm-only flags, and the translated flag is present—with liveness guards so empty derived sets cannot vacuously pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086a5b3783fa8416280f60fb6125dca9af34ca86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->