### PR TITLE
chore(claude-plugins): remove the wakatime plugin

### DIFF
--- a/flake/home-manager-modules.nix
+++ b/flake/home-manager-modules.nix
@@ -44,7 +44,6 @@ let
       axton-obsidian-visual-skills
       superpowers-marketplace
       visual-explainer-marketplace
-      wakatime
       ;
     inherit browser-use-skills;
     inherit jacobpevans-cc-plugins;

--- a/modules/claude/plugins/05-specialty.nix
+++ b/modules/claude/plugins/05-specialty.nix
@@ -24,7 +24,6 @@
 #   - visual-explainer-marketplace (nicobailon/..., 7816★)
 #   - browser-use-skills (browser-use/browser-use, 91681★ upstream, synthetic)
 #   - vct-cribl-pack-validator-skills (private source, 0★, synthetic)
-#   - wakatime (wakatime/claude-code-wakatime, 73★)         — telemetry
 
 _:
 
@@ -142,11 +141,5 @@ _:
     # cc-stream-*) via per-repo .claude/settings.json overrides.
     "cribl-pack-validator@vct-cribl-pack-validator-skills" = false;
 
-    # ========================================================================
-    # wakatime — wakatime/claude-code-wakatime (time tracking)
-    # ========================================================================
-    # Marketplace key is `wakatime` (org name), not `claude-code-wakatime`.
-    # Plugin reference: claude-code-wakatime@wakatime.
-    "claude-code-wakatime@wakatime" = true;
   };
 }

--- a/modules/claude/plugins/README.md
+++ b/modules/claude/plugins/README.md
@@ -27,7 +27,7 @@ disable the lower-tier one. Document each disable inline with a reason.
 | **2** | First-party AI/cloud vendors | `openai-codex`, MCP integrations under `claude-plugins-official/external_plugins/*` |
 | **3** | Personal | `jacobpevans-cc-plugins` |
 | **4** | Broad-scope community marketplaces (multi-plugin); ordering within the tier follows GitHub stars | `claude-code-workflows` (34k★), `superpowers-marketplace` (925★), `cc-marketplace` (679★), `claude-skills` (129★) |
-| **5** | Niche / specialty / single-purpose / synthetic — classified by use-case scope, not stars | `lunar-claude`, `claude-code-plugins-plus`, `bitwarden-marketplace`, `cc-dev-tools`, `fabric-patterns`, `huggingface-skills`, `langfuse-skills`, `obsidian-skills`, `axton-obsidian-visual-skills`, `visual-explainer-marketplace`, `browser-use-skills`, `vct-cribl-pack-validator-skills`, `wakatime` |
+| **5** | Niche / specialty / single-purpose / synthetic — classified by use-case scope, not stars | `lunar-claude`, `claude-code-plugins-plus`, `bitwarden-marketplace`, `cc-dev-tools`, `fabric-patterns`, `huggingface-skills`, `langfuse-skills`, `obsidian-skills`, `axton-obsidian-visual-skills`, `visual-explainer-marketplace`, `browser-use-skills`, `vct-cribl-pack-validator-skills` |
 
 > Tier 4 vs Tier 5 is **not** purely a star count comparison. Several Tier 5
 > entries wrap very high-star upstream repos (e.g., `browser-use` 91k★,
@@ -66,7 +66,6 @@ priority system above.
 | `axton-obsidian-visual-skills` | `axtonliu/axton-obsidian-visual-skills` | 2651 | 5 |
 | `claude-code-plugins-plus` | `jeremylongshore/claude-code-plugins-plus` | 2083 | 5 |
 | `bitwarden-marketplace` | `bitwarden/ai-plugins` | 90 | 5 |
-| `wakatime` | `wakatime/claude-code-wakatime` | 73 | 5 |
 | `cc-dev-tools` | `Lucklyric/cc-dev-tools` | 29 | 5 |
 | `lunar-claude` | `basher83/lunar-claude` | 18 | 5 |
 | `vct-cribl-pack-validator-skills` | private source (synthetic) | 0 | 5 |


### PR DESCRIPTION
Removes the wakatime plugin enable from the specialty tier, the marketplace inherit, and the catalog documentation rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9a82bFankwKmteZF9izMn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and documentation cleanup only; no auth, data, or runtime logic changes beyond disabling an optional telemetry plugin.
> 
> **Overview**
> **Removes WakaTime** from the managed Claude Code plugin set so time-tracking telemetry is no longer enabled by default.
> 
> `claude-code-wakatime@wakatime` is dropped from specialty-tier `enabledPlugins` (it was previously `true`). The `wakatime` marketplace is no longer inherited in `marketplaceInputs` for home-manager consumers, and the plugin catalog docs no longer list it under Tier 5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b38b871dbbda51d35e89e4da5569803ea6f1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->