### PR TITLE
fix(ci): attach the LXC template to a draft release, then publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,6 +50,10 @@ jobs:
             printf '  %s\n' "${found[@]}" >&2
             exit 1
           fi
-          tag="$(gh release view --json tagName --jq .tagName)"
+          # Releases are immutable once published, so release-please creates a
+          # draft (release-please-config.json); attach the asset, then publish.
+          tag="$(gh release list --limit 10 --json tagName,isDraft --jq '[.[] | select(.isDraft)][0].tagName')"
+          [ -n "$tag" ] || { echo 'no draft release to attach the template to' >&2; exit 1; }
           sha256sum "${found[0]}"
           gh release upload "$tag" "${found[0]}#nixos-herdr-lxc.tar.xz" --clobber
+          gh release edit "$tag" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,7 @@ jobs:
           fi
           # Releases are immutable once published, so release-please creates a
           # draft (release-please-config.json); attach the asset, then publish.
-          tag="$(gh release list --limit 10 --json tagName,isDraft --jq '[.[] | select(.isDraft)][0].tagName')"
+          tag="$(gh release list --limit 10 --json tagName,isDraft --jq '[.[] | select(.isDraft)][0].tagName // empty')"
           [ -n "$tag" ] || { echo 'no draft release to attach the template to' >&2; exit 1; }
           sha256sum "${found[0]}"
           gh release upload "$tag" "${found[0]}#nixos-herdr-lxc.tar.xz" --clobber

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "simple",
       "version-file": "VERSION",
       "include-v-in-tag": true,
+      "draft": true,
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
The v4.38.0 publish job built the template and then failed with `HTTP 422: Cannot upload assets to an immutable release`. release-please now creates a draft release, the publish job attaches the asset to the draft and publishes it.

Verification: the next release carries `nixos-herdr-lxc.tar.xz` in its assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes; no runtime application or auth logic affected.
> 
> **Overview**
> Fixes failed release publishes where the LXC template upload hit **HTTP 422** because GitHub releases become immutable once published.
> 
> **release-please** now creates **draft** releases (`"draft": true` in `release-please-config.json`). The `publish-lxc-template` job resolves the draft tag via `gh release list`, uploads `nixos-herdr-lxc.tar.xz`, then runs **`gh release edit … --draft=false`** so the release goes live only after the asset is attached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f488eed4ab3fadc3aba8aad5e27e7c1f64041e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->